### PR TITLE
Add full testing harness with CI (backend + frontend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+# beacon2/.github/workflows/ci.yml
+# Runs backend and frontend tests on every push to a claude/* branch
+# and on every pull request targeting main.
+
+name: CI
+
+on:
+  push:
+    branches:
+      - 'claude/**'
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  # ── Backend unit/integration tests ───────────────────────────────────────
+  backend-test:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # DB is fully mocked — no Postgres service container needed.
+      # Secrets are set in vitest.config.js env block for tests.
+      - name: Run tests
+        run: npm test
+
+  # ── Frontend smoke tests ──────────────────────────────────────────────────
+  frontend-test:
+    name: Frontend tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,54 @@ Do **not** replace these with generic Tailwind classes — they match the Beacon
 
 ### SystemLogin / SystemDashboard
 These already used Tailwind before the Option B migration. They use `bg-slate-100` for the whole page (no lighthouse background) — this is intentional for the system-admin area.
+
+## Testing harness (set up March 2026)
+
+### How to run tests
+
+```bash
+# Backend (from /backend)
+npm test           # runs vitest --run (exits after one pass)
+
+# Frontend (from /frontend)
+npm test           # runs vitest --run (exits after one pass)
+```
+
+CI runs automatically on every push to `claude/**` branches via `.github/workflows/ci.yml`.
+
+### Backend tests — architecture
+
+- **Framework**: vitest + supertest
+- **Config**: `backend/vitest.config.js` — sets JWT secrets in `env` block so `jwt.js` loads without throwing
+- **No real database**: the DB layer (`../utils/db.js`) is mocked with `vi.mock()` in every test file
+- **Auth bypass**: `../utils/redis.js` is mocked so `isSessionInvalidated` always returns false
+- **Token helper**: `backend/src/__tests__/helpers.js` exports `makeAuthHeader()` and `makeSysAdminHeader()` — use these instead of hard-coding tokens
+- **Test files**: `backend/src/__tests__/{health,auth,users,roles}.test.js`
+- **app.js vs server.js**: `app.js` exports the pure Express app (safe to import in tests); `server.js` handles `migrateAndSeed()` + `app.listen()` — never import `server.js` in tests
+
+### Backend testing patterns
+
+When adding tests for a new endpoint:
+1. Add `vi.mock('../utils/db.js', ...)` and `vi.mock('../utils/redis.js', ...)`
+2. Use `tenantQuery.mockResolvedValueOnce([...])` to simulate DB responses
+3. Use `makeAuthHeader()` for the `Authorization` header
+4. Use `makeAuthHeader({ privileges: [] })` to test 403 responses
+
+### Frontend tests — architecture
+
+- **Framework**: vitest + React Testing Library + jsdom
+- **Config**: `vite.config.js` `test` block — environment `jsdom`, setupFiles loads `@testing-library/jest-dom`
+- **All API calls mocked**: `vi.mock('../lib/api.js', ...)` with resolved empty arrays
+- **Auth context mocked**: `vi.mock('../context/AuthContext.jsx', ...)` injects a test user with `can` always returning true
+- **Router mocked**: `useParams` and `useNavigate` are overridden via `vi.mock('react-router-dom', ...)`; pages are wrapped in `<MemoryRouter>`
+- **Test files**: `frontend/src/__tests__/*.test.jsx` — one per page
+
+### Frontend testing patterns
+
+When adding a new page, add a smoke test that:
+1. Mocks `AuthContext` with the minimum fields the page needs
+2. Mocks any API calls the page makes
+3. Wraps in `<MemoryRouter>`
+4. Asserts the page heading is visible (use `getByText`)
+
+This catches: import errors, JSX syntax errors, missing context, broken component props.

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,12 +6,12 @@
   "main": "src/app.js",
   "scripts": {
     "build": "prisma generate",
-    "dev": "node --watch src/app.js",
-    "start": "node src/app.js",
+    "dev": "node --watch src/server.js",
+    "start": "node src/server.js",
     "db:migrate": "prisma migrate dev",
     "db:seed": "node src/seed/index.js",
     "db:studio": "prisma studio",
-    "test": "vitest"
+    "test": "vitest --run"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "prisma": "^5.0.0",
+    "supertest": "^6.3.4",
     "vitest": "^1.0.0"
   }
 }

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -1,0 +1,161 @@
+// beacon2/backend/src/__tests__/auth.test.js
+// Tests for POST /auth/login, /auth/logout, /auth/refresh, /auth/system/login
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { makeAuthHeader, TEST_TENANT } from './helpers.js';
+
+// ── Module mocks (hoisted before imports by vitest) ───────────────────────
+
+vi.mock('../utils/db.js', () => ({
+  prisma:      { $disconnect: vi.fn() },
+  tenantQuery: vi.fn(),
+  withTenant:  vi.fn(),
+}));
+
+vi.mock('../utils/redis.js', () => ({
+  isSessionInvalidated:   vi.fn().mockResolvedValue(false),
+  invalidateUserSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/authService.js', () => ({
+  loginUser:     vi.fn(),
+  logoutUser:    vi.fn().mockResolvedValue(undefined),
+  refreshTokens: vi.fn(),
+  loginSysAdmin: vi.fn(),
+}));
+
+const { default: app } = await import('../app.js');
+const { loginUser, logoutUser, refreshTokens, loginSysAdmin } =
+  await import('../services/authService.js');
+
+// ── POST /auth/login ──────────────────────────────────────────────────────
+
+describe('POST /auth/login', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with accessToken on valid credentials', async () => {
+    loginUser.mockResolvedValueOnce({
+      accessToken:  'acc.tok.en',
+      refreshToken: 'ref.tok.en',
+      user: { id: 'u1', name: 'Alice', email: 'alice@example.com' },
+    });
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ tenantSlug: 'test-u3a', email: 'alice@example.com', password: 'secret' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.accessToken).toBe('acc.tok.en');
+    expect(res.body.user.name).toBe('Alice');
+    expect(loginUser).toHaveBeenCalledWith('test-u3a', 'alice@example.com', 'secret');
+  });
+
+  it('returns 401 when authService throws an auth error', async () => {
+    const err = new Error('Invalid credentials.'); err.status = 401;
+    loginUser.mockRejectedValueOnce(err);
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ tenantSlug: 'test-u3a', email: 'x@y.com', password: 'wrong' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid credentials.');
+  });
+
+  it('returns 422 on invalid body (missing email)', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ tenantSlug: 'test-u3a', password: 'pw' });
+
+    expect(res.status).toBe(422);
+  });
+});
+
+// ── POST /auth/logout ─────────────────────────────────────────────────────
+
+describe('POST /auth/logout', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with message on valid token', async () => {
+    const res = await request(app)
+      .post('/auth/logout')
+      .set('Authorization', makeAuthHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Logged out successfully.');
+  });
+
+  it('returns 401 with no token', async () => {
+    const res = await request(app).post('/auth/logout');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── POST /auth/refresh ────────────────────────────────────────────────────
+
+describe('POST /auth/refresh', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 401 when no refresh cookie is present', async () => {
+    const res = await request(app)
+      .post('/auth/refresh')
+      .set('x-tenant-slug', TEST_TENANT);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('No refresh token.');
+  });
+
+  it('returns 400 when x-tenant-slug header is missing', async () => {
+    const res = await request(app)
+      .post('/auth/refresh')
+      .set('Cookie', 'beacon2_refresh=sometoken');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Tenant not specified.');
+  });
+
+  it('returns 200 with new accessToken on valid refresh', async () => {
+    refreshTokens.mockResolvedValueOnce({
+      accessToken:  'new.acc.tok',
+      refreshToken: 'new.ref.tok',
+    });
+
+    const res = await request(app)
+      .post('/auth/refresh')
+      .set('Cookie', 'beacon2_refresh=valid-token')
+      .set('x-tenant-slug', TEST_TENANT);
+
+    expect(res.status).toBe(200);
+    expect(res.body.accessToken).toBe('new.acc.tok');
+  });
+});
+
+// ── POST /auth/system/login ───────────────────────────────────────────────
+
+describe('POST /auth/system/login', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with accessToken on valid sysAdmin credentials', async () => {
+    loginSysAdmin.mockResolvedValueOnce({
+      accessToken: 'sys.acc.tok',
+      admin: { id: 'a1', name: 'Admin', email: 'admin@beacon2.local' },
+    });
+
+    const res = await request(app)
+      .post('/auth/system/login')
+      .send({ email: 'admin@beacon2.local', password: 'supersecret' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.accessToken).toBe('sys.acc.tok');
+    expect(res.body.admin.name).toBe('Admin');
+  });
+
+  it('returns 422 on missing password', async () => {
+    const res = await request(app)
+      .post('/auth/system/login')
+      .send({ email: 'admin@beacon2.local' });
+
+    expect(res.status).toBe(422);
+  });
+});

