### PR TITLE
feat: restyle all pages to match Beacon's visual design

### DIFF
--- a/frontend/src/components/BeaconLogo.jsx
+++ b/frontend/src/components/BeaconLogo.jsx
@@ -1,0 +1,36 @@
+// beacon2/frontend/src/components/BeaconLogo.jsx
+// Approximate recreation of the u3a Beacon logo using styled text.
+// Expects light.jpg in frontend/public/ for the page background,
+// but the logo itself is pure CSS.
+
+const BLUE = '#1d5da8';
+
+export default function BeaconLogo({ large = false }) {
+  return (
+    <div style={{ display: 'inline-block', textAlign: 'center', lineHeight: 1 }}>
+      <div style={{
+        fontFamily: '"Arial Black", "Arial Bold", Arial, sans-serif',
+        fontWeight: 900,
+        fontSize: large ? 72 : 52,
+        color: BLUE,
+        letterSpacing: -2,
+        lineHeight: 1,
+        userSelect: 'none',
+      }}>
+        u3a
+      </div>
+      <div style={{
+        fontFamily: 'Arial, sans-serif',
+        fontWeight: 700,
+        fontSize: large ? 24 : 17,
+        color: BLUE,
+        letterSpacing: 3,
+        textAlign: 'center',
+        marginTop: large ? 4 : 2,
+        userSelect: 'none',
+      }}>
+        Beacon
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,22 +1,18 @@
 // beacon2/frontend/src/components/NavBar.jsx
-// Shared navigation bar rendered at the top (and optionally bottom) of each page.
-// Pass `links` as an array of { label, to? } objects.
-// Items without `to` are rendered as plain text (current page indicator).
+// Beacon-style navigation bar: centred blue links separated by " - ".
 
 import { Link } from 'react-router-dom';
 
 export default function NavBar({ links }) {
   return (
-    <nav className="text-center py-2 text-sm text-blue-600">
+    <nav className="b-nav">
       {links.map((link, i) => (
         <span key={i}>
-          {i > 0 && <span className="mx-2 text-slate-400">–</span>}
+          {i > 0 && <span className="b-nav-sep"> - </span>}
           {link.to ? (
-            <Link to={link.to} className="hover:underline">
-              {link.label}
-            </Link>
+            <Link to={link.to}>{link.label}</Link>
           ) : (
-            <span className="text-slate-600">{link.label}</span>
+            <span style={{ color: '#444' }}>{link.label}</span>
           )}
         </span>
       ))}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,199 @@
+/* beacon2/frontend/src/index.css
+   Global styles matching Beacon's visual design.
+   Background image: place lighthouse photo at frontend/public/light.jpg
+*/
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 13px;
+  /* Lighthouse photo. Blue-sky gradient is the fallback while image loads
+     or if light.jpg has not yet been added to frontend/public/. */
+  background:
+    url('/light.jpg') no-repeat center center fixed;
+  background-size: cover;
+  background-color: #9dc8df;
+}
+
+#root { min-height: 100vh; }
+
+a            { color: #0000ff; text-decoration: none; }
+a:hover      { text-decoration: underline; }
+h1           { font-family: Arial, Helvetica, sans-serif; font-size: 20px; margin: 0 0 8px; }
+h2           { font-family: Arial, Helvetica, sans-serif; font-size: 18px; margin: 0 0 6px; }
+p            { font-family: Arial, Helvetica, sans-serif; font-size: 13px; }
+
+/* ── Inputs ─────────────────────────────────────────────────────── */
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+select {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 13px;
+  border: 1px solid #777;
+  padding: 2px 4px;
+  height: 24px;
+  background: #fff;
+}
+
+button {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+/* ── Beacon navigation bar ──────────────────────────────────────── */
+
+.b-nav {
+  text-align: center;
+  padding: 8px 0 6px;
+  font-size: 13px;
+}
+
+.b-nav a      { color: #0000ff; }
+.b-nav-sep    { margin: 0 6px; color: #444; }
+
+/* ── Data table (roles list etc.) ───────────────────────────────── */
+
+.b-table {
+  border-collapse: collapse;
+  margin: 0 auto;
+  font-size: 13px;
+}
+
+.b-table th {
+  background-color: #fff;
+  font-style: italic;
+  font-weight: normal;
+  border: 1px solid #999;
+  padding: 3px 12px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.b-table td {
+  background-color: #ffffc6;
+  border: 1px solid #999;
+  padding: 3px 12px;
+  vertical-align: middle;
+}
+
+.b-table td.b-td-action {
+  background-color: #ffffc6;
+  white-space: nowrap;
+}
+
+/* ── Menu table (Home page) ─────────────────────────────────────── */
+
+.b-menu-table {
+  border-collapse: collapse;
+  margin: 0 auto;
+  background-image: radial-gradient(#ffffc6, #f7ae56);
+  font-size: 13px;
+  min-width: 600px;
+}
+
+.b-menu-table th {
+  font-weight: bold;
+  font-size: 13px;
+  border: 1px solid #bbb;
+  padding: 8px 18px 4px;
+  vertical-align: top;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.b-menu-table td {
+  border: 1px solid #bbb;
+  padding: 3px 18px;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.b-menu-table td.b-menu-footer {
+  text-align: center;
+  font-size: 12px;
+  padding: 6px 18px;
+  background-color: rgba(255,255,255,0.3);
+}
+
+.b-menu-link-dim {
+  color: #888;
+  cursor: default;
+}
+.b-menu-link-dim:hover { text-decoration: none; }
+
+/* ── Flash / error messages ─────────────────────────────────────── */
+
+.b-flash-error {
+  border: 2px solid #ebcccc;
+  background-color: #f2dede;
+  color: #a94442;
+  padding: 6px 12px;
+  margin: 10px auto;
+  max-width: 400px;
+  text-align: center;
+  font-size: 13px;
+}
+
+/* ── Role editor ────────────────────────────────────────────────── */
+
+.b-form-table {
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.b-form-table td {
+  padding: 4px 6px;
+  vertical-align: middle;
+  background: transparent;
+  border: none;
+}
+
+.b-form-table td.b-label {
+  text-align: right;
+  padding-right: 8px;
+  color: #222;
+}
+
+.b-priv-table {
+  border-collapse: collapse;
+  margin: 0 auto;
+  font-size: 13px;
+}
+
+.b-priv-table th {
+  background-color: #fff;
+  font-style: italic;
+  font-weight: normal;
+  border: 1px solid #999;
+  padding: 4px 10px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.b-priv-table th.b-res-head {
+  text-align: left;
+}
+
+.b-priv-table td {
+  background-color: #ffffc6;
+  border: 1px solid #999;
+  padding: 3px 10px;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.b-priv-table td.b-res-name {
+  text-align: left;
+  cursor: pointer;
+}
+
+.b-priv-table td.b-res-name:hover {
+  background-color: #fff5a0;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import './index.css';
 import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,9 +1,9 @@
 // beacon2/frontend/src/pages/Home.jsx
-// Landing page after login. Shows the u3a name, welcome message,
-// and cards linking to available modules.
+// Landing page after login — styled to match Beacon's main menu page.
 
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext.jsx';
+import BeaconLogo from '../components/BeaconLogo.jsx';
 
 export default function Home() {
   const { user, tenant, logout, can } = useAuth();
@@ -14,68 +14,132 @@ export default function Home() {
     navigate('/login');
   };
 
-  return (
-    <div className="min-h-screen bg-slate-100">
+  // Tenant display name: capitalise the slug for now
+  const tenantDisplay = tenant
+    ? tenant.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    : '';
 
-      {/* Header */}
-      <header className="bg-white border-b border-slate-200 px-6 py-4 flex items-center justify-between">
-        <div>
-          <span className="text-xl font-bold text-slate-800">
-            Beacon<span className="text-blue-600">2</span>
+  return (
+    <div style={{ minHeight: '100vh', paddingBottom: 40 }}>
+
+      {/* ── Logo + tenant name header ─────────────────────────── */}
+      <div style={{ display: 'flex', alignItems: 'center', padding: '16px 32px 8px' }}>
+        <BeaconLogo />
+        {tenantDisplay && (
+          <span style={{
+            fontFamily: 'Arial, sans-serif',
+            fontSize: 42,
+            fontWeight: 'normal',
+            marginLeft: 24,
+            color: '#000',
+          }}>
+            {tenantDisplay}
           </span>
-          {tenant && (
-            <span className="ml-3 text-slate-500 text-sm capitalize">{tenant}</span>
-          )}
-        </div>
-        <div className="flex items-center gap-4 text-sm">
-          {user?.name && (
-            <span className="text-slate-600">Signed in as <strong>{user.name}</strong></span>
-          )}
-          <button onClick={handleLogout} className="text-red-600 hover:underline">
-            Sign out
-          </button>
-        </div>
-      </header>
-
-      <div className="p-8 max-w-3xl mx-auto">
-        <h1 className="text-2xl font-semibold text-slate-800 mb-1">Home</h1>
-        <p className="text-slate-500 text-sm mb-8">Select a section to manage.</p>
-
-        <div className="grid gap-4 sm:grid-cols-2">
-
-          {can('role_record', 'view') && (
-            <ModuleCard
-              title="Roles & Privileges"
-              description="Manage user roles and their permission sets."
-              links={[
-                { label: 'Roles list', to: '/roles' },
-                { label: 'Add role', to: '/roles/new' },
-              ]}
-            />
-          )}
-
-        </div>
+        )}
       </div>
-    </div>
-  );
-}
 
-function ModuleCard({ title, description, links }) {
-  return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-100 p-5">
-      <h2 className="font-semibold text-slate-800 mb-1">{title}</h2>
-      <p className="text-xs text-slate-500 mb-3">{description}</p>
-      <div className="flex flex-wrap gap-3">
-        {links.map((l) => (
-          <Link
-            key={l.to}
-            to={l.to}
-            className="text-sm text-blue-600 hover:underline"
+      {/* ── Page title + user info ────────────────────────────── */}
+      <div style={{ textAlign: 'center', marginTop: 16, marginBottom: 16 }}>
+        <h1 style={{ fontSize: 20, fontWeight: 'bold', margin: '0 0 6px' }}>Administration</h1>
+        <span style={{ fontSize: 13, color: '#222' }}>
+          You are logged in as {user?.name ?? user?.email ?? ''}
+          {'  '}
+          <button
+            onClick={handleLogout}
+            style={{ background: 'none', border: 'none', color: '#0000ff', cursor: 'pointer', fontSize: 13, padding: 0 }}
           >
-            {l.label}
-          </Link>
-        ))}
+            Log Out
+          </button>
+        </span>
       </div>
+
+      {/* ── Main menu table ───────────────────────────────────── */}
+      <table className="b-menu-table">
+        <thead>
+          <tr>
+            <th>Membership</th>
+            <th>Groups</th>
+            <th>Finance</th>
+            <th>Misc</th>
+            <th>Set up</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><span className="b-menu-link-dim">Members</span></td>
+            <td><span className="b-menu-link-dim">Groups</span></td>
+            <td><span className="b-menu-link-dim">Ledger (by account)</span></td>
+            <td><span className="b-menu-link-dim">Audit log</span></td>
+            <td><span className="b-menu-link-dim">System users</span></td>
+          </tr>
+          <tr>
+            <td><span className="b-menu-link-dim">Add new member</span></td>
+            <td><span className="b-menu-link-dim">Venues</span></td>
+            <td><span className="b-menu-link-dim">Ledger (by category)</span></td>
+            <td><span className="b-menu-link-dim">Gift aid log</span></td>
+            <td>
+              {can('role_record', 'view')
+                ? <a href="/roles">Roles and privileges</a>
+                : <span className="b-menu-link-dim">Roles and privileges</span>}
+            </td>
+          </tr>
+          <tr>
+            <td><span className="b-menu-link-dim">Membership renewals</span></td>
+            <td><span className="b-menu-link-dim">Faculties</span></td>
+            <td><span className="b-menu-link-dim">Ledger (by group)</span></td>
+            <td><span className="b-menu-link-dim">u3a Officers</span></td>
+            <td><span className="b-menu-link-dim">System settings</span></td>
+          </tr>
+          <tr>
+            <td><span className="b-menu-link-dim">Recent members</span></td>
+            <td><span className="b-menu-link-dim">Calendar</span></td>
+            <td><span className="b-menu-link-dim">Add transaction</span></td>
+            <td><span className="b-menu-link-dim">Public links</span></td>
+            <td><span className="b-menu-link-dim">System messages</span></td>
+          </tr>
+          <tr>
+            <td><span className="b-menu-link-dim">Non-renewals</span></td>
+            <td></td>
+            <td><span className="b-menu-link-dim">Transfer money</span></td>
+            <td><span className="b-menu-link-dim">Data export &amp; backup</span></td>
+            <td><span className="b-menu-link-dim">Finance accounts</span></td>
+          </tr>
+          <tr>
+            <td><span className="b-menu-link-dim">Membership cards</span></td>
+            <td></td>
+            <td><span className="b-menu-link-dim">Credit batches</span></td>
+            <td><span className="b-menu-link-dim">E-mail delivery</span></td>
+            <td><span className="b-menu-link-dim">Finance categories</span></td>
+          </tr>
+          <tr>
+            <td><span className="b-menu-link-dim">Addresses export</span></td>
+            <td></td>
+            <td><span className="b-menu-link-dim">Reconcile account</span></td>
+            <td><span className="b-menu-link-dim">Personal preferences</span></td>
+            <td><span className="b-menu-link-dim">Membership classes</span></td>
+          </tr>
+          <tr>
+            <td><span className="b-menu-link-dim">Statistics</span></td>
+            <td></td>
+            <td><span className="b-menu-link-dim">Financial statement</span></td>
+            <td></td>
+            <td><span className="b-menu-link-dim">Member statuses</span></td>
+          </tr>
+          <tr>
+            <td></td>
+            <td></td>
+            <td><span className="b-menu-link-dim">Gift Aid declaration</span></td>
+            <td></td>
+            <td><span className="b-menu-link-dim">Poll</span></td>
+          </tr>
+          <tr>
+            <td className="b-menu-footer" colSpan={5} style={{ textAlign: 'center', fontSize: 12, fontStyle: 'italic', color: '#555' }}>
+              Hover mouse over captions for more information
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
     </div>
   );
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,14 +1,17 @@
 // beacon2/frontend/src/pages/Login.jsx
+// Tenant user sign-in — styled to match Beacon's original login page.
 
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext.jsx';
+import BeaconLogo from '../components/BeaconLogo.jsx';
 
 export default function Login() {
   const { login, loading, error } = useAuth();
   const navigate = useNavigate();
 
   const [form, setForm] = useState({ tenantSlug: '', email: '', password: '' });
+  const [showPw, setShowPw] = useState(false);
 
   const handleChange = (e) =>
     setForm((f) => ({ ...f, [e.target.name]: e.target.value }));
@@ -20,74 +23,97 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-100 flex items-center justify-center">
-      <div className="bg-white rounded-xl shadow-md w-full max-w-md p-8">
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 60 }}>
 
-        {/* Logo / title */}
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-slate-800">Beacon<span className="text-blue-600">2</span></h1>
-          <p className="text-slate-500 text-sm mt-1">u3a management system</p>
-        </div>
+      <BeaconLogo large />
 
-        {error && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
-            {error}
-          </div>
-        )}
+      <h1 style={{ marginTop: 24, fontWeight: 'bold', textAlign: 'center', fontSize: 20 }}>
+        Administration
+      </h1>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">
-              u3a name
-            </label>
-            <input
-              name="tenantSlug"
-              value={form.tenantSlug}
-              onChange={handleChange}
-              placeholder="e.g. oxfordshire"
-              required
-              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            <p className="text-xs text-slate-400 mt-1">Your u3a's short name (provided by your administrator)</p>
-          </div>
+      {error && <div className="b-flash-error">{error}</div>}
 
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">
-              Email address
-            </label>
-            <input
-              name="email"
-              type="email"
-              value={form.email}
-              onChange={handleChange}
-              required
-              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-          </div>
+      <form onSubmit={handleSubmit} style={{ marginTop: 16 }}>
+        <table style={{ borderCollapse: 'collapse', fontSize: 13 }}>
+          <tbody>
+            <tr>
+              <td style={{ textAlign: 'right', paddingRight: 8, paddingBottom: 6, color: '#222' }}>u3a</td>
+              <td style={{ paddingBottom: 6 }}>
+                <input
+                  name="tenantSlug"
+                  value={form.tenantSlug}
+                  onChange={handleChange}
+                  placeholder="your-u3a-slug"
+                  required
+                  style={{ width: 220 }}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: 'right', paddingRight: 8, paddingBottom: 6, color: '#222' }}>Email</td>
+              <td style={{ paddingBottom: 6 }}>
+                <input
+                  name="email"
+                  type="email"
+                  value={form.email}
+                  onChange={handleChange}
+                  required
+                  style={{ width: 220 }}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: 'right', paddingRight: 8, paddingBottom: 4, color: '#222' }}>Password</td>
+              <td style={{ paddingBottom: 4 }}>
+                <span style={{ position: 'relative', display: 'inline-block' }}>
+                  <input
+                    name="password"
+                    type={showPw ? 'text' : 'password'}
+                    value={form.password}
+                    onChange={handleChange}
+                    required
+                    style={{ width: 196, paddingRight: 24 }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPw((v) => !v)}
+                    style={{
+                      position: 'absolute', right: 4, top: '50%', transform: 'translateY(-50%)',
+                      background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, padding: 0,
+                    }}
+                    title={showPw ? 'Hide password' : 'Show password'}
+                  >
+                    {showPw ? '🙈' : '👁'}
+                  </button>
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td colSpan={2} style={{ textAlign: 'center', fontSize: 11, color: '#666', paddingBottom: 10 }}>
+                Passwords are case sensitive
+              </td>
+            </tr>
+            <tr>
+              <td colSpan={2} style={{ textAlign: 'center' }}>
+                <button
+                  type="submit"
+                  disabled={loading}
+                  style={{ padding: '3px 20px', fontSize: 13 }}
+                >
+                  {loading ? 'Signing in…' : 'Enter'}
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
 
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">
-              Password
-            </label>
-            <input
-              name="password"
-              type="password"
-              value={form.password}
-              onChange={handleChange}
-              required
-              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-          </div>
+      <hr style={{ width: 600, marginTop: 28, borderTop: '1px solid #999', border: 'none', borderBottom: '1px solid #ccc' }} />
 
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white font-medium py-2 rounded-lg text-sm transition-colors"
-          >
-            {loading ? 'Signing in…' : 'Sign in'}
-          </button>
-        </form>
-      </div>
+      <p style={{ marginTop: 16, fontSize: 13 }}>
+        Forgotten your username or password?{' '}
+        <a href="#forgot">Click here.</a>
+      </p>
     </div>
   );
 }

--- a/frontend/src/pages/roles/RoleEditor.jsx
+++ b/frontend/src/pages/roles/RoleEditor.jsx
@@ -1,29 +1,28 @@
 // beacon2/frontend/src/pages/roles/RoleEditor.jsx
 // Edit a role's name, committee flag, and privilege matrix.
-// Used for both creating new roles and editing existing ones.
 
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { roles as rolesApi, privileges as privsApi } from '../../lib/api.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import NavBar from '../../components/NavBar.jsx';
+import BeaconLogo from '../../components/BeaconLogo.jsx';
 
 export default function RoleEditor() {
-  const { id }    = useParams();           // undefined for new role
-  const isNew     = !id || id === 'new';
-  const navigate  = useNavigate();
-  const { can }   = useAuth();
+  const { id }   = useParams();
+  const isNew    = !id || id === 'new';
+  const navigate = useNavigate();
+  const { can, tenant } = useAuth();
 
   const [name,        setName]        = useState('');
   const [isCommittee, setIsCommittee] = useState(false);
   const [notes,       setNotes]       = useState('');
-  const [resources,   setResources]   = useState([]);   // all privilege resources
-  const [granted,     setGranted]     = useState({});   // { "resource_id:action": true }
+  const [resources,   setResources]   = useState([]);
+  const [granted,     setGranted]     = useState({});
   const [loading,     setLoading]     = useState(!isNew);
   const [saving,      setSaving]      = useState(false);
   const [error,       setError]       = useState(null);
 
-  // ── Load privilege resources + existing role ────────────────────────────
   useEffect(() => {
     async function load() {
       try {
@@ -32,13 +31,10 @@ export default function RoleEditor() {
           isNew ? null : rolesApi.get(id),
         ]);
         setResources(resourceList);
-
         if (role) {
           setName(role.name);
           setIsCommittee(role.is_committee);
           setNotes(role.notes ?? '');
-
-          // Build granted map from role's privilege data
           const map = {};
           for (const res of role.privileges) {
             for (const action of res.granted_actions) {
@@ -56,84 +52,63 @@ export default function RoleEditor() {
     load();
   }, [id, isNew]);
 
-  // ── Toggle a single privilege cell ─────────────────────────────────────
   const toggle = useCallback((resourceId, action) => {
     const key = `${resourceId}:${action}`;
     setGranted((prev) => {
       const next = { ...prev };
       if (next[key]) {
         delete next[key];
-        // If un-ticking view, also remove create/change/delete (can't act without view)
         if (action === 'view') {
-          Object.keys(next).forEach((k) => {
-            if (k.startsWith(resourceId + ':')) delete next[k];
-          });
+          Object.keys(next).forEach((k) => { if (k.startsWith(resourceId + ':')) delete next[k]; });
         }
       } else {
         next[key] = true;
-        // Auto-add view if ticking any other action
-        if (action !== 'view') {
-          next[`${resourceId}:view`] = true;
-        }
+        if (action !== 'view') next[`${resourceId}:view`] = true;
       }
       return next;
     });
   }, []);
 
-  // ── Toggle entire column ────────────────────────────────────────────────
   const toggleColumn = useCallback((action) => {
     setGranted((prev) => {
-      const next = { ...prev };
+      const next     = { ...prev };
       const eligible = resources.filter((r) => r.actions.includes(action));
       const allOn    = eligible.every((r) => next[`${r.id}:${action}`]);
       eligible.forEach((r) => {
         const key = `${r.id}:${action}`;
-        if (allOn) {
-          delete next[key];
-        } else {
-          next[key] = true;
-          if (action !== 'view') next[`${r.id}:view`] = true;
-        }
+        if (allOn) { delete next[key]; }
+        else { next[key] = true; if (action !== 'view') next[`${r.id}:view`] = true; }
       });
       return next;
     });
   }, [resources]);
 
-  // ── Toggle entire row ───────────────────────────────────────────────────
   const toggleRow = useCallback((resourceId, possibleActions) => {
     setGranted((prev) => {
-      const next = { ...prev };
+      const next  = { ...prev };
       const allOn = possibleActions.every((a) => next[`${resourceId}:${a}`]);
-      if (allOn) {
-        possibleActions.forEach((a) => delete next[`${resourceId}:${a}`]);
-      } else {
-        possibleActions.forEach((a) => { next[`${resourceId}:${a}`] = true; });
-      }
+      if (allOn) { possibleActions.forEach((a) => delete next[`${resourceId}:${a}`]); }
+      else       { possibleActions.forEach((a) => { next[`${resourceId}:${a}`] = true; }); }
       return next;
     });
   }, []);
 
-  // ── Save ────────────────────────────────────────────────────────────────
   const handleSave = async () => {
     if (!name.trim()) { setError('Role name is required.'); return; }
     setSaving(true);
     setError(null);
     try {
       let roleId = id;
-
       if (isNew) {
         const created = await rolesApi.create({ name: name.trim(), isCommittee, notes });
         roleId = created.id;
       } else {
         await rolesApi.update(id, { name: name.trim(), isCommittee, notes });
       }
-
-      // Build privilege list from granted map
       const privilegeList = Object.keys(granted).map((key) => {
         const [resourceId, action] = key.split(':');
         return { resourceId, action };
       });
-
       await rolesApi.setPrivileges(roleId, privilegeList);
       navigate('/roles');
     } catch (err) {
@@ -143,10 +118,7 @@ export default function RoleEditor() {
     }
   };
 
-  // ── Column headers ───────────────────────────────────────────────────────
   const STANDARD_ACTIONS = ['view', 'create', 'change', 'delete'];
-
-  // Collect all "other" action names (non-standard) across all resources
   const otherActions = [...new Set(
     resources.flatMap((r) => r.actions.filter((a) => !STANDARD_ACTIONS.includes(a)))
   )].sort();
@@ -159,170 +131,175 @@ export default function RoleEditor() {
     ...(!isNew && can('role_record', 'create') ? [{ label: 'Add Role', to: '/roles/new' }] : []),
   ];
 
-  if (loading) return <PageShell navLinks={navLinks}><p className="text-slate-400 text-sm">Loading…</p></PageShell>;
+  const tenantDisplay = tenant
+    ? tenant.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    : '';
+
+  if (loading) {
+    return (
+      <div style={{ minHeight: '100vh' }}>
+        <div style={{ display: 'flex', alignItems: 'center', padding: '16px 32px 8px' }}>
+          <BeaconLogo />
+        </div>
+        <NavBar links={navLinks} />
+        <p style={{ textAlign: 'center', marginTop: 20, color: '#555' }}>Loading…</p>
+      </div>
+    );
+  }
 
   return (
-    <PageShell navLinks={navLinks}>
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-xl font-semibold text-slate-800">
-          {isNew ? 'New role' : `Edit: ${name}`}
+    <div style={{ minHeight: '100vh', paddingBottom: 40 }}>
+
+      {/* Logo + tenant header */}
+      <div style={{ display: 'flex', alignItems: 'center', padding: '16px 32px 8px' }}>
+        <BeaconLogo />
+        {tenantDisplay && (
+          <span style={{ fontFamily: 'Arial', fontSize: 42, marginLeft: 24, color: '#000' }}>
+            {tenantDisplay}
+          </span>
+        )}
+      </div>
+
+      <NavBar links={navLinks} />
+
+      <div style={{ maxWidth: 960, margin: '0 auto', padding: '12px 16px' }}>
+
+        <h1 style={{ textAlign: 'center', fontWeight: 'bold', marginBottom: 14 }}>
+          {isNew ? 'Add Role' : `Edit Role: ${name}`}
         </h1>
-        <div className="flex gap-2">
-          <button
-            onClick={() => navigate('/roles')}
-            className="text-sm px-4 py-2 border border-slate-300 rounded-lg hover:bg-slate-50"
-          >
-            Cancel
-          </button>
-          {canEdit && (
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className="text-sm px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded-lg transition-colors"
-            >
-              {saving ? 'Saving…' : 'Save role'}
-            </button>
-          )}
-        </div>
-      </div>
 
-      {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>
-      )}
+        {error && <div className="b-flash-error">{error}</div>}
 
-      {/* Role details */}
-      <div className="bg-white rounded-xl shadow-sm p-5 mb-6 space-y-4">
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">Role name</label>
-            <input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              disabled={!canEdit}
-              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-slate-50"
-            />
-          </div>
-          <div className="flex items-end pb-2">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={isCommittee}
-                onChange={(e) => setIsCommittee(e.target.checked)}
-                disabled={!canEdit}
-                className="w-4 h-4 accent-blue-600"
-              />
-              <span className="text-sm text-slate-700">Committee role</span>
-            </label>
-          </div>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-slate-700 mb-1">Notes</label>
-          <textarea
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            disabled={!canEdit}
-            rows={2}
-            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-slate-50 resize-none"
-          />
-        </div>
-      </div>
+        {/* Role details form */}
+        <table className="b-form-table" style={{ margin: '0 auto 20px' }}>
+          <tbody>
+            <tr>
+              <td className="b-label">Role name</td>
+              <td>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  disabled={!canEdit}
+                  style={{ width: 280 }}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td className="b-label">Committee role</td>
+              <td>
+                <input
+                  type="checkbox"
+                  checked={isCommittee}
+                  onChange={(e) => setIsCommittee(e.target.checked)}
+                  disabled={!canEdit}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td className="b-label" style={{ verticalAlign: 'top', paddingTop: 6 }}>Notes</td>
+              <td>
+                <textarea
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  disabled={!canEdit}
+                  rows={3}
+                  style={{ width: 280, fontFamily: 'Arial', fontSize: 13, border: '1px solid #777', padding: '2px 4px', resize: 'vertical' }}
+                />
+              </td>
+            </tr>
+            {canEdit && (
+              <tr>
+                <td></td>
+                <td style={{ paddingTop: 8 }}>
+                  <button onClick={handleSave} disabled={saving} style={{ marginRight: 8, padding: '3px 16px' }}>
+                    {saving ? 'Saving…' : 'Save role'}
+                  </button>
+                  <button onClick={() => navigate('/roles')} style={{ padding: '3px 16px' }}>
+                    Cancel
+                  </button>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
 
-      {/* Privilege matrix */}
-      <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-        <div className="px-5 py-4 border-b border-slate-100">
-          <h2 className="font-medium text-slate-700 text-sm">Privileges</h2>
-          <p className="text-xs text-slate-400 mt-0.5">
-            Click a row or column header to toggle all. View is required for any other action.
-          </p>
-        </div>
+        {/* Privilege matrix */}
+        <h2 style={{ textAlign: 'center', fontWeight: 'bold', marginBottom: 10 }}>Privileges</h2>
+        <p style={{ textAlign: 'center', fontSize: 12, color: '#555', marginBottom: 10 }}>
+          Click a row or column heading to toggle all. View is required for any other action.
+        </p>
 
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs">
+        <div style={{ overflowX: 'auto' }}>
+          <table className="b-priv-table">
             <thead>
-              <tr className="bg-slate-50 border-b border-slate-200">
-                <th className="text-left px-4 py-3 font-medium text-slate-600 w-64">Resource</th>
+              <tr>
+                <th className="b-res-head" style={{ minWidth: 220 }}>Resource</th>
                 {STANDARD_ACTIONS.map((a) => (
-                  <th key={a} className="px-3 py-3 font-medium text-slate-600 text-center capitalize">
-                    {canEdit ? (
-                      <button onClick={() => toggleColumn(a)} className="hover:text-blue-600 transition-colors">
-                        {a}
-                      </button>
-                    ) : a}
+                  <th key={a} onClick={() => canEdit && toggleColumn(a)} style={{ textTransform: 'capitalize', minWidth: 60 }}>
+                    {a}
                   </th>
                 ))}
                 {otherActions.map((a) => (
-                  <th key={a} className="px-3 py-3 font-medium text-slate-600 text-center capitalize">
-                    {canEdit ? (
-                      <button onClick={() => toggleColumn(a)} className="hover:text-blue-600 transition-colors">
-                        {a.replace(/_/g, ' ')}
-                      </button>
-                    ) : a.replace(/_/g, ' ')}
+                  <th key={a} onClick={() => canEdit && toggleColumn(a)} style={{ minWidth: 80 }}>
+                    {a.replace(/_/g, ' ')}
                   </th>
                 ))}
               </tr>
             </thead>
             <tbody>
-              {resources.map((resource, i) => {
-                const rowAllOn = resource.actions.every((a) => granted[`${resource.id}:${a}`]);
-                return (
-                  <tr key={resource.id} className={`border-b border-slate-100 ${i % 2 === 0 ? '' : 'bg-slate-50/50'}`}>
-                    <td className="px-4 py-2 text-slate-700">
-                      {canEdit ? (
-                        <button
-                          onClick={() => toggleRow(resource.id, resource.actions)}
-                          className={`hover:text-blue-600 text-left transition-colors ${rowAllOn ? 'font-medium' : ''}`}
-                        >
-                          {resource.label}
-                        </button>
-                      ) : resource.label}
+              {resources.map((resource) => (
+                <tr key={resource.id}>
+                  <td
+                    className="b-res-name"
+                    onClick={() => canEdit && toggleRow(resource.id, resource.actions)}
+                    title={canEdit ? 'Click to toggle all' : ''}
+                  >
+                    {resource.label}
+                  </td>
+                  {STANDARD_ACTIONS.map((action) => (
+                    <td key={action} style={{ textAlign: 'center' }}>
+                      {resource.actions.includes(action) ? (
+                        <input
+                          type="checkbox"
+                          checked={!!granted[`${resource.id}:${action}`]}
+                          onChange={() => canEdit && toggle(resource.id, action)}
+                          disabled={!canEdit}
+                        />
+                      ) : ''}
                     </td>
-                    {STANDARD_ACTIONS.map((action) => (
-                      <td key={action} className="px-3 py-2 text-center">
-                        {resource.actions.includes(action) ? (
-                          <input
-                            type="checkbox"
-                            checked={!!granted[`${resource.id}:${action}`]}
-                            onChange={() => canEdit && toggle(resource.id, action)}
-                            disabled={!canEdit}
-                            className="w-4 h-4 accent-blue-600 cursor-pointer disabled:cursor-default"
-                          />
-                        ) : (
-                          <span className="text-slate-200">—</span>
-                        )}
-                      </td>
-                    ))}
-                    {otherActions.map((action) => (
-                      <td key={action} className="px-3 py-2 text-center">
-                        {resource.actions.includes(action) ? (
-                          <input
-                            type="checkbox"
-                            checked={!!granted[`${resource.id}:${action}`]}
-                            onChange={() => canEdit && toggle(resource.id, action)}
-                            disabled={!canEdit}
-                            className="w-4 h-4 accent-blue-600 cursor-pointer disabled:cursor-default"
-                          />
-                        ) : (
-                          <span className="text-slate-200">—</span>
-                        )}
-                      </td>
-                    ))}
-                  </tr>
-                );
-              })}
+                  ))}
+                  {otherActions.map((action) => (
+                    <td key={action} style={{ textAlign: 'center' }}>
+                      {resource.actions.includes(action) ? (
+                        <input
+                          type="checkbox"
+                          checked={!!granted[`${resource.id}:${action}`]}
+                          onChange={() => canEdit && toggle(resource.id, action)}
+                          disabled={!canEdit}
+                        />
+                      ) : ''}
+                    </td>
+                  ))}
+                </tr>
+              ))}
             </tbody>
           </table>
         </div>
-      </div>
-    </PageShell>
-  );
-}
 
-function PageShell({ navLinks, children }) {
-  return (
-    <div className="min-h-screen bg-slate-100">
-      <NavBar links={navLinks} />
-      <div className="p-6 max-w-5xl mx-auto">{children}</div>
+        {canEdit && (
+          <div style={{ textAlign: 'center', marginTop: 16 }}>
+            <button onClick={handleSave} disabled={saving} style={{ marginRight: 8, padding: '3px 16px' }}>
+              {saving ? 'Saving…' : 'Save role'}
+            </button>
+            <button onClick={() => navigate('/roles')} style={{ padding: '3px 16px' }}>
+              Cancel
+            </button>
+          </div>
+        )}
+
+      </div>
+
       <NavBar links={navLinks} />
     </div>
   );

--- a/frontend/src/pages/roles/RoleList.jsx
+++ b/frontend/src/pages/roles/RoleList.jsx
@@ -5,26 +5,23 @@ import { useNavigate } from 'react-router-dom';
 import { roles as rolesApi } from '../../lib/api.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import NavBar from '../../components/NavBar.jsx';
+import BeaconLogo from '../../components/BeaconLogo.jsx';
 
 export default function RoleList() {
-  const { can } = useAuth();
+  const { can, tenant } = useAuth();
   const navigate = useNavigate();
-  const [roleList, setRoleList]   = useState([]);
-  const [loading,  setLoading]    = useState(true);
-  const [error,    setError]      = useState(null);
-  const [deleting, setDeleting]   = useState(null);
+  const [roleList, setRoleList] = useState([]);
+  const [loading,  setLoading]  = useState(true);
+  const [error,    setError]    = useState(null);
+  const [deleting, setDeleting] = useState(null);
 
   useEffect(() => { load(); }, []);
 
   async function load() {
     setLoading(true);
-    try {
-      setRoleList(await rolesApi.list());
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
+    try { setRoleList(await rolesApi.list()); }
+    catch (err) { setError(err.message); }
+    finally { setLoading(false); }
   }
 
   async function handleDelete(role) {
@@ -45,79 +42,81 @@ export default function RoleList() {
     ...(can('role_record', 'create') ? [{ label: 'Add Role', to: '/roles/new' }] : []),
   ];
 
-  if (loading) return <PageShell navLinks={navLinks}><Spinner /></PageShell>;
-  if (error)   return <PageShell navLinks={navLinks}><ErrorMsg msg={error} /></PageShell>;
+  const tenantDisplay = tenant
+    ? tenant.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    : '';
 
   return (
-    <PageShell navLinks={navLinks}>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-xl font-semibold text-slate-800">Roles</h1>
+    <div style={{ minHeight: '100vh', paddingBottom: 40 }}>
+
+      {/* Logo + tenant header */}
+      <div style={{ display: 'flex', alignItems: 'center', padding: '16px 32px 8px' }}>
+        <BeaconLogo />
+        {tenantDisplay && (
+          <span style={{ fontFamily: 'Arial', fontSize: 42, marginLeft: 24, color: '#000' }}>
+            {tenantDisplay}
+          </span>
+        )}
       </div>
 
-      {roleList.length === 0 ? (
-        <p className="text-slate-500 text-sm">No roles found.</p>
-      ) : (
-        <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="bg-slate-50 border-b border-slate-200">
-                <th className="text-left px-4 py-3 font-medium text-slate-600">Role name</th>
-                <th className="text-left px-4 py-3 font-medium text-slate-600">Committee role</th>
-                <th className="text-left px-4 py-3 font-medium text-slate-600">Users</th>
-                <th className="px-4 py-3"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {roleList.map((role) => (
-                <tr key={role.id} className="border-b border-slate-100 hover:bg-slate-50">
-                  <td className="px-4 py-3 font-medium text-slate-800">{role.name}</td>
-                  <td className="px-4 py-3 text-slate-600">
-                    {role.is_committee ? (
-                      <span className="inline-block bg-blue-100 text-blue-700 text-xs font-medium px-2 py-0.5 rounded-full">Yes</span>
-                    ) : '—'}
-                  </td>
-                  <td className="px-4 py-3 text-slate-600">{role.user_count}</td>
-                  <td className="px-4 py-3 text-right space-x-2">
-                    {can('role_record', 'view') && (
-                      <button
-                        onClick={() => navigate(`/roles/${role.id}`)}
-                        className="text-blue-600 hover:underline text-xs"
-                      >
-                        Edit
-                      </button>
-                    )}
-                    {can('role_record', 'delete') && (
-                      <button
-                        onClick={() => handleDelete(role)}
-                        disabled={deleting === role.id}
-                        className="text-red-500 hover:underline text-xs disabled:opacity-50"
-                      >
-                        {deleting === role.id ? 'Deleting…' : 'Delete'}
-                      </button>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </PageShell>
-  );
-}
-
-function PageShell({ navLinks, children }) {
-  return (
-    <div className="min-h-screen bg-slate-100">
       <NavBar links={navLinks} />
-      <div className="p-6 max-w-4xl mx-auto">{children}</div>
+
+      <div style={{ maxWidth: 900, margin: '0 auto', padding: '12px 16px' }}>
+        <h1 style={{ textAlign: 'center', fontWeight: 'bold', marginBottom: 14 }}>User Roles</h1>
+
+        {loading && <p style={{ textAlign: 'center', color: '#555' }}>Loading…</p>}
+        {error   && <p style={{ textAlign: 'center', color: 'red' }}>Error: {error}</p>}
+
+        {!loading && !error && (
+          roleList.length === 0 ? (
+            <p style={{ textAlign: 'center', color: '#555' }}>No roles found.</p>
+          ) : (
+            <table className="b-table">
+              <thead>
+                <tr>
+                  <th>Role Name</th>
+                  <th>Committee role</th>
+                  <th>Users</th>
+                  {(can('role_record', 'view') || can('role_record', 'delete')) && <th></th>}
+                </tr>
+              </thead>
+              <tbody>
+                {roleList.map((role) => (
+                  <tr key={role.id}>
+                    <td>{role.name}</td>
+                    <td style={{ textAlign: 'center' }}>{role.is_committee ? 'Y' : ''}</td>
+                    <td style={{ textAlign: 'center' }}>{role.user_count}</td>
+                    {(can('role_record', 'view') || can('role_record', 'delete')) && (
+                      <td className="b-td-action" style={{ textAlign: 'right' }}>
+                        {can('role_record', 'view') && (
+                          <a
+                            href="#edit"
+                            onClick={(e) => { e.preventDefault(); navigate(`/roles/${role.id}`); }}
+                            style={{ marginRight: 8 }}
+                          >
+                            Edit
+                          </a>
+                        )}
+                        {can('role_record', 'delete') && (
+                          <a
+                            href="#del"
+                            onClick={(e) => { e.preventDefault(); handleDelete(role); }}
+                            style={{ color: '#cc0000' }}
+                          >
+                            {deleting === role.id ? 'Deleting…' : 'Delete'}
+                          </a>
+                        )}
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )
+        )}
+      </div>
+
       <NavBar links={navLinks} />
     </div>
   );
-}
-function Spinner() {
-  return <div className="text-slate-400 text-sm">Loading…</div>;
-}
-function ErrorMsg({ msg }) {
-  return <div className="text-red-600 text-sm">Error: {msg}</div>;
 }


### PR DESCRIPTION
- Lighthouse photo background (blue-sky gradient fallback until light.jpg added)
- BeaconLogo component approximating u3a Beacon branding
- Login page: centered form on background, no white card, 'Enter' button, HR + forgot link
- Home page: logo+tenant header, full amber/yellow menu table matching Beacon layout
- Inner pages: logo+tenant header, Beacon-style yellow-row data tables
- NavBar: centred blue links separated by ' - '
- RoleEditor: Beacon form and privilege matrix styling
- All pages now use global index.css (Arial font, link colours, table classes)

NOTE: add the lighthouse photo as frontend/public/light.jpg for full effect.

https://claude.ai/code/session_01WdSsJg1nZ4vKZB2ncxM2Ej