### PR TITLE
fix: use sameSite=none for cross-origin refresh token cookie

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -11,8 +11,8 @@ const router = Router();
 const COOKIE_NAME = 'beacon2_refresh';
 const cookieOptions = {
   httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: 'strict',
+  secure: true,
+  sameSite: 'none',   // required for cross-origin (Vercel frontend → Render backend)
   maxAge: 1000 * 60 * 60 * 24 * parseInt(process.env.JWT_REFRESH_EXPIRES_DAYS ?? '30', 10),
 };
 


### PR DESCRIPTION
Vercel frontend and Render backend are on different domains, so sameSite=strict prevents the browser from ever sending the refresh token cookie. Switch to sameSite=none (requires secure=true) so the cookie is included in cross-origin requests.

https://claude.ai/code/session_01WdSsJg1nZ4vKZB2ncxM2Ej