--- a/backend/src/__tests__/health.test.js
+++ b/backend/src/__tests__/health.test.js
@@ -1,0 +1,27 @@
+// beacon2/backend/src/__tests__/health.test.js
+// Sanity-check: the app wires up and the /health endpoint responds.
+
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+
+// Prevent the Prisma client from trying to connect during tests
+vi.mock('../utils/db.js', () => ({
+  prisma:      { $disconnect: vi.fn() },
+  tenantQuery: vi.fn(),
+  withTenant:  vi.fn(),
+}));
+
+vi.mock('../utils/redis.js', () => ({
+  isSessionInvalidated: vi.fn().mockResolvedValue(false),
+  invalidateUserSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { default: app } = await import('../app.js');
+
+describe('GET /health', () => {
+  it('returns 200 { status: "ok" }', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/backend/src/__tests__/helpers.js
+++ b/backend/src/__tests__/helpers.js
@@ -1,0 +1,34 @@
+// beacon2/backend/src/__tests__/helpers.js
+// Shared test utilities.
+
+import { signAccessToken } from '../utils/jwt.js';
+
+// Privilege set that covers all currently-used route guards
+export const ALL_PRIVS = [
+  'users_list:view',
+  'user_record:view', 'user_record:create', 'user_record:change', 'user_record:delete',
+  'roles_list:view',
+  'role_record:view', 'role_record:create', 'role_record:change', 'role_record:delete',
+  'privilege_resources:view',
+];
+
+export const TEST_TENANT = 'test-u3a';
+export const TEST_USER_ID = 'user-id-1';
+
+/** Returns a Bearer token string for use in Authorization headers. */
+export function makeAuthHeader(overrides = {}) {
+  const token = signAccessToken({
+    userId: TEST_USER_ID,
+    tenantSlug: TEST_TENANT,
+    name: 'Test User',
+    privileges: ALL_PRIVS,
+    ...overrides,
+  });
+  return `Bearer ${token}`;
+}
+
+/** Returns a sysAdmin Bearer token. */
+export function makeSysAdminHeader() {
+  const token = signAccessToken({ sysAdminId: 'admin-1', isSysAdmin: true, name: 'Admin' });
+  return `Bearer ${token}`;
+}

--- a/backend/src/__tests__/roles.test.js
+++ b/backend/src/__tests__/roles.test.js
@@ -1,0 +1,205 @@
+// beacon2/backend/src/__tests__/roles.test.js
+// Tests for /roles endpoints.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { makeAuthHeader } from './helpers.js';
+
+// ── Module mocks ──────────────────────────────────────────────────────────
+
+vi.mock('../utils/redis.js', () => ({
+  isSessionInvalidated:   vi.fn().mockResolvedValue(false),
+  invalidateUserSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/db.js', () => ({
+  prisma:      { $disconnect: vi.fn() },
+  tenantQuery: vi.fn(),
+  withTenant:  vi.fn(),
+}));
+
+const { default: app } = await import('../app.js');
+const { tenantQuery } = await import('../utils/db.js');
+
+const AUTH = makeAuthHeader();
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const SAMPLE_ROLE = {
+  id: 'r1', name: 'Admin', is_committee: false, notes: null, user_count: 2,
+};
+
+// ── GET /roles ────────────────────────────────────────────────────────────
+
+describe('GET /roles', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with role list', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_ROLE]);
+
+    const res = await request(app).get('/roles').set('Authorization', AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].name).toBe('Admin');
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/roles');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when privilege missing', async () => {
+    const res = await request(app)
+      .get('/roles')
+      .set('Authorization', makeAuthHeader({ privileges: [] }));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── GET /roles/:id ────────────────────────────────────────────────────────
+
+describe('GET /roles/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with role and privileges', async () => {
+    tenantQuery
+      .mockResolvedValueOnce([{ id: 'r1', name: 'Admin', is_committee: false, notes: null }])
+      .mockResolvedValueOnce([]); // empty privileges
+
+    const res = await request(app).get('/roles/r1').set('Authorization', AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Admin');
+    expect(res.body.privileges).toEqual([]);
+  });
+
+  it('returns 404 when role not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app).get('/roles/missing').set('Authorization', AUTH);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /roles ───────────────────────────────────────────────────────────
+
+describe('POST /roles', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 201 with created role', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'r2', name: 'Treasurer', is_committee: true, notes: null }]);
+
+    const res = await request(app)
+      .post('/roles')
+      .set('Authorization', AUTH)
+      .send({ name: 'Treasurer', isCommittee: true });
+
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Treasurer');
+  });
+
+  it('returns 422 on invalid body (empty name)', async () => {
+    const res = await request(app)
+      .post('/roles')
+      .set('Authorization', AUTH)
+      .send({ name: '' });
+
+    expect(res.status).toBe(422);
+  });
+});
+
+// ── PATCH /roles/:id ──────────────────────────────────────────────────────
+
+describe('PATCH /roles/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with updated role', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'r1', name: 'SuperAdmin', is_committee: false, notes: null }]);
+
+    const res = await request(app)
+      .patch('/roles/r1')
+      .set('Authorization', AUTH)
+      .send({ name: 'SuperAdmin' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('SuperAdmin');
+  });
+
+  it('returns 400 when nothing to update', async () => {
+    const res = await request(app)
+      .patch('/roles/r1')
+      .set('Authorization', AUTH)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when role not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .patch('/roles/missing')
+      .set('Authorization', AUTH)
+      .send({ name: 'X' });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── DELETE /roles/:id ─────────────────────────────────────────────────────
+
+describe('DELETE /roles/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 when deleted', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'r1' }]);
+
+    const res = await request(app).delete('/roles/r1').set('Authorization', AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Role deleted.');
+  });
+
+  it('returns 404 when role not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app).delete('/roles/ghost').set('Authorization', AUTH);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── PUT /roles/:id/privileges ─────────────────────────────────────────────
+
+describe('PUT /roles/:id/privileges', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 when privileges updated', async () => {
+    tenantQuery
+      .mockResolvedValueOnce([{ id: 'r1' }])  // role exists check
+      .mockResolvedValueOnce([])               // DELETE old privs
+      .mockResolvedValueOnce([])               // INSERT priv 1
+      .mockResolvedValueOnce([]);              // SELECT affected users
+
+    const res = await request(app)
+      .put('/roles/r1/privileges')
+      .set('Authorization', AUTH)
+      .send({ privileges: [{ resourceId: 'res-1', action: 'view' }] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+  });
+
+  it('returns 404 when role not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]); // role does not exist
+
+    const res = await request(app)
+      .put('/roles/ghost/privileges')
+      .set('Authorization', AUTH)
+      .send({ privileges: [] });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/src/__tests__/setup.js
+++ b/backend/src/__tests__/setup.js
@@ -1,0 +1,9 @@
+// beacon2/backend/src/__tests__/setup.js
+// Global test setup: runs before every test file.
+
+import { vi, beforeEach } from 'vitest';
+
+// Silence console.error spam from the Express error handler during tests
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});

--- a/backend/src/__tests__/users.test.js
+++ b/backend/src/__tests__/users.test.js
@@ -1,0 +1,222 @@
+// beacon2/backend/src/__tests__/users.test.js
+// Tests for /users endpoints.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { makeAuthHeader, TEST_TENANT, TEST_USER_ID } from './helpers.js';
+
+// ── Module mocks ──────────────────────────────────────────────────────────
+
+vi.mock('../utils/redis.js', () => ({
+  isSessionInvalidated:   vi.fn().mockResolvedValue(false),
+  invalidateUserSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/db.js', () => ({
+  prisma:      { $disconnect: vi.fn() },
+  tenantQuery: vi.fn(),
+  withTenant:  vi.fn(),
+}));
+
+// Mock bcrypt to avoid expensive hashing in tests
+vi.mock('../utils/password.js', () => ({
+  hashPassword:   vi.fn().mockResolvedValue('$hashed$'),
+  verifyPassword: vi.fn().mockResolvedValue(true),
+}));
+
+const { default: app } = await import('../app.js');
+const { tenantQuery } = await import('../utils/db.js');
+
+const AUTH = makeAuthHeader();
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const SAMPLE_USER = {
+  id: 'u1', name: 'Alice', email: 'alice@example.com', active: true, roles: [],
+};
+
+// ── GET /users ────────────────────────────────────────────────────────────
+
+describe('GET /users', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with user list', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_USER]);
+
+    const res = await request(app).get('/users').set('Authorization', AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].name).toBe('Alice');
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).get('/users');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when privilege is missing', async () => {
+    const res = await request(app)
+      .get('/users')
+      .set('Authorization', makeAuthHeader({ privileges: [] }));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── GET /users/:id ────────────────────────────────────────────────────────
+
+describe('GET /users/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with a single user', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_USER]);
+
+    const res = await request(app).get('/users/u1').set('Authorization', AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.email).toBe('alice@example.com');
+  });
+
+  it('returns 404 when user does not exist', async () => {
+    tenantQuery.mockResolvedValueOnce([]); // empty = not found
+
+    const res = await request(app).get('/users/missing-id').set('Authorization', AUTH);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /users ───────────────────────────────────────────────────────────
+
+describe('POST /users', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 201 with the created user', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'u2', email: 'bob@example.com', name: 'Bob', active: true }]);
+
+    const res = await request(app)
+      .post('/users')
+      .set('Authorization', AUTH)
+      .send({ name: 'Bob', email: 'bob@example.com', password: 'password123', active: true });
+
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Bob');
+  });
+
+  it('returns 422 on invalid body', async () => {
+    const res = await request(app)
+      .post('/users')
+      .set('Authorization', AUTH)
+      .send({ name: 'Bad' }); // missing email
+
+    expect(res.status).toBe(422);
+  });
+});
+
+// ── PATCH /users/:id ──────────────────────────────────────────────────────
+
+describe('PATCH /users/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with updated user', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'u1', email: 'alice@example.com', name: 'Alice Updated', active: true }]);
+
+    const res = await request(app)
+      .patch('/users/u1')
+      .set('Authorization', AUTH)
+      .send({ name: 'Alice Updated' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Alice Updated');
+  });
+
+  it('returns 400 when body has nothing to update', async () => {
+    const res = await request(app)
+      .patch('/users/u1')
+      .set('Authorization', AUTH)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user does not exist', async () => {
+    tenantQuery.mockResolvedValueOnce([]); // UPDATE returns nothing
+
+    const res = await request(app)
+      .patch('/users/missing')
+      .set('Authorization', AUTH)
+      .send({ name: 'Nobody' });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── DELETE /users/:id ─────────────────────────────────────────────────────
+
+describe('DELETE /users/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 when deleted', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'u2' }]);
+
+    const res = await request(app)
+      .delete('/users/u2')
+      .set('Authorization', AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('User deleted.');
+  });
+
+  it('returns 400 when trying to self-delete', async () => {
+    const res = await request(app)
+      .delete(`/users/${TEST_USER_ID}`)
+      .set('Authorization', AUTH);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user does not exist', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .delete('/users/ghost')
+      .set('Authorization', AUTH);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /users/:id/roles ─────────────────────────────────────────────────
+
+describe('POST /users/:id/roles', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 when role assigned', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .post('/users/u1/roles')
+      .set('Authorization', AUTH)
+      .send({ roleId: 'role-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Role assigned.');
+  });
+});
+
+// ── DELETE /users/:id/roles/:roleId ──────────────────────────────────────
+
+describe('DELETE /users/:id/roles/:roleId', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 when role removed', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .delete('/users/u1/roles/role-1')
+      .set('Authorization', AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Role removed.');
+  });
+});

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -12,8 +12,6 @@ import roleRoutes      from './routes/roles.js';
 import privilegeRoutes from './routes/privileges.js';
 import systemRoutes    from './routes/system.js';
 import { errorHandler } from './middleware/errorHandler.js';
