### PR TITLE
Match RoleEditor screen to Beacon 8.4 documentation

### DIFF
--- a/frontend/src/pages/roles/RoleEditor.jsx
+++ b/frontend/src/pages/roles/RoleEditor.jsx
@@ -20,7 +20,9 @@ export default function RoleEditor() {
   const [resources,   setResources]   = useState([]);
   const [granted,     setGranted]     = useState({});
   const [loading,     setLoading]     = useState(!isNew);
-  const [saving,      setSaving]      = useState(false);
+  const [savingRole,  setSavingRole]  = useState(false);
+  const [savingPrivs, setSavingPrivs] = useState(false);
+  const [deleting,    setDeleting]    = useState(false);
   const [error,       setError]       = useState(null);
 
   useEffect(() => {
@@ -51,6 +53,8 @@ export default function RoleEditor() {
     }
     load();
   }, [id, isNew]);
+
+  const STANDARD_ACTIONS = ['view', 'create', 'change', 'delete'];
 
   const toggle = useCallback((resourceId, action) => {
     const key = `${resourceId}:${action}`;
@@ -83,6 +87,22 @@ export default function RoleEditor() {
     });
   }, [resources]);
 
+  const toggleOtherColumn = useCallback(() => {
+    setGranted((prev) => {
+      const next    = { ...prev };
+      const pairs   = resources.flatMap((r) =>
+        r.actions.filter((a) => !STANDARD_ACTIONS.includes(a)).map((a) => ({ r, a }))
+      );
+      const allOn   = pairs.every(({ r, a }) => next[`${r.id}:${a}`]);
+      pairs.forEach(({ r, a }) => {
+        const key = `${r.id}:${a}`;
+        if (allOn) { delete next[key]; }
+        else { next[key] = true; next[`${r.id}:view`] = true; }
+      });
+      return next;
+    });
+  }, [resources]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const toggleRow = useCallback((resourceId, possibleActions) => {
     setGranted((prev) => {
       const next  = { ...prev };
@@ -93,37 +113,56 @@ export default function RoleEditor() {
     });
   }, []);
 
-  const handleSave = async () => {
+  const handleSaveRole = async () => {
     if (!name.trim()) { setError('Role name is required.'); return; }
-    setSaving(true);
+    setSavingRole(true);
     setError(null);
     try {
-      let roleId = id;
       if (isNew) {
         const created = await rolesApi.create({ name: name.trim(), isCommittee, notes });
-        roleId = created.id;
+        navigate(`/roles/${created.id}`);
       } else {
         await rolesApi.update(id, { name: name.trim(), isCommittee, notes });
       }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSavingRole(false);
+    }
+  };
+
+  const handleSavePrivileges = async () => {
+    setSavingPrivs(true);
+    setError(null);
+    try {
       const privilegeList = Object.keys(granted).map((key) => {
         const [resourceId, action] = key.split(':');
         return { resourceId, action };
       });
-      await rolesApi.setPrivileges(roleId, privilegeList);
-      navigate('/roles');
+      await rolesApi.setPrivileges(id, privilegeList);
     } catch (err) {
       setError(err.message);
     } finally {
-      setSaving(false);
+      setSavingPrivs(false);
     }
   };
 
-  const STANDARD_ACTIONS = ['view', 'create', 'change', 'delete'];
-  const otherActions = [...new Set(
-    resources.flatMap((r) => r.actions.filter((a) => !STANDARD_ACTIONS.includes(a)))
-  )].sort();
+  const handleDeleteRole = async () => {
+    if (!confirm(`Delete role "${name}"? This cannot be undone.`)) return;
+    setDeleting(true);
+    try {
+      await rolesApi.delete(id);
+      navigate('/roles');
+    } catch (err) {
+      setError(err.message);
+      setDeleting(false);
+    }
+  };
 
-  const canEdit = can('role_record', isNew ? 'create' : 'change');
+  const hasOtherActions  = resources.some((r) => r.actions.some((a) => !STANDARD_ACTIONS.includes(a)));
+
+  const canEdit   = can('role_record', isNew ? 'create' : 'change');
+  const canDelete = !isNew && can('role_record', 'delete');
 
   const navLinks = [
     { label: 'Home', to: '/' },
@@ -134,6 +173,33 @@ export default function RoleEditor() {
   const tenantDisplay = tenant
     ? tenant.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
     : '';
+
+  const colHeadStyle = {
+    fontStyle: 'italic',
+    color: '#0000cc',
+    textAlign: 'center',
+    padding: '2px 6px',
+    cursor: canEdit ? 'pointer' : 'default',
+    minWidth: 52,
+    fontWeight: 'normal',
+  };
+
+  const colHeaders = (
+    <>
+      <th style={{ minWidth: 220 }}></th>
+      {STANDARD_ACTIONS.map((a) => (
+        <th key={a} style={colHeadStyle} onClick={() => canEdit && toggleColumn(a)}>
+          {a.charAt(0).toUpperCase() + a.slice(1)}
+        </th>
+      ))}
+      {hasOtherActions && (
+        <th style={{ ...colHeadStyle, minWidth: 120, cursor: canEdit ? 'pointer' : 'default' }}
+            onClick={() => canEdit && toggleOtherColumn()}>
+          Other
+        </th>
+      )}
+    </>
+  );
 
   if (loading) {
     return (
@@ -165,7 +231,7 @@ export default function RoleEditor() {
       <div style={{ maxWidth: 960, margin: '0 auto', padding: '12px 16px' }}>
 
         <h1 style={{ textAlign: 'center', fontWeight: 'bold', marginBottom: 14 }}>
-          {isNew ? 'Add Role' : `Edit Role: ${name}`}
+          Role Record
         </h1>
 
         {error && <div className="b-flash-error">{error}</div>}
@@ -174,7 +240,7 @@ export default function RoleEditor() {
         <table className="b-form-table" style={{ margin: '0 auto 20px' }}>
           <tbody>
             <tr>
-              <td className="b-label">Role name</td>
+              <td className="b-label">Name</td>
               <td>
                 <input
                   type="text"
@@ -184,6 +250,9 @@ export default function RoleEditor() {
                   style={{ width: 280 }}
                 />
               </td>
+              {isNew && (
+                <td style={{ paddingLeft: 10, color: '#555', fontStyle: 'italic' }}>New Role</td>
+              )}
             </tr>
             <tr>
               <td className="b-label">Committee role</td>
@@ -208,94 +277,113 @@ export default function RoleEditor() {
                 />
               </td>
             </tr>
+            {isNew && (
+              <tr>
+                <td></td>
+                <td style={{ fontSize: 12, color: '#555', fontStyle: 'italic', paddingTop: 2 }}>
+                  New record
+                </td>
+              </tr>
+            )}
             {canEdit && (
               <tr>
                 <td></td>
                 <td style={{ paddingTop: 8 }}>
-                  <button onClick={handleSave} disabled={saving} style={{ marginRight: 8, padding: '3px 16px' }}>
-                    {saving ? 'Saving…' : 'Save role'}
+                  <button onClick={handleSaveRole} disabled={savingRole} style={{ marginRight: 8, padding: '3px 16px' }}>
+                    {savingRole ? 'Saving…' : 'Save Role'}
                   </button>
-                  <button onClick={() => navigate('/roles')} style={{ padding: '3px 16px' }}>
-                    Cancel
-                  </button>
+                  {canDelete && (
+                    <button onClick={handleDeleteRole} disabled={deleting} style={{ padding: '3px 16px' }}>
+                      {deleting ? 'Deleting…' : 'Delete Role'}
+                    </button>
+                  )}
                 </td>
               </tr>
             )}
           </tbody>
         </table>
 
-        {/* Privilege matrix */}
-        <h2 style={{ textAlign: 'center', fontWeight: 'bold', marginBottom: 10 }}>Privileges</h2>
-        <p style={{ textAlign: 'center', fontSize: 12, color: '#555', marginBottom: 10 }}>
-          Click a row or column heading to toggle all. View is required for any other action.
-        </p>
+        {/* Privilege matrix — only shown when editing an existing role */}
+        {!isNew && (
+          <>
+            <h2 style={{ textAlign: 'center', fontWeight: 'bold', marginBottom: 10 }}>Privileges</h2>
+            <p style={{ textAlign: 'center', fontSize: 12, color: '#555', marginBottom: 10 }}>
+              Click a row or column heading to toggle all. View is required for any other action.
+            </p>
 
-        <div style={{ overflowX: 'auto' }}>
-          <table className="b-priv-table">
-            <thead>
-              <tr>
-                <th className="b-res-head" style={{ minWidth: 220 }}>Resource</th>
-                {STANDARD_ACTIONS.map((a) => (
-                  <th key={a} onClick={() => canEdit && toggleColumn(a)} style={{ textTransform: 'capitalize', minWidth: 60 }}>
-                    {a}
-                  </th>
-                ))}
-                {otherActions.map((a) => (
-                  <th key={a} onClick={() => canEdit && toggleColumn(a)} style={{ minWidth: 80 }}>
-                    {a.replace(/_/g, ' ')}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {resources.map((resource) => (
-                <tr key={resource.id}>
-                  <td
-                    className="b-res-name"
-                    onClick={() => canEdit && toggleRow(resource.id, resource.actions)}
-                    title={canEdit ? 'Click to toggle all' : ''}
-                  >
-                    {resource.label}
-                  </td>
-                  {STANDARD_ACTIONS.map((action) => (
-                    <td key={action} style={{ textAlign: 'center' }}>
-                      {resource.actions.includes(action) ? (
-                        <input
-                          type="checkbox"
-                          checked={!!granted[`${resource.id}:${action}`]}
-                          onChange={() => canEdit && toggle(resource.id, action)}
-                          disabled={!canEdit}
-                        />
-                      ) : ''}
-                    </td>
-                  ))}
-                  {otherActions.map((action) => (
-                    <td key={action} style={{ textAlign: 'center' }}>
-                      {resource.actions.includes(action) ? (
-                        <input
-                          type="checkbox"
-                          checked={!!granted[`${resource.id}:${action}`]}
-                          onChange={() => canEdit && toggle(resource.id, action)}
-                          disabled={!canEdit}
-                        />
-                      ) : ''}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+            <div style={{ overflowX: 'auto' }}>
+              <table className="b-priv-table" style={{ borderCollapse: 'collapse', width: '100%' }}>
+                <thead>
+                  <tr>{colHeaders}</tr>
+                </thead>
+                <tbody>
+                  {resources.map((resource, i) => {
+                    const resourceOtherActions = resource.actions.filter((a) => !STANDARD_ACTIONS.includes(a));
+                    return (
+                      <tr key={resource.id} style={{ backgroundColor: i % 2 === 0 ? '#ffffcc' : '#f0f0f0' }}>
+                        <td
+                          style={{
+                            color: '#0000cc',
+                            fontStyle: 'italic',
+                            cursor: canEdit ? 'pointer' : 'default',
+                            padding: '2px 6px',
+                            whiteSpace: 'nowrap',
+                          }}
+                          onClick={() => canEdit && toggleRow(resource.id, resource.actions)}
+                          title={canEdit ? 'Click to toggle all' : ''}
+                        >
+                          {resource.label}
+                        </td>
+                        {STANDARD_ACTIONS.map((action) => (
+                          <td key={action} style={{ textAlign: 'center', padding: '2px 4px' }}>
+                            {resource.actions.includes(action) ? (
+                              <input
+                                type="checkbox"
+                                checked={!!granted[`${resource.id}:${action}`]}
+                                onChange={() => canEdit && toggle(resource.id, action)}
+                                disabled={!canEdit}
+                              />
+                            ) : ''}
+                          </td>
+                        ))}
+                        {hasOtherActions && (
+                          <td style={{ padding: '2px 8px' }}>
+                            {resourceOtherActions.map((action) => (
+                              <label key={action} style={{ display: 'inline-flex', alignItems: 'center', marginRight: 8, whiteSpace: 'nowrap' }}>
+                                <input
+                                  type="checkbox"
+                                  checked={!!granted[`${resource.id}:${action}`]}
+                                  onChange={() => canEdit && toggle(resource.id, action)}
+                                  disabled={!canEdit}
+                                  style={{ marginRight: 3 }}
+                                />
+                                {action.charAt(0).toUpperCase() + action.slice(1).replace(/_/g, ' ')}
+                              </label>
+                            ))}
+                          </td>
+                        )}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+                <tfoot>
+                  <tr>{colHeaders}</tr>
+                </tfoot>
+              </table>
+            </div>
 
-        {canEdit && (
-          <div style={{ textAlign: 'center', marginTop: 16 }}>
-            <button onClick={handleSave} disabled={saving} style={{ marginRight: 8, padding: '3px 16px' }}>
-              {saving ? 'Saving…' : 'Save role'}
-            </button>
-            <button onClick={() => navigate('/roles')} style={{ padding: '3px 16px' }}>
-              Cancel
-            </button>
-          </div>
+            {canEdit && (
+              <div style={{ textAlign: 'center', marginTop: 12 }}>
+                <button
+                  onClick={handleSavePrivileges}
+                  disabled={savingPrivs}
+                  style={{ padding: '4px 24px', backgroundColor: '#e08000', color: '#fff', border: '1px solid #b06000', borderRadius: 3, fontWeight: 'bold', cursor: 'pointer' }}
+                >
+                  {savingPrivs ? 'Saving…' : 'Save Privileges'}
+                </button>
+              </div>
+            )}
+          </>
         )}
 
       </div>


### PR DESCRIPTION
- Rename page title to "Role Record"
- Rename "Role name" field label to "Name"
- Show "New Role" / "New record" annotations for new roles
- Replace Cancel with "Delete Role" button (existing roles only)
- Split save into separate "Save Role" and "Save Privileges" actions
- Combine all non-standard privilege actions into a single "Other" column with labelled inline checkboxes, matching Beacon table layout
- Repeat column headers in <tfoot>
- Alternating yellow/grey row background and blue italic resource names
- Orange "Save Privileges" button below privilege matrix
- Privilege matrix hidden on new-role form (shown only for existing roles)

https://claude.ai/code/session_01WdSsJg1nZ4vKZB2ncxM2Ej