### PR TITLE
docs: rewrite README to reflect current project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,52 @@
 # Beacon2
 
-Modern rebuild of the Beacon u3a management system.
+Modern rebuild of the [Beacon](https://www.u3abeacon.org.uk/) u3a management system —
+a multi-tenant web app for running u3a groups across the UK.
 
-## Structure
+## Project structure
 
 ```
 beacon2/
-  backend/    Node.js + Express API
-  frontend/   React UI (Vite)
+├── backend/                   Node.js 20 + Express 4 API
+│   ├── src/
+│   │   ├── server.js          Entry point (migrate → seed → listen)
+│   │   ├── app.js             Pure Express app (imported by tests)
+│   │   ├── routes/            auth  users  roles  privileges  system
+│   │   ├── middleware/        auth  requirePrivilege  errorHandler
+│   │   ├── services/          authService
+│   │   ├── utils/             db  jwt  password  redis  migrate
+│   │   ├── seed/              system admin + per-tenant defaults
+│   │   └── __tests__/        vitest + supertest (no real DB needed)
+│   ├── prisma/                system-level schema (SysTenant, SysAdmin)
+│   └── vitest.config.js
+│
+├── frontend/                  React 18 + Vite 5 + Tailwind CSS 3
+│   ├── src/
+│   │   ├── App.jsx            Route tree
+│   │   ├── context/           AuthContext (in-memory token)
+│   │   ├── lib/               api.js (auto token refresh)
+│   │   ├── components/        PageHeader  NavBar  BeaconLogo
+│   │   ├── pages/             Login  Home  users/*  roles/*  system/*
+│   │   └── __tests__/        vitest + React Testing Library smoke tests
+│   └── vite.config.js         also used as vitest config
+│
+├── docs/
+│   ├── BeaconUG/              Beacon User Guide pages (Markdown + images)
+│   └── FromBeacon/            Selected files from the original Beacon codebase
+│
+├── .github/workflows/ci.yml   Runs backend + frontend tests on every push
+├── render.yaml                Render blueprint (backend + Postgres)
+├── DEPLOYMENT.md              Step-by-step deployment guide (Render + Vercel)
+└── CLAUDE.md                  Instructions for Claude Code
 ```
 
-## Quick start
+## Quick start (local development)
 
 ### Prerequisites
+
 - Node.js 20+
 - PostgreSQL 15+
-- Redis 7+
+- Redis 7+ *(optional — only needed if `USE_REDIS=true`)*
 
 ### Backend
 
@@ -24,8 +55,8 @@ cd backend
 cp .env.example .env          # fill in your values
 npm install
 npx prisma migrate dev        # creates system-level tables
-npm run db:seed               # creates first system admin (see seed/index.js)
-npm run dev
+npm run db:seed               # creates first system admin
+npm run dev                   # starts on http://localhost:3001
 ```
 
 ### Frontend
@@ -33,14 +64,24 @@ npm run dev
 ```bash
 cd frontend
 npm install
-npm run dev
+npm run dev                   # starts on http://localhost:5173
 ```
 
-The frontend runs at http://localhost:5173 and proxies API calls to http://localhost:3001.
+The frontend expects the API at `VITE_API_URL` (defaults to `http://localhost:3001`).
+
+## Tests
+
+```bash
+cd backend  && npm test   # vitest — no real DB required (fully mocked)
+cd frontend && npm test   # vitest + React Testing Library smoke tests
+```
+
+CI runs both suites automatically on every push to a `claude/**` branch via
+`.github/workflows/ci.yml`.
 
 ## Creating a u3a tenant
 
-Once the backend is running, use the system admin credentials to POST to `/system/tenants`:
+Log in to the system admin UI at `/system/login`, or POST directly:
 
 ```bash
 curl -X POST http://localhost:3001/system/tenants \
@@ -55,24 +96,34 @@ curl -X POST http://localhost:3001/system/tenants \
   }'
 ```
 
-This creates the database schema, seeds all privilege resources, seeds the 5 default roles, and creates the first admin user.
+This creates the tenant's PostgreSQL schema (`u3a_oxfordshire`), seeds all privilege
+resources, creates the five default roles, and sets up the first admin user.
 
-## Architecture notes
+## Architecture
 
-- **Multi-tenancy:** each u3a has its own PostgreSQL schema (`u3a_<slug>`). Isolation is enforced at the database level.
-- **Auth:** short-lived JWT access tokens (15 min) in memory + long-lived refresh tokens in httpOnly cookies.
-- **Privileges:** embedded in the JWT at login. When roles change, affected sessions are invalidated via Redis.
-- **Roles:** fully configurable per u3a. Names, committee flag, and privilege sets can all be changed.
+| Concern | Approach |
+|---|---|
+| **Multi-tenancy** | Each u3a gets its own PostgreSQL schema (`u3a_<slug>`). All tenant queries go through `tenantQuery()` in `utils/db.js`. |
+| **Auth** | Short-lived JWT access tokens (15 min, in memory) + long-lived refresh tokens in httpOnly cookies. |
+| **Privileges** | Embedded in the JWT at login. Role changes invalidate affected sessions via Redis (or expire naturally after 15 min if Redis is disabled). |
+| **Roles** | Fully configurable per u3a — names, committee flag, and privilege sets can all be edited. |
+| **Validation** | All request bodies validated with Zod before any DB access. |
+| **SQL** | Parameterised queries only — never string concatenation. |
 
-## Modules implemented so far
+## Deployment
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for a step-by-step guide to deploying on
+Render (backend + Postgres) and Vercel (frontend) — no command-line knowledge needed.
+
+## Modules implemented
 
 - [x] Authentication (login, logout, token refresh)
+- [x] System admin UI (tenant create / activate / deactivate)
 - [x] Users (CRUD, role assignment)
-- [x] Roles (CRUD)
-- [x] Privileges (full matrix, per-role)
-- [x] System admin (tenant management)
+- [x] Roles (CRUD, privilege matrix editor)
+- [x] Privileges (full resource × action matrix, per role)
 
-## Next modules (in suggested order)
+## Next modules (suggested order)
 
 1. Members
 2. Groups


### PR DESCRIPTION
- Accurate directory tree including __tests__, server.js, docs/
- Prerequisites: Redis now flagged as optional (USE_REDIS=false default)
- Testing section: how to run backend and frontend suites, CI note
- Architecture table replacing scattered bullet points
- Mention system admin UI as the tenant-creation alternative to curl
- Add DEPLOYMENT.md cross-reference
- Keep implemented/next-modules checklist

https://claude.ai/code/session_01WdSsJg1nZ4vKZB2ncxM2Ej