-import { prisma }       from './utils/db.js';
-import { migrateAndSeed } from './utils/migrate.js';
 
 const app = express();
 
@@ -39,24 +37,5 @@ app.use('/system',     systemRoutes);
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 
 app.use(errorHandler);
-
-// ── Start: migrate first, then listen ────────────────────────────────────
-const PORT = process.env.PORT ?? 3001;
-
-migrateAndSeed()
-  .then(() => {
-    app.listen(PORT, () => {
-      console.log(`Beacon2 API running on port ${PORT} [${process.env.NODE_ENV}]`);
-    });
-  })
-  .catch((err) => {
-    console.error('Startup failed:', err);
-    process.exit(1);
-  });
-
-process.on('SIGTERM', async () => {
-  await prisma.$disconnect();
-  process.exit(0);
-});
 
 export default app;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,26 @@
+// beacon2/backend/src/server.js
+// Entry point: migrate, seed, then start listening.
+// app.js exports the pure Express app (importable without side-effects for tests).
+
+import 'dotenv/config';
+import app from './app.js';
+import { prisma } from './utils/db.js';
+import { migrateAndSeed } from './utils/migrate.js';
+
+const PORT = process.env.PORT ?? 3001;
+
+migrateAndSeed()
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`Beacon2 API running on port ${PORT} [${process.env.NODE_ENV}]`);
+    });
+  })
+  .catch((err) => {
+    console.error('Startup failed:', err);
+    process.exit(1);
+  });
+
+process.on('SIGTERM', async () => {
+  await prisma.$disconnect();
+  process.exit(0);
+});

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -1,0 +1,19 @@
+// beacon2/backend/vitest.config.js
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    setupFiles: ['./src/__tests__/setup.js'],
+    // Set JWT secrets so jwt.js module loads without throwing
+    env: {
+      JWT_ACCESS_SECRET:  'test-access-secret-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+      JWT_REFRESH_SECRET: 'test-refresh-secret-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+      JWT_ACCESS_EXPIRES_IN: '15m',
+      JWT_REFRESH_EXPIRES_DAYS: '30',
+      NODE_ENV: 'test',
+      CORS_ORIGIN: 'http://localhost:5173',
+    },
+  },
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,20 +3,26 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev":   "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "dev":     "vite",
+    "build":   "vite build",
+    "preview": "vite preview",
+    "test":    "vitest --run"
   },
   "dependencies": {
-    "react":        "^18.2.0",
-    "react-dom":    "^18.2.0",
+    "react":            "^18.2.0",
+    "react-dom":        "^18.2.0",
     "react-router-dom": "^6.20.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom":   "^6.1.5",
+    "@testing-library/react":      "^14.1.2",
+    "@testing-library/user-event": "^14.5.1",
     "@vitejs/plugin-react": "^4.2.0",
-    "autoprefixer":  "^10.4.16",
-    "postcss":       "^8.4.31",
-    "tailwindcss":   "^3.3.5",
-    "vite":          "^5.0.0"
+    "autoprefixer": "^10.4.16",
+    "jsdom":        "^23.0.1",
+    "postcss":      "^8.4.31",
+    "tailwindcss":  "^3.3.5",
+    "vite":         "^5.0.0",
+    "vitest":       "^1.0.0"
   }
 }

--- a/frontend/src/__tests__/Home.test.jsx
+++ b/frontend/src/__tests__/Home.test.jsx
@@ -1,0 +1,37 @@
+// beacon2/frontend/src/__tests__/Home.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Home from '../pages/Home.jsx';
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    user:   { name: 'Test User', email: 'test@test.com' },
+    tenant: 'test-u3a',
+    logout: vi.fn().mockResolvedValue(undefined),
+    can:    vi.fn().mockReturnValue(true),
+  }),
+}));
+
+describe('Home page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><Home /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows the Administration heading', () => {
+    const { getByText } = render(<MemoryRouter><Home /></MemoryRouter>);
+    expect(getByText('Administration')).toBeInTheDocument();
+  });
+
+  it('shows the Log Out button', () => {
+    const { getByText } = render(<MemoryRouter><Home /></MemoryRouter>);
+    expect(getByText('Log Out')).toBeInTheDocument();
+  });
+
+  it('shows the Set up section', () => {
+    const { getAllByText } = render(<MemoryRouter><Home /></MemoryRouter>);
+    // Appears in both mobile and desktop layouts
+    expect(getAllByText('Set up').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/Login.test.jsx
+++ b/frontend/src/__tests__/Login.test.jsx
@@ -1,0 +1,26 @@
+// beacon2/frontend/src/__tests__/Login.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Login from '../pages/Login.jsx';
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({ login: vi.fn(), loading: false, error: null }),
+}));
+
+describe('Login page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><Login /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows the Administration heading', () => {
+    const { getByText } = render(<MemoryRouter><Login /></MemoryRouter>);
+    expect(getByText('Administration')).toBeInTheDocument();
+  });
+
+  it('shows the Enter button', () => {
+    const { getByRole } = render(<MemoryRouter><Login /></MemoryRouter>);
+    expect(getByRole('button', { name: /enter/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/RoleEditor.test.jsx
+++ b/frontend/src/__tests__/RoleEditor.test.jsx
@@ -1,0 +1,34 @@
+// beacon2/frontend/src/__tests__/RoleEditor.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RoleEditor from '../pages/roles/RoleEditor.jsx';
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    tenant: 'test-u3a',
+    can:    vi.fn().mockReturnValue(true),
+  }),
+}));
+
+vi.mock('../lib/api.js', () => ({
+  roles:      { get: vi.fn().mockResolvedValue({ name: '', is_committee: false, notes: '', privileges: [] }) },
+  privileges: { resources: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useParams: () => ({ id: 'new' }), useNavigate: () => vi.fn() };
+});
+
+describe('RoleEditor page (new role)', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><RoleEditor /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows the Role Record heading', () => {
+    const { getByText } = render(<MemoryRouter><RoleEditor /></MemoryRouter>);
+    expect(getByText('Role Record')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/RoleList.test.jsx
+++ b/frontend/src/__tests__/RoleList.test.jsx
@@ -1,0 +1,28 @@
+// beacon2/frontend/src/__tests__/RoleList.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RoleList from '../pages/roles/RoleList.jsx';
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    tenant: 'test-u3a',
+    can:    vi.fn().mockReturnValue(true),
+  }),
+}));
+
+vi.mock('../lib/api.js', () => ({
+  roles: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+describe('RoleList page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><RoleList /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows the User Roles heading', () => {
+    const { getByText } = render(<MemoryRouter><RoleList /></MemoryRouter>);
+    expect(getByText('User Roles')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/SystemDashboard.test.jsx
+++ b/frontend/src/__tests__/SystemDashboard.test.jsx
@@ -1,0 +1,38 @@
+// beacon2/frontend/src/__tests__/SystemDashboard.test.jsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SystemDashboard from '../pages/system/SystemDashboard.jsx';
+
+vi.mock('../lib/api.js', () => ({
+  system: {
+    listTenants:     vi.fn().mockResolvedValue([]),
+    createTenant:    vi.fn(),
+    setTenantActive: vi.fn(),
+  },
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+// Provide a fake sysToken so the page doesn't immediately redirect
+beforeEach(() => {
+  Object.defineProperty(window, 'sessionStorage', {
+    value: { getItem: vi.fn().mockReturnValue('fake-sys-token'), removeItem: vi.fn() },
+    writable: true,
+  });
+});
+
+describe('SystemDashboard page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><SystemDashboard /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows Beacon2 / System Admin heading', () => {
+    const { getByText } = render(<MemoryRouter><SystemDashboard /></MemoryRouter>);
+    expect(getByText(/System Admin/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/SystemLogin.test.jsx
+++ b/frontend/src/__tests__/SystemLogin.test.jsx
@@ -1,0 +1,26 @@
+// beacon2/frontend/src/__tests__/SystemLogin.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SystemLogin from '../pages/system/SystemLogin.jsx';
+
+vi.mock('../lib/api.js', () => ({
+  system: { login: vi.fn() },
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+describe('SystemLogin page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><SystemLogin /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows a Sign in button', () => {
+    const { getByRole } = render(<MemoryRouter><SystemLogin /></MemoryRouter>);
+    expect(getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/UserEditor.test.jsx
+++ b/frontend/src/__tests__/UserEditor.test.jsx
@@ -1,0 +1,34 @@
+// beacon2/frontend/src/__tests__/UserEditor.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UserEditor from '../pages/users/UserEditor.jsx';
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    tenant: 'test-u3a',
+    can:    vi.fn().mockReturnValue(true),
+  }),
+}));
+
+vi.mock('../lib/api.js', () => ({
+  users: { get: vi.fn().mockResolvedValue({ name: '', email: '', active: true, roles: [] }) },
+  roles: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useParams: () => ({ id: 'new' }), useNavigate: () => vi.fn() };
+});
+
+describe('UserEditor page (new user)', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><UserEditor /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows the Add User heading', () => {
+    const { getByText } = render(<MemoryRouter><UserEditor /></MemoryRouter>);
+    expect(getByText('Add User')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/UserList.test.jsx
+++ b/frontend/src/__tests__/UserList.test.jsx
@@ -1,0 +1,28 @@
+// beacon2/frontend/src/__tests__/UserList.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UserList from '../pages/users/UserList.jsx';
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    tenant: 'test-u3a',
+    can:    vi.fn().mockReturnValue(true),
+  }),
+}));
+
+vi.mock('../lib/api.js', () => ({
+  users: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+describe('UserList page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><UserList /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows the System Users heading', () => {
+    const { getByText } = render(<MemoryRouter><UserList /></MemoryRouter>);
+    expect(getByText('System Users')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/setup.js
+++ b/frontend/src/__tests__/setup.js
@@ -1,0 +1,2 @@
+// beacon2/frontend/src/__tests__/setup.js
+import '@testing-library/jest-dom';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/__tests__/setup.js'],
+  },
 });


### PR DESCRIPTION
Backend (vitest + supertest, no real DB):
- Refactor app.js to export pure Express app without side-effects; move migrateAndSeed + app.listen into new server.js entry point
- vitest.config.js: sets JWT secrets in env block so jwt.js loads cleanly
- __tests__/helpers.js: makeAuthHeader() / makeSysAdminHeader() using real JWT signing, ALL_PRIVS constant
- __tests__/setup.js: suppress console.error spam from errorHandler
- health.test.js: sanity check on GET /health
- auth.test.js: login success/fail/validation, logout, refresh, sys login
- users.test.js: all 7 /users endpoints (list, get, create, patch, delete, assign role, remove role) with mocked tenantQuery
- roles.test.js: all 6 /roles endpoints including PUT .../privileges
- Add supertest to backend devDependencies; change test script to --run

Frontend (vitest + React Testing Library + jsdom):
- vite.config.js: add test block (jsdom, globals, setupFiles)
- frontend/package.json: add test script + vitest/RTL/jsdom deps
- __tests__/setup.js: import @testing-library/jest-dom matchers
- Smoke tests for all 8 pages: Login, Home, UserList, UserEditor, RoleList, RoleEditor, SystemLogin, SystemDashboard Each mocks AuthContext, api.js, react-router-dom hooks, wraps in MemoryRouter, and asserts the page heading is in the document

CI:
- .github/workflows/ci.yml: parallel backend-test + frontend-test jobs trigger on push to claude/** branches and PRs to main (no Postgres service needed — DB is fully mocked)

CLAUDE.md: document testing architecture and per-feature patterns

https://claude.ai/code/session_01WdSsJg1nZ4vKZB2ncxM2Ej