### PR TITLE
feat: implement group list, record and members (5.1, 5.2, 5.4, 5.6)

### DIFF
--- a/backend/prisma/tenant_schema.sql
+++ b/backend/prisma/tenant_schema.sql
@@ -159,6 +159,55 @@ CREATE TABLE :schema.members (
 );
 
 -- ─────────────────────────────────────────────
+-- FACULTIES
+-- ─────────────────────────────────────────────
+CREATE TABLE :schema.faculties (
+  id         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  name       TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ─────────────────────────────────────────────
+-- GROUPS
+-- ─────────────────────────────────────────────
+CREATE TABLE :schema.groups (
+  id                   TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  name                 TEXT NOT NULL,
+  faculty_id           TEXT REFERENCES :schema.faculties(id),
+  status               TEXT NOT NULL DEFAULT 'active'
+                         CHECK (status IN ('active', 'inactive')),
+  when_text            TEXT,               -- e.g. "2nd Thursday at 2:00pm"
+  start_time           TIME,               -- default start time for events
+  end_time             TIME,               -- default end time for events
+  venue                TEXT,
+  enquiries            TEXT,               -- public contact info for enquirers
+  max_members          INTEGER,
+  allow_online_join    BOOLEAN NOT NULL DEFAULT false,
+  enable_waiting_list  BOOLEAN NOT NULL DEFAULT false,
+  notify_leader        BOOLEAN NOT NULL DEFAULT false,
+  display_waiting_list BOOLEAN NOT NULL DEFAULT false,
+  information          TEXT,               -- may be shown publicly
+  notes                TEXT,               -- private notes
+  show_addresses       BOOLEAN NOT NULL DEFAULT false,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ─────────────────────────────────────────────
+-- GROUP MEMBERS
+-- ─────────────────────────────────────────────
+CREATE TABLE :schema.group_members (
+  id            TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  group_id      TEXT NOT NULL REFERENCES :schema.groups(id) ON DELETE CASCADE,
+  member_id     TEXT NOT NULL REFERENCES :schema.members(id) ON DELETE CASCADE,
+  is_leader     BOOLEAN NOT NULL DEFAULT false,
+  waiting_since DATE,                      -- non-null = member is on waiting list
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (group_id, member_id)
+);
+
+-- ─────────────────────────────────────────────
 -- INDEXES
 -- ─────────────────────────────────────────────
 CREATE INDEX ON :schema.user_roles (user_id);
@@ -170,3 +219,7 @@ CREATE INDEX ON :schema.members (surname, forenames);
 CREATE INDEX ON :schema.members (status_id);
 CREATE INDEX ON :schema.members (class_id);
 CREATE INDEX ON :schema.members (address_id);
+CREATE INDEX ON :schema.groups (faculty_id);
+CREATE INDEX ON :schema.groups (status);
+CREATE INDEX ON :schema.group_members (group_id);
+CREATE INDEX ON :schema.group_members (member_id);

--- a/backend/src/__tests__/faculties.test.js
+++ b/backend/src/__tests__/faculties.test.js
@@ -1,0 +1,105 @@
+// beacon2/backend/src/__tests__/faculties.test.js
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { makeAuthHeader } from './helpers.js';
+
+vi.mock('../utils/redis.js', () => ({
+  isSessionInvalidated:   vi.fn().mockResolvedValue(false),
+  invalidateUserSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/db.js', () => ({
+  prisma:      { $disconnect: vi.fn() },
+  tenantQuery: vi.fn(),
+  withTenant:  vi.fn(),
+}));
+
+const { default: app } = await import('../app.js');
+const { tenantQuery } = await import('../utils/db.js');
+
+const AUTH = makeAuthHeader();
+const SAMPLE_FACULTY = { id: 'f1', name: 'Art & Literature', created_at: new Date().toISOString(), updated_at: new Date().toISOString() };
+
+// ── GET /faculties ─────────────────────────────────────────────────────────
+
+describe('GET /faculties', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with faculty list', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_FACULTY]);
+    const res = await request(app).get('/faculties').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body[0].name).toBe('Art & Literature');
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/faculties');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 without privilege', async () => {
+    const res = await request(app).get('/faculties').set('Authorization', makeAuthHeader({ privileges: [] }));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── POST /faculties ────────────────────────────────────────────────────────
+
+describe('POST /faculties', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a faculty and returns 201', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_FACULTY]);
+    const res = await request(app).post('/faculties').set('Authorization', AUTH).send({ name: 'Art & Literature' });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Art & Literature');
+  });
+
+  it('returns 422 when name is missing', async () => {
+    const res = await request(app).post('/faculties').set('Authorization', AUTH).send({});
+    expect(res.status).toBe(422);
+  });
+});
+
+// ── PATCH /faculties/:id ───────────────────────────────────────────────────
+
+describe('PATCH /faculties/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates a faculty', async () => {
+    tenantQuery
+      .mockResolvedValueOnce([SAMPLE_FACULTY])  // exists check
+      .mockResolvedValueOnce([{ id: 'f1', name: 'Walking' }]);  // update
+    const res = await request(app).patch('/faculties/f1').set('Authorization', AUTH).send({ name: 'Walking' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Walking');
+  });
+
+  it('returns 404 when not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const res = await request(app).patch('/faculties/unknown').set('Authorization', AUTH).send({ name: 'X' });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── DELETE /faculties/:id ──────────────────────────────────────────────────
+
+describe('DELETE /faculties/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes a faculty', async () => {
+    tenantQuery
+      .mockResolvedValueOnce([SAMPLE_FACULTY])  // exists check
+      .mockResolvedValueOnce([]);               // delete
+    const res = await request(app).delete('/faculties/f1').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/deleted/i);
+  });
+
+  it('returns 404 when not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const res = await request(app).delete('/faculties/unknown').set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/src/__tests__/groups.test.js
+++ b/backend/src/__tests__/groups.test.js
@@ -1,0 +1,230 @@
+// beacon2/backend/src/__tests__/groups.test.js
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { makeAuthHeader } from './helpers.js';
+
+vi.mock('../utils/redis.js', () => ({
+  isSessionInvalidated:   vi.fn().mockResolvedValue(false),
+  invalidateUserSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/db.js', () => ({
+  prisma:      { $disconnect: vi.fn() },
+  tenantQuery: vi.fn(),
+  withTenant:  vi.fn(),
+}));
+
+const { default: app } = await import('../app.js');
+const { tenantQuery } = await import('../utils/db.js');
+
+const AUTH = makeAuthHeader();
+
+const SAMPLE_GROUP = {
+  id: 'g1', name: 'Watercolour', faculty_id: null, faculty_name: null,
+  status: 'active', when_text: 'Every Monday', max_members: null,
+  show_addresses: false, member_count: 3, leaders: [],
+};
+
+const SAMPLE_GROUP_FULL = {
+  ...SAMPLE_GROUP,
+  start_time: null, end_time: null, venue: null, enquiries: null,
+  allow_online_join: false, enable_waiting_list: false, notify_leader: false,
+  display_waiting_list: false, information: null, notes: null,
+  created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+};
+
+// ── GET /groups ────────────────────────────────────────────────────────────
+
+describe('GET /groups', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with group list', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_GROUP]);
+    const res = await request(app).get('/groups').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body[0].name).toBe('Watercolour');
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/groups');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 without privilege', async () => {
+    const res = await request(app).get('/groups').set('Authorization', makeAuthHeader({ privileges: [] }));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── GET /groups/:id ────────────────────────────────────────────────────────
+
+describe('GET /groups/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with full group record', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_GROUP_FULL]);
+    const res = await request(app).get('/groups/g1').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Watercolour');
+  });
+
+  it('returns 404 when not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const res = await request(app).get('/groups/unknown').set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /groups ───────────────────────────────────────────────────────────
+
+describe('POST /groups', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a group and returns 201', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_GROUP_FULL]);
+    const res = await request(app).post('/groups').set('Authorization', AUTH).send({ name: 'Watercolour' });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Watercolour');
+  });
+
+  it('returns 422 when name is missing', async () => {
+    const res = await request(app).post('/groups').set('Authorization', AUTH).send({});
+    expect(res.status).toBe(422);
+  });
+});
+
+// ── PATCH /groups/:id ──────────────────────────────────────────────────────
+
+describe('PATCH /groups/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates a group', async () => {
+    tenantQuery.mockResolvedValueOnce([{ ...SAMPLE_GROUP_FULL, name: 'Oils' }]);
+    const res = await request(app).patch('/groups/g1').set('Authorization', AUTH).send({ name: 'Oils' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Oils');
+  });
+
+  it('returns 400 when body is empty', async () => {
+    const res = await request(app).patch('/groups/g1').set('Authorization', AUTH).send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);  // UPDATE returns empty
+    const res = await request(app).patch('/groups/unknown').set('Authorization', AUTH).send({ name: 'X' });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── DELETE /groups/:id ─────────────────────────────────────────────────────
+
+describe('DELETE /groups/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes a group', async () => {
+    tenantQuery
+      .mockResolvedValueOnce([{ id: 'g1' }])  // exists check
+      .mockResolvedValueOnce([]);              // delete
+    const res = await request(app).delete('/groups/g1').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/deleted/i);
+  });
+
+  it('returns 404 when not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const res = await request(app).delete('/groups/unknown').set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── GET /groups/:id/members ────────────────────────────────────────────────
+
+describe('GET /groups/:id/members', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with member list', async () => {
+    tenantQuery
+      .mockResolvedValueOnce([{ id: 'g1' }])   // group exists
+      .mockResolvedValueOnce([{ gm_id: 'gm1', member_id: 'm1', forenames: 'Jane', surname: 'Doe', is_leader: false, waiting_since: null }]);
+    const res = await request(app).get('/groups/g1/members').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body[0].surname).toBe('Doe');
+  });
+
+  it('returns 404 when group not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const res = await request(app).get('/groups/unknown/members').set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /groups/:id/members ───────────────────────────────────────────────
+
+describe('POST /groups/:id/members', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('adds a member by memberId', async () => {
+    tenantQuery
+      .mockResolvedValueOnce([{ id: 'g1' }])                                  // group exists
+      .mockResolvedValueOnce([{ id: 'm1', membership_number: 42, forenames: 'Jane', surname: 'Doe' }])  // member lookup
+      .mockResolvedValueOnce([])                                               // not already in group
+      .mockResolvedValueOnce([{ id: 'gm1', group_id: 'g1', member_id: 'm1', is_leader: false, waiting_since: null, created_at: new Date().toISOString() }]);
+    const res = await request(app).post('/groups/g1/members').set('Authorization', AUTH).send({ memberId: 'm1' });
+    expect(res.status).toBe(201);
+    expect(res.body.member_id).toBe('m1');
+  });
+
+  it('returns 409 when member already in group', async () => {
+    tenantQuery
+      .mockResolvedValueOnce([{ id: 'g1' }])
+      .mockResolvedValueOnce([{ id: 'm1', membership_number: 42, forenames: 'Jane', surname: 'Doe' }])
+      .mockResolvedValueOnce([{ id: 'gm1' }]);  // already exists
+    const res = await request(app).post('/groups/g1/members').set('Authorization', AUTH).send({ memberId: 'm1' });
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 422 when body is invalid', async () => {
+    const res = await request(app).post('/groups/g1/members').set('Authorization', AUTH).send({});
+    expect(res.status).toBe(422);
+  });
+});
+
+// ── PATCH /groups/:id/members/:memberId ───────────────────────────────────
+
+describe('PATCH /groups/:id/members/:memberId', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('makes member a leader', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'gm1', member_id: 'm1', is_leader: true }]);
+    const res = await request(app).patch('/groups/g1/members/m1').set('Authorization', AUTH).send({ isLeader: true });
+    expect(res.status).toBe(200);
+    expect(res.body.is_leader).toBe(true);
+  });
+
+  it('returns 404 when group member not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const res = await request(app).patch('/groups/g1/members/unknown').set('Authorization', AUTH).send({ isLeader: true });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── DELETE /groups/:id/members/:memberId ──────────────────────────────────
+
+describe('DELETE /groups/:id/members/:memberId', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('removes a member from group', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'gm1' }]);
+    const res = await request(app).delete('/groups/g1/members/m1').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/removed/i);
+  });
+
+  it('returns 404 when not found', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const res = await request(app).delete('/groups/g1/members/unknown').set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/src/__tests__/helpers.js
+++ b/backend/src/__tests__/helpers.js
@@ -14,6 +14,9 @@ export const ALL_PRIVS = [
   'member_statuses:view', 'member_statuses:create', 'member_statuses:change', 'member_statuses:delete',
   'members_list:view',
   'member_record:view', 'member_record:create', 'member_record:change', 'member_record:delete',
+  'groups_list:view',
+  'group_records_all:view', 'group_records_all:create', 'group_records_all:change', 'group_records_all:delete',
+  'group_faculties:view', 'group_faculties:create', 'group_faculties:change', 'group_faculties:delete',
 ];
 
 export const TEST_TENANT = 'test-u3a';

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -15,6 +15,8 @@ import systemRoutes        from './routes/system.js';
 import memberClassRoutes   from './routes/memberClasses.js';
 import memberStatusRoutes  from './routes/memberStatuses.js';
 import memberRoutes        from './routes/members.js';
+import facultyRoutes       from './routes/faculties.js';
+import groupRoutes         from './routes/groups.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 const app = express();
@@ -41,6 +43,8 @@ app.use('/system',          systemRoutes);
 app.use('/member-classes',  memberClassRoutes);
 app.use('/member-statuses', memberStatusRoutes);
 app.use('/members',         memberRoutes);
+app.use('/faculties',       facultyRoutes);
+app.use('/groups',          groupRoutes);
 
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 

--- a/backend/src/routes/faculties.js
+++ b/backend/src/routes/faculties.js
@@ -1,0 +1,84 @@
+// beacon2/backend/src/routes/faculties.js
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../middleware/auth.js';
+import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { tenantQuery } from '../utils/db.js';
+import { AppError } from '../middleware/errorHandler.js';
+
+const router = Router();
+router.use(requireAuth);
+
+// ─── GET /faculties ───────────────────────────────────────────────────────
+router.get('/', requirePrivilege('group_faculties', 'view'), async (req, res, next) => {
+  try {
+    const rows = await tenantQuery(
+      req.user.tenantSlug,
+      `SELECT id, name, created_at, updated_at FROM faculties ORDER BY name`,
+    );
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── POST /faculties ──────────────────────────────────────────────────────
+const createSchema = z.object({ name: z.string().min(1).max(100) });
+
+router.post('/', requirePrivilege('group_faculties', 'create'), async (req, res, next) => {
+  try {
+    const { name } = createSchema.parse(req.body);
+    const [row] = await tenantQuery(
+      req.user.tenantSlug,
+      `INSERT INTO faculties (name) VALUES ($1) RETURNING id, name, created_at`,
+      [name],
+    );
+    res.status(201).json(row);
+  } catch (err) {
+    if (err.code === '23505') {
+      return next(AppError('A faculty with that name already exists.', 409));
+    }
+    next(err);
+  }
+});
+
+// ─── PATCH /faculties/:id ─────────────────────────────────────────────────
+const updateSchema = z.object({ name: z.string().min(1).max(100) });
+
+router.patch('/:id', requirePrivilege('group_faculties', 'change'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const [existing] = await tenantQuery(slug, `SELECT id FROM faculties WHERE id = $1`, [req.params.id]);
+    if (!existing) throw AppError('Faculty not found.', 404);
+
+    const { name } = updateSchema.parse(req.body);
+    const [row] = await tenantQuery(
+      slug,
+      `UPDATE faculties SET name = $1, updated_at = now() WHERE id = $2 RETURNING id, name`,
+      [name, req.params.id],
+    );
+    res.json(row);
+  } catch (err) {
+    if (err.code === '23505') {
+      return next(AppError('A faculty with that name already exists.', 409));
+    }
+    next(err);
+  }
+});
+
+// ─── DELETE /faculties/:id ────────────────────────────────────────────────
+router.delete('/:id', requirePrivilege('group_faculties', 'delete'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const [existing] = await tenantQuery(slug, `SELECT id FROM faculties WHERE id = $1`, [req.params.id]);
+    if (!existing) throw AppError('Faculty not found.', 404);
+
+    await tenantQuery(slug, `DELETE FROM faculties WHERE id = $1`, [req.params.id]);
+    res.json({ message: 'Faculty deleted.' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -1,0 +1,382 @@
+// beacon2/backend/src/routes/groups.js
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../middleware/auth.js';
+import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { tenantQuery } from '../utils/db.js';
+import { AppError } from '../middleware/errorHandler.js';
+
+const router = Router();
+router.use(requireAuth);
+
+// ─── GET /groups ───────────────────────────────────────────────────────────
+// Query params:
+//   activeOnly – 'true' (default) | 'false'
+//   facultyId  – filter by faculty
+//   letter     – single letter to filter group name start
+
+router.get('/', requirePrivilege('groups_list', 'view'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const { activeOnly = 'true', facultyId, letter } = req.query;
+
+    const conditions = [];
+    const params = [];
+    let i = 1;
+
+    if (activeOnly !== 'false') {
+      conditions.push(`g.status = 'active'`);
+    }
+    if (facultyId) {
+      conditions.push(`g.faculty_id = $${i++}`);
+      params.push(facultyId);
+    }
+    if (letter && /^[A-Z]$/i.test(letter)) {
+      conditions.push(`upper(g.name) LIKE $${i++}`);
+      params.push(letter.toUpperCase() + '%');
+    }
+
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const groups = await tenantQuery(
+      slug,
+      `SELECT g.id, g.name, g.faculty_id, f.name AS faculty_name,
+              g.status, g.when_text, g.max_members, g.show_addresses,
+              (SELECT COUNT(*)::int FROM group_members gm
+               WHERE gm.group_id = g.id AND gm.waiting_since IS NULL) AS member_count,
+              (SELECT COALESCE(
+                 json_agg(json_build_object(
+                   'id',       m.id,
+                   'forenames', m.forenames,
+                   'surname',   m.surname
+                 ) ORDER BY m.surname, m.forenames),
+                 '[]'::json
+               )
+               FROM group_members gm
+               JOIN members m ON m.id = gm.member_id
+               WHERE gm.group_id = g.id AND gm.is_leader = true) AS leaders
+       FROM groups g
+       LEFT JOIN faculties f ON f.id = g.faculty_id
+       ${where}
+       ORDER BY g.name`,
+      params,
+    );
+
+    res.json(groups);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── GET /groups/:id ──────────────────────────────────────────────────────
+
+router.get('/:id', requirePrivilege('group_records_all', 'view'), async (req, res, next) => {
+  try {
+    const [group] = await tenantQuery(
+      req.user.tenantSlug,
+      `SELECT g.*, f.name AS faculty_name
+       FROM groups g
+       LEFT JOIN faculties f ON f.id = g.faculty_id
+       WHERE g.id = $1`,
+      [req.params.id],
+    );
+    if (!group) throw AppError('Group not found.', 404);
+    res.json(group);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── POST /groups ─────────────────────────────────────────────────────────
+
+const groupSchema = z.object({
+  name:                z.string().min(1).max(200),
+  facultyId:           z.string().nullable().optional(),
+  status:              z.enum(['active', 'inactive']).default('active'),
+  whenText:            z.string().nullable().optional(),
+  startTime:           z.string().nullable().optional(),  // "HH:MM"
+  endTime:             z.string().nullable().optional(),
+  venue:               z.string().nullable().optional(),
+  enquiries:           z.string().nullable().optional(),
+  maxMembers:          z.number().int().positive().nullable().optional(),
+  allowOnlineJoin:     z.boolean().default(false),
+  enableWaitingList:   z.boolean().default(false),
+  notifyLeader:        z.boolean().default(false),
+  displayWaitingList:  z.boolean().default(false),
+  information:         z.string().nullable().optional(),
+  notes:               z.string().nullable().optional(),
+  showAddresses:       z.boolean().default(false),
+});
+
+router.post('/', requirePrivilege('group_records_all', 'create'), async (req, res, next) => {
+  try {
+    const data = groupSchema.parse(req.body);
+    const slug = req.user.tenantSlug;
+
+    const [group] = await tenantQuery(
+      slug,
+      `INSERT INTO groups
+         (name, faculty_id, status, when_text, start_time, end_time, venue, enquiries,
+          max_members, allow_online_join, enable_waiting_list, notify_leader,
+          display_waiting_list, information, notes, show_addresses)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+       RETURNING *`,
+      [
+        data.name,
+        data.facultyId     ?? null,
+        data.status,
+        data.whenText      ?? null,
+        data.startTime     ?? null,
+        data.endTime       ?? null,
+        data.venue         ?? null,
+        data.enquiries     ?? null,
+        data.maxMembers    ?? null,
+        data.allowOnlineJoin,
+        data.enableWaitingList,
+        data.notifyLeader,
+        data.displayWaitingList,
+        data.information   ?? null,
+        data.notes         ?? null,
+        data.showAddresses,
+      ],
+    );
+    res.status(201).json(group);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── PATCH /groups/:id ────────────────────────────────────────────────────
+
+const updateGroupSchema = z.object({
+  name:                z.string().min(1).max(200).optional(),
+  facultyId:           z.string().nullable().optional(),
+  status:              z.enum(['active', 'inactive']).optional(),
+  whenText:            z.string().nullable().optional(),
+  startTime:           z.string().nullable().optional(),
+  endTime:             z.string().nullable().optional(),
+  venue:               z.string().nullable().optional(),
+  enquiries:           z.string().nullable().optional(),
+  maxMembers:          z.number().int().positive().nullable().optional(),
+  allowOnlineJoin:     z.boolean().optional(),
+  enableWaitingList:   z.boolean().optional(),
+  notifyLeader:        z.boolean().optional(),
+  displayWaitingList:  z.boolean().optional(),
+  information:         z.string().nullable().optional(),
+  notes:               z.string().nullable().optional(),
+  showAddresses:       z.boolean().optional(),
+});
+
+const GROUP_FIELDS = [
+  ['name',               'name'],
+  ['facultyId',          'faculty_id'],
+  ['status',             'status'],
+  ['whenText',           'when_text'],
+  ['startTime',          'start_time'],
+  ['endTime',            'end_time'],
+  ['venue',              'venue'],
+  ['enquiries',          'enquiries'],
+  ['maxMembers',         'max_members'],
+  ['allowOnlineJoin',    'allow_online_join'],
+  ['enableWaitingList',  'enable_waiting_list'],
+  ['notifyLeader',       'notify_leader'],
+  ['displayWaitingList', 'display_waiting_list'],
+  ['information',        'information'],
+  ['notes',              'notes'],
+  ['showAddresses',      'show_addresses'],
+];
+
+router.patch('/:id', requirePrivilege('group_records_all', 'change'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const data = updateGroupSchema.parse(req.body);
+
+    const setClauses = [];
+    const values = [];
+    let i = 1;
+    for (const [jsKey, col] of GROUP_FIELDS) {
+      if (data[jsKey] !== undefined) {
+        setClauses.push(`${col} = $${i++}`);
+        values.push(data[jsKey]);
+      }
+    }
+
+    if (setClauses.length === 0) {
+      return res.status(400).json({ error: 'Nothing to update.' });
+    }
+
+    setClauses.push(`updated_at = now()`);
+    values.push(req.params.id);
+
+    const [group] = await tenantQuery(
+      slug,
+      `UPDATE groups SET ${setClauses.join(', ')} WHERE id = $${i} RETURNING *`,
+      values,
+    );
+    if (!group) throw AppError('Group not found.', 404);
+    res.json(group);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── DELETE /groups/:id ───────────────────────────────────────────────────
+
+router.delete('/:id', requirePrivilege('group_records_all', 'delete'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const [existing] = await tenantQuery(slug, `SELECT id FROM groups WHERE id = $1`, [req.params.id]);
+    if (!existing) throw AppError('Group not found.', 404);
+
+    await tenantQuery(slug, `DELETE FROM groups WHERE id = $1`, [req.params.id]);
+    res.json({ message: 'Group deleted.' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// GROUP MEMBERS  sub-resource:  /groups/:id/members
+// ─────────────────────────────────────────────────────────────────────────
+
+// ─── GET /groups/:id/members ──────────────────────────────────────────────
+// Query: showWaiting=true (default: show active + waiting), showWaiting=false (joined only)
+
+router.get('/:id/members', requirePrivilege('group_records_all', 'view'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const { showWaiting = 'true' } = req.query;
+
+    const [group] = await tenantQuery(slug, `SELECT id FROM groups WHERE id = $1`, [req.params.id]);
+    if (!group) throw AppError('Group not found.', 404);
+
+    const waitingCondition = showWaiting === 'false' ? 'AND gm.waiting_since IS NULL' : '';
+
+    const rows = await tenantQuery(
+      slug,
+      `SELECT gm.id AS gm_id, gm.member_id, gm.is_leader, gm.waiting_since, gm.created_at AS joined_at,
+              m.membership_number, m.title, m.forenames, m.surname, m.known_as,
+              m.email, m.mobile, m.hide_contact,
+              ms.name AS status,
+              a.house_no, a.street, a.town, a.postcode, a.telephone
+       FROM group_members gm
+       JOIN members m ON m.id = gm.member_id
+       LEFT JOIN member_statuses ms ON ms.id = m.status_id
+       LEFT JOIN addresses a ON a.id = m.address_id
+       WHERE gm.group_id = $1 ${waitingCondition}
+       ORDER BY m.surname, m.forenames`,
+      [req.params.id],
+    );
+
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── POST /groups/:id/members ─────────────────────────────────────────────
+// Add member by memberId OR membershipNumber
+
+const addMemberSchema = z.union([
+  z.object({ memberId: z.string().min(1) }),
+  z.object({ membershipNumber: z.coerce.number().int().positive() }),
+]);
+
+router.post('/:id/members', requirePrivilege('group_records_all', 'change'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+
+    // Validate body first so invalid input returns 422 before any DB call
+    const data = addMemberSchema.parse(req.body);
+
+    const [group] = await tenantQuery(slug, `SELECT id FROM groups WHERE id = $1`, [req.params.id]);
+    if (!group) throw AppError('Group not found.', 404);
+
+    let member;
+    if ('memberId' in data) {
+      const [row] = await tenantQuery(
+        slug,
+        `SELECT id, membership_number, forenames, surname FROM members WHERE id = $1`,
+        [data.memberId],
+      );
+      member = row;
+    } else {
+      const [row] = await tenantQuery(
+        slug,
+        `SELECT id, membership_number, forenames, surname FROM members WHERE membership_number = $1`,
+        [data.membershipNumber],
+      );
+      member = row;
+    }
+
+    if (!member) throw AppError('Member not found.', 404);
+
+    // Check not already in group
+    const [existing] = await tenantQuery(
+      slug,
+      `SELECT id FROM group_members WHERE group_id = $1 AND member_id = $2`,
+      [req.params.id, member.id],
+    );
+    if (existing) throw AppError('Member is already in this group.', 409);
+
+    const [gm] = await tenantQuery(
+      slug,
+      `INSERT INTO group_members (group_id, member_id) VALUES ($1, $2)
+       RETURNING id, group_id, member_id, is_leader, waiting_since, created_at`,
+      [req.params.id, member.id],
+    );
+
+    res.status(201).json({
+      ...gm,
+      membership_number: member.membership_number,
+      forenames: member.forenames,
+      surname: member.surname,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── PATCH /groups/:id/members/:memberId ──────────────────────────────────
+// Toggle leader status
+
+const patchMemberSchema = z.object({ isLeader: z.boolean() });
+
+router.patch('/:id/members/:memberId', requirePrivilege('group_records_all', 'change'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const { isLeader } = patchMemberSchema.parse(req.body);
+
+    const [gm] = await tenantQuery(
+      slug,
+      `UPDATE group_members SET is_leader = $1
+       WHERE group_id = $2 AND member_id = $3
+       RETURNING id, member_id, is_leader`,
+      [isLeader, req.params.id, req.params.memberId],
+    );
+    if (!gm) throw AppError('Group member not found.', 404);
+    res.json(gm);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── DELETE /groups/:id/members/:memberId ─────────────────────────────────
+
+router.delete('/:id/members/:memberId', requirePrivilege('group_records_all', 'change'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const [gm] = await tenantQuery(
+      slug,
+      `DELETE FROM group_members WHERE group_id = $1 AND member_id = $2 RETURNING id`,
+      [req.params.id, req.params.memberId],
+    );
+    if (!gm) throw AppError('Group member not found.', 404);
+    res.json({ message: 'Member removed from group.' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,8 @@ import MemberClassEditor from './pages/membership/MemberClassEditor.jsx';
 import MemberStatusList  from './pages/membership/MemberStatusList.jsx';
 import MemberList        from './pages/members/MemberList.jsx';
 import MemberEditor      from './pages/members/MemberEditor.jsx';
+import GroupList         from './pages/groups/GroupList.jsx';
+import GroupRecord       from './pages/groups/GroupRecord.jsx';
 
 function ProtectedRoute({ children }) {
   const { isLoggedIn } = useAuth();
@@ -47,6 +49,9 @@ export default function App() {
           <Route path="/members"      element={<ProtectedRoute><MemberList /></ProtectedRoute>} />
           <Route path="/members/new"  element={<ProtectedRoute><MemberEditor /></ProtectedRoute>} />
           <Route path="/members/:id"  element={<ProtectedRoute><MemberEditor /></ProtectedRoute>} />
+          <Route path="/groups"       element={<ProtectedRoute><GroupList /></ProtectedRoute>} />
+          <Route path="/groups/new"   element={<ProtectedRoute><GroupRecord /></ProtectedRoute>} />
+          <Route path="/groups/:id"   element={<ProtectedRoute><GroupRecord /></ProtectedRoute>} />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/frontend/src/__tests__/GroupList.test.jsx
+++ b/frontend/src/__tests__/GroupList.test.jsx
@@ -1,0 +1,29 @@
+// beacon2/frontend/src/__tests__/GroupList.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import GroupList from '../pages/groups/GroupList.jsx';
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    tenant: 'test-u3a',
+    can:    vi.fn().mockReturnValue(true),
+  }),
+}));
+
+vi.mock('../lib/api.js', () => ({
+  groups:    { list: vi.fn().mockResolvedValue([]) },
+  faculties: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+describe('GroupList page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><GroupList /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows the Groups heading', () => {
+    const { getByText } = render(<MemoryRouter><GroupList /></MemoryRouter>);
+    expect(getByText('Groups')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/GroupRecord.test.jsx
+++ b/frontend/src/__tests__/GroupRecord.test.jsx
@@ -1,0 +1,63 @@
+// beacon2/frontend/src/__tests__/GroupRecord.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import GroupRecord from '../pages/groups/GroupRecord.jsx';
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    tenant: 'test-u3a',
+    can:    vi.fn().mockReturnValue(true),
+  }),
+}));
+
+vi.mock('../lib/api.js', () => ({
+  groups:    {
+    get:         vi.fn().mockResolvedValue({ id: 'g1', name: 'Watercolour', status: 'active', faculty_id: null }),
+    update:      vi.fn().mockResolvedValue({}),
+    delete:      vi.fn().mockResolvedValue({}),
+    listMembers: vi.fn().mockResolvedValue([]),
+    addMember:   vi.fn().mockResolvedValue({}),
+    updateMember: vi.fn().mockResolvedValue({}),
+    removeMember: vi.fn().mockResolvedValue({}),
+  },
+  faculties: { list: vi.fn().mockResolvedValue([]) },
+  members:   { list: vi.fn().mockResolvedValue([]) },
+}));
+
+describe('GroupRecord page — new group', () => {
+  it('renders without crashing', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/groups/new']}>
+        <Routes>
+          <Route path="/groups/new" element={<GroupRecord />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(container).toBeTruthy();
+  });
+
+  it('shows Add New Group heading', () => {
+    const { getAllByText } = render(
+      <MemoryRouter initialEntries={['/groups/new']}>
+        <Routes>
+          <Route path="/groups/new" element={<GroupRecord />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(getAllByText('Add New Group').length).toBeGreaterThan(0);
+  });
+});
+
+describe('GroupRecord page — existing group', () => {
+  it('renders without crashing', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/groups/g1']}>
+        <Routes>
+          <Route path="/groups/:id" element={<GroupRecord />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(container).toBeTruthy();
+  });
+});

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -162,6 +162,42 @@ export const members = {
   delete:  (id)              => request(`/members/${id}`, { method: 'DELETE' }),
 };
 
+// ─── Faculties ────────────────────────────────────────────────────────────
+
+export const faculties = {
+  list:   ()         => request('/faculties'),
+  create: (data)     => request('/faculties', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id, data) => request(`/faculties/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  delete: (id)       => request(`/faculties/${id}`, { method: 'DELETE' }),
+};
+
+// ─── Groups ───────────────────────────────────────────────────────────────
+
+export const groups = {
+  list: (params = {}) => {
+    const qs = new URLSearchParams();
+    if (params.activeOnly !== undefined) qs.set('activeOnly', params.activeOnly ? 'true' : 'false');
+    if (params.facultyId) qs.set('facultyId', params.facultyId);
+    if (params.letter)    qs.set('letter',    params.letter);
+    const query = qs.toString();
+    return request(`/groups${query ? '?' + query : ''}`);
+  },
+  get:    (id)       => request(`/groups/${id}`),
+  create: (data)     => request('/groups', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id, data) => request(`/groups/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  delete: (id)       => request(`/groups/${id}`, { method: 'DELETE' }),
+
+  listMembers:  (id, params = {}) => {
+    const qs = new URLSearchParams();
+    if (params.showWaiting !== undefined) qs.set('showWaiting', params.showWaiting ? 'true' : 'false');
+    const query = qs.toString();
+    return request(`/groups/${id}/members${query ? '?' + query : ''}`);
+  },
+  addMember:    (id, data)           => request(`/groups/${id}/members`, { method: 'POST', body: JSON.stringify(data) }),
+  updateMember: (id, memberId, data) => request(`/groups/${id}/members/${memberId}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  removeMember: (id, memberId)       => request(`/groups/${id}/members/${memberId}`, { method: 'DELETE' }),
+};
+
 // ─── System admin (separate token, no tenant) ─────────────────────────────
 
 export const system = {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -31,10 +31,10 @@ export default function Home() {
     {
       title: 'Groups',
       items: [
-        { label: 'Groups',   to: null },
-        { label: 'Venues',   to: null },
+        { label: 'Groups',    to: can('groups_list', 'view') ? '/groups' : null },
+        { label: 'Venues',    to: null },
         { label: 'Faculties', to: null },
-        { label: 'Calendar', to: null },
+        { label: 'Calendar',  to: null },
       ],
     },
     {

--- a/frontend/src/pages/groups/GroupList.jsx
+++ b/frontend/src/pages/groups/GroupList.jsx
@@ -1,0 +1,189 @@
+// beacon2/frontend/src/pages/groups/GroupList.jsx
+
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { groups as groupsApi, faculties as facultiesApi } from '../../lib/api.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import NavBar from '../../components/NavBar.jsx';
+import PageHeader from '../../components/PageHeader.jsx';
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+export default function GroupList() {
+  const { can, tenant } = useAuth();
+  const navigate = useNavigate();
+
+  const [groupList,   setGroupList]   = useState([]);
+  const [faculties,   setFaculties]   = useState([]);
+  const [loading,     setLoading]     = useState(true);
+  const [error,       setError]       = useState(null);
+
+  const [activeOnly,   setActiveOnly]  = useState(true);
+  const [facultyId,    setFacultyId]   = useState('');
+  const [letter,       setLetter]      = useState('');
+
+  useEffect(() => {
+    facultiesApi.list().then(setFaculties).catch(() => {});
+  }, []);
+
+  useEffect(() => { load(); }, [activeOnly, facultyId, letter]);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await groupsApi.list({ activeOnly, facultyId, letter });
+      setGroupList(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleLetterClick(l) {
+    setLetter(l === letter ? '' : l);
+  }
+
+  const navLinks = [
+    { label: 'Home', to: '/' },
+    ...(can('group_records_all', 'create') ? [{ label: 'Add New Group', to: '/groups/new' }] : []),
+  ];
+
+  return (
+    <div className="min-h-screen pb-10">
+      <PageHeader tenant={tenant} />
+      <NavBar links={navLinks} />
+
+      <div className="max-w-6xl mx-auto px-4 py-4">
+        <h1 className="text-xl font-bold text-center mb-3">Groups</h1>
+
+        {/* ── Filters ──────────────────────────────────────────────── */}
+        <div className="bg-white/90 rounded-lg shadow-sm p-3 mb-3 flex flex-wrap gap-4 items-end">
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={activeOnly}
+              onChange={(e) => setActiveOnly(e.target.checked)}
+              className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+            />
+            Show active only
+          </label>
+
+          {faculties.length > 0 && (
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">Faculty</label>
+              <select
+                value={facultyId}
+                onChange={(e) => setFacultyId(e.target.value)}
+                className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">All faculties</option>
+                {faculties.map((f) => (
+                  <option key={f.id} value={f.id}>{f.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+
+        {/* ── Letter navigation ─────────────────────────────────────── */}
+        <div className="flex flex-wrap gap-1 mb-3">
+          <button
+            onClick={() => handleLetterClick('')}
+            className={`px-2 py-0.5 text-sm rounded border ${letter === '' ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+          >
+            All
+          </button>
+          {ALPHABET.map((l) => (
+            <button
+              key={l}
+              onClick={() => handleLetterClick(l)}
+              className={`px-2 py-0.5 text-sm rounded border ${letter === l ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+            >
+              {l}
+            </button>
+          ))}
+        </div>
+
+        {/* ── Results ───────────────────────────────────────────────── */}
+        {error   && <p className="text-center text-red-600 mb-3">Error: {error}</p>}
+        {loading && <p className="text-center text-slate-500">Loading…</p>}
+
+        {!loading && !error && (
+          groupList.length === 0 ? (
+            <p className="text-center text-slate-500 py-6">No groups found.</p>
+          ) : (
+            <>
+              <p className="text-sm text-slate-500 mb-1">{groupList.length} group{groupList.length !== 1 ? 's' : ''}</p>
+              <div className="overflow-x-auto rounded-lg shadow-sm">
+                <table className="w-full text-sm bg-white min-w-max">
+                  <thead>
+                    <tr className="bg-slate-50 border-b border-slate-200 text-left text-slate-600 italic font-normal">
+                      <th className="px-3 py-2 font-normal">Group</th>
+                      <th className="px-3 py-2 font-normal">When</th>
+                      <th className="px-3 py-2 font-normal">Leader(s)</th>
+                      <th className="px-3 py-2 font-normal">Members</th>
+                      {!activeOnly && <th className="px-3 py-2 font-normal">Status</th>}
+                      {faculties.length > 0 && <th className="px-3 py-2 font-normal">Faculty</th>}
+                      <th className="px-3 py-2"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {groupList.map((g, i) => (
+                      <tr
+                        key={g.id}
+                        className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}`}
+                      >
+                        <td className="px-3 py-2 font-medium">
+                          {can('group_records_all', 'view') ? (
+                            <button
+                              onClick={() => navigate(`/groups/${g.id}`)}
+                              className="text-blue-700 hover:underline text-left"
+                            >
+                              {g.name}
+                            </button>
+                          ) : g.name}
+                          {g.status === 'inactive' && (
+                            <span className="ml-2 text-xs text-red-500">(inactive)</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2 text-slate-500">{g.when_text ?? ''}</td>
+                        <td className="px-3 py-2">
+                          {(g.leaders ?? []).map((l) => `${l.forenames} ${l.surname}`).join(', ')}
+                        </td>
+                        <td className="px-3 py-2 tabular-nums">{g.member_count ?? 0}</td>
+                        {!activeOnly && (
+                          <td className="px-3 py-2">
+                            <span className={g.status === 'active' ? 'text-green-700' : 'text-red-600'}>
+                              {g.status}
+                            </span>
+                          </td>
+                        )}
+                        {faculties.length > 0 && (
+                          <td className="px-3 py-2 text-slate-500">{g.faculty_name ?? ''}</td>
+                        )}
+                        <td className="px-3 py-2 text-right">
+                          {can('group_records_all', 'view') && (
+                            <button
+                              onClick={() => navigate(`/groups/${g.id}`)}
+                              className="text-blue-700 hover:underline text-xs"
+                            >
+                              Edit
+                            </button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )
+        )}
+      </div>
+
+      <NavBar links={navLinks} />
+    </div>
+  );
+}

--- a/frontend/src/pages/groups/GroupRecord.jsx
+++ b/frontend/src/pages/groups/GroupRecord.jsx
@@ -1,0 +1,607 @@
+// beacon2/frontend/src/pages/groups/GroupRecord.jsx
+// Group record page with Details and Members tabs.
+// Route /groups/new → create mode (Details only, no tabs)
+// Route /groups/:id → view/edit mode with Details + Members tabs
+
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { groups as groupsApi, faculties as facultiesApi, members as membersApi } from '../../lib/api.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import NavBar from '../../components/NavBar.jsx';
+import PageHeader from '../../components/PageHeader.jsx';
+
+// ─── Details sub-component ────────────────────────────────────────────────
+
+function GroupDetails({ groupId, faculties, onSaved, onDeleted }) {
+  const { can } = useAuth();
+  const isNew = !groupId;
+
+  const EMPTY = {
+    name: '', facultyId: '', status: 'active', whenText: '',
+    startTime: '', endTime: '', venue: '', enquiries: '',
+    maxMembers: '', allowOnlineJoin: false, enableWaitingList: false,
+    notifyLeader: false, displayWaitingList: false,
+    information: '', notes: '', showAddresses: false,
+  };
+
+  const [form,    setForm]    = useState(EMPTY);
+  const [loading, setLoading] = useState(!isNew);
+  const [saving,  setSaving]  = useState(false);
+  const [error,   setError]   = useState(null);
+
+  useEffect(() => {
+    if (!groupId) return;
+    setLoading(true);
+    groupsApi.get(groupId)
+      .then((g) => setForm({
+        name:                g.name ?? '',
+        facultyId:           g.faculty_id ?? '',
+        status:              g.status ?? 'active',
+        whenText:            g.when_text ?? '',
+        startTime:           g.start_time ?? '',
+        endTime:             g.end_time ?? '',
+        venue:               g.venue ?? '',
+        enquiries:           g.enquiries ?? '',
+        maxMembers:          g.max_members != null ? String(g.max_members) : '',
+        allowOnlineJoin:     g.allow_online_join ?? false,
+        enableWaitingList:   g.enable_waiting_list ?? false,
+        notifyLeader:        g.notify_leader ?? false,
+        displayWaitingList:  g.display_waiting_list ?? false,
+        information:         g.information ?? '',
+        notes:               g.notes ?? '',
+        showAddresses:       g.show_addresses ?? false,
+      }))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [groupId]);
+
+  function set(field, value) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  async function handleSave(e) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        name:                form.name,
+        facultyId:           form.facultyId || null,
+        status:              form.status,
+        whenText:            form.whenText || null,
+        startTime:           form.startTime || null,
+        endTime:             form.endTime || null,
+        venue:               form.venue || null,
+        enquiries:           form.enquiries || null,
+        maxMembers:          form.maxMembers ? parseInt(form.maxMembers, 10) : null,
+        allowOnlineJoin:     form.allowOnlineJoin,
+        enableWaitingList:   form.enableWaitingList,
+        notifyLeader:        form.notifyLeader,
+        displayWaitingList:  form.displayWaitingList,
+        information:         form.information || null,
+        notes:               form.notes || null,
+        showAddresses:       form.showAddresses,
+      };
+      let result;
+      if (isNew) {
+        result = await groupsApi.create(payload);
+      } else {
+        result = await groupsApi.update(groupId, payload);
+      }
+      onSaved(result);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!window.confirm(`Delete group "${form.name}"? This cannot be undone.`)) return;
+    try {
+      await groupsApi.delete(groupId);
+      onDeleted();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  if (loading) return <p className="text-center text-slate-500 py-8">Loading…</p>;
+
+  const canChange = can('group_records_all', 'change') || (isNew && can('group_records_all', 'create'));
+  const canDelete = !isNew && can('group_records_all', 'delete');
+
+  const inputCls = 'border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
+  const labelCls = 'block text-sm font-medium text-slate-700 mb-1';
+  const cbCls    = 'rounded border-slate-300 text-blue-600 focus:ring-blue-500';
+
+  return (
+    <form onSubmit={handleSave} className="space-y-4 max-w-2xl">
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+
+      {/* Name */}
+      <div>
+        <label className={labelCls}>Group Name *</label>
+        <input className={`${inputCls} w-full`} required value={form.name}
+          onChange={(e) => set('name', e.target.value)} disabled={!canChange} />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {/* Faculty */}
+        <div>
+          <label className={labelCls}>Faculty</label>
+          <select className={`${inputCls} w-full`} value={form.facultyId}
+            onChange={(e) => set('facultyId', e.target.value)} disabled={!canChange}>
+            <option value="">— none —</option>
+            {faculties.map((f) => <option key={f.id} value={f.id}>{f.name}</option>)}
+          </select>
+        </div>
+
+        {/* Status */}
+        <div>
+          <label className={labelCls}>Status</label>
+          <select className={`${inputCls} w-full`} value={form.status}
+            onChange={(e) => set('status', e.target.value)} disabled={isNew || !canChange}>
+            <option value="active">Active</option>
+            <option value="inactive">Inactive</option>
+          </select>
+        </div>
+      </div>
+
+      {/* When */}
+      <div>
+        <label className={labelCls}>When</label>
+        <input className={`${inputCls} w-full`} placeholder="e.g. 2nd Thursday at 2:00pm"
+          value={form.whenText} onChange={(e) => set('whenText', e.target.value)} disabled={!canChange} />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {/* Start time */}
+        <div>
+          <label className={labelCls}>Start time</label>
+          <input type="time" className={`${inputCls} w-full`} value={form.startTime}
+            onChange={(e) => set('startTime', e.target.value)} disabled={!canChange} />
+        </div>
+
+        {/* End time */}
+        <div>
+          <label className={labelCls}>End time</label>
+          <input type="time" className={`${inputCls} w-full`} value={form.endTime}
+            onChange={(e) => set('endTime', e.target.value)} disabled={!canChange} />
+        </div>
+      </div>
+
+      {/* Venue */}
+      <div>
+        <label className={labelCls}>Venue</label>
+        <input className={`${inputCls} w-full`} value={form.venue}
+          onChange={(e) => set('venue', e.target.value)} disabled={!canChange} />
+      </div>
+
+      {/* Enquiries */}
+      <div>
+        <label className={labelCls}>Enquiries</label>
+        <input className={`${inputCls} w-full`} placeholder="Name/phone for enquirers"
+          value={form.enquiries} onChange={(e) => set('enquiries', e.target.value)} disabled={!canChange} />
+      </div>
+
+      {/* Max members */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className={labelCls}>Max members</label>
+          <input type="number" min="1" className={`${inputCls} w-full`} value={form.maxMembers}
+            onChange={(e) => set('maxMembers', e.target.value)} disabled={!canChange} />
+        </div>
+      </div>
+
+      {/* Checkboxes */}
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="checkbox" className={cbCls} checked={form.allowOnlineJoin}
+            onChange={(e) => set('allowOnlineJoin', e.target.checked)} disabled={!canChange} />
+          Allow members to join/leave online
+        </label>
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="checkbox" className={cbCls} checked={form.enableWaitingList}
+            onChange={(e) => set('enableWaitingList', e.target.checked)} disabled={!canChange} />
+          Enable waiting list
+        </label>
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="checkbox" className={cbCls} checked={form.notifyLeader}
+            onChange={(e) => set('notifyLeader', e.target.checked)} disabled={!canChange} />
+          Notify leader when members join/leave
+        </label>
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="checkbox" className={cbCls} checked={form.displayWaitingList}
+            onChange={(e) => set('displayWaitingList', e.target.checked)} disabled={!canChange} />
+          Display waiting list by default
+        </label>
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input type="checkbox" className={cbCls} checked={form.showAddresses}
+            onChange={(e) => set('showAddresses', e.target.checked)} disabled={!canChange} />
+          Show member addresses to group leader
+        </label>
+      </div>
+
+      {/* Information */}
+      <div>
+        <label className={labelCls}>Information (may be shown publicly)</label>
+        <textarea rows={4} className={`${inputCls} w-full resize-y`} value={form.information}
+          onChange={(e) => set('information', e.target.value)} disabled={!canChange} />
+      </div>
+
+      {/* Notes */}
+      <div>
+        <label className={labelCls}>Notes (private)</label>
+        <textarea rows={3} className={`${inputCls} w-full resize-y`} value={form.notes}
+          onChange={(e) => set('notes', e.target.value)} disabled={!canChange} />
+      </div>
+
+      {/* Buttons */}
+      {canChange && (
+        <div className="flex gap-3 items-center pt-2">
+          <button type="submit" disabled={saving}
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium transition-colors">
+            {saving ? 'Saving…' : (isNew ? 'Add Group' : 'Save Record')}
+          </button>
+          {canDelete && (
+            <button type="button" onClick={handleDelete}
+              className="border border-red-300 text-red-600 hover:bg-red-50 rounded px-5 py-2 text-sm">
+              Delete Group
+            </button>
+          )}
+        </div>
+      )}
+    </form>
+  );
+}
+
+// ─── Members sub-component ────────────────────────────────────────────────
+
+function GroupMembers({ groupId }) {
+  const { can } = useAuth();
+  const [groupMembers, setGroupMembers] = useState([]);
+  const [allMembers,   setAllMembers]   = useState([]);
+  const [loading,      setLoading]      = useState(true);
+  const [error,        setError]        = useState(null);
+
+  const [addByName,   setAddByName]   = useState('');
+  const [addByNumber, setAddByNumber] = useState('');
+  const [addError,    setAddError]    = useState(null);
+  const [addLoading,  setAddLoading]  = useState(false);
+
+  const canManage = can('group_records_all', 'change');
+
+  useEffect(() => {
+    load();
+    if (canManage) {
+      membersApi.list({}).then(setAllMembers).catch(() => {});
+    }
+  }, [groupId]);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await groupsApi.listMembers(groupId);
+      setGroupMembers(rows);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleAddByName() {
+    if (!addByName) return;
+    setAddLoading(true);
+    setAddError(null);
+    try {
+      await groupsApi.addMember(groupId, { memberId: addByName });
+      setAddByName('');
+      await load();
+    } catch (err) {
+      setAddError(err.message);
+    } finally {
+      setAddLoading(false);
+    }
+  }
+
+  async function handleAddByNumber() {
+    const num = parseInt(addByNumber, 10);
+    if (!num) return;
+    setAddLoading(true);
+    setAddError(null);
+    try {
+      await groupsApi.addMember(groupId, { membershipNumber: num });
+      setAddByNumber('');
+      await load();
+    } catch (err) {
+      setAddError(err.message);
+    } finally {
+      setAddLoading(false);
+    }
+  }
+
+  async function handleRemove(memberId) {
+    if (!window.confirm('Remove this member from the group?')) return;
+    try {
+      await groupsApi.removeMember(groupId, memberId);
+      setGroupMembers((prev) => prev.filter((m) => m.member_id !== memberId));
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleToggleLeader(memberId, currentIsLeader) {
+    try {
+      const updated = await groupsApi.updateMember(groupId, memberId, { isLeader: !currentIsLeader });
+      setGroupMembers((prev) =>
+        prev.map((m) => m.member_id === updated.member_id ? { ...m, is_leader: updated.is_leader } : m),
+      );
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  // Determine row class based on member status
+  function rowStyle(m) {
+    if (m.status === 'Resigned' || m.status === 'Deceased') return 'line-through text-red-500';
+    if (m.status === 'Lapsed') return 'text-red-500';
+    return '';
+  }
+
+  if (loading) return <p className="text-center text-slate-500 py-8">Loading…</p>;
+
+  const joinedMembers  = groupMembers.filter((m) => !m.waiting_since);
+  const waitingMembers = groupMembers.filter((m) => m.waiting_since);
+
+  // Compute which members can still be added (not already in group)
+  const memberIdsInGroup = new Set(groupMembers.map((m) => m.member_id));
+  const availableToAdd = allMembers.filter((m) => !memberIdsInGroup.has(m.id));
+
+  return (
+    <div className="space-y-4">
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+
+      {/* ── Members table ──────────────────────────────────────────── */}
+      {joinedMembers.length === 0 ? (
+        <p className="text-slate-500 text-sm">No members in this group yet.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg shadow-sm">
+          <table className="w-full text-sm bg-white min-w-max">
+            <thead>
+              <tr className="bg-slate-50 border-b border-slate-200 text-left text-slate-600 italic font-normal">
+                <th className="px-3 py-2 font-normal">No</th>
+                <th className="px-3 py-2 font-normal">Name</th>
+                <th className="px-3 py-2 font-normal">Town</th>
+                <th className="px-3 py-2 font-normal">Email</th>
+                <th className="px-3 py-2 font-normal">Tel</th>
+                <th className="px-3 py-2 font-normal">Status</th>
+                <th className="px-3 py-2 font-normal">Leader</th>
+                {canManage && <th className="px-3 py-2"></th>}
+              </tr>
+            </thead>
+            <tbody>
+              {joinedMembers.map((m, i) => (
+                <tr key={m.member_id} className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}`}>
+                  <td className="px-3 py-2 tabular-nums">{m.membership_number}</td>
+                  <td className={`px-3 py-2 ${rowStyle(m)}`}>
+                    {m.is_leader && <span className="text-blue-600 font-medium mr-1">★</span>}
+                    {m.title ? `${m.title} ` : ''}{m.forenames} {m.surname}
+                    {m.known_as ? ` (${m.known_as})` : ''}
+                    {!m.email && <span className="ml-2 text-red-400 text-xs" title="No email">✉✗</span>}
+                  </td>
+                  <td className="px-3 py-2">{m.town ?? ''}</td>
+                  <td className="px-3 py-2 text-xs">{m.hide_contact ? '' : (m.email ?? '')}</td>
+                  <td className="px-3 py-2 text-xs">{m.hide_contact ? '' : (m.telephone ?? m.mobile ?? '')}</td>
+                  <td className="px-3 py-2">{m.status ?? ''}</td>
+                  <td className="px-3 py-2">{m.is_leader ? 'Yes' : ''}</td>
+                  {canManage && (
+                    <td className="px-3 py-2 text-right space-x-3 whitespace-nowrap">
+                      <button
+                        onClick={() => handleToggleLeader(m.member_id, m.is_leader)}
+                        className="text-blue-600 hover:underline text-xs"
+                      >
+                        {m.is_leader ? 'Remove leader' : 'Make leader'}
+                      </button>
+                      <button
+                        onClick={() => handleRemove(m.member_id)}
+                        className="text-red-600 hover:underline text-xs"
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* ── Waiting list ──────────────────────────────────────────── */}
+      {waitingMembers.length > 0 && (
+        <details className="bg-white/90 rounded-lg shadow-sm p-3">
+          <summary className="text-sm font-medium cursor-pointer">
+            Waiting list ({waitingMembers.length})
+          </summary>
+          <ul className="mt-2 space-y-1">
+            {waitingMembers.map((m) => (
+              <li key={m.member_id} className="text-sm text-slate-600 flex justify-between">
+                <span>{m.forenames} {m.surname} — waiting since {m.waiting_since}</span>
+                {canManage && (
+                  <button onClick={() => handleRemove(m.member_id)}
+                    className="text-red-600 hover:underline text-xs ml-3">Remove</button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      {/* ── Add members ───────────────────────────────────────────── */}
+      {canManage && (
+        <div className="bg-white/90 rounded-lg shadow-sm p-4 space-y-3">
+          <h3 className="text-sm font-semibold text-slate-700">Add a member</h3>
+
+          {addError && <p className="text-red-600 text-sm">{addError}</p>}
+
+          {/* By name */}
+          <div className="flex gap-2 items-end">
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-slate-700 mb-1">Add member by name</label>
+              <select
+                value={addByName}
+                onChange={(e) => setAddByName(e.target.value)}
+                className="border border-slate-300 rounded px-3 py-2 text-sm w-full focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">— select member —</option>
+                {availableToAdd.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.surname}, {m.forenames}{m.known_as ? ` (${m.known_as})` : ''} — #{m.membership_number}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              onClick={handleAddByName}
+              disabled={!addByName || addLoading}
+              className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-4 py-2 text-sm font-medium"
+            >
+              Add
+            </button>
+          </div>
+
+          {/* By membership number */}
+          <div className="flex gap-2 items-end">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">Add member by membership number</label>
+              <input
+                type="number"
+                min="1"
+                value={addByNumber}
+                onChange={(e) => setAddByNumber(e.target.value)}
+                placeholder="e.g. 42"
+                className="border border-slate-300 rounded px-3 py-2 text-sm w-36 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <button
+              onClick={handleAddByNumber}
+              disabled={!addByNumber || addLoading}
+              className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-4 py-2 text-sm font-medium"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── GroupRecord page ─────────────────────────────────────────────────────
+
+export default function GroupRecord() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { can, tenant } = useAuth();
+  const [faculties, setFaculties] = useState([]);
+  const [groupName, setGroupName] = useState('');
+
+  const isNew = id === undefined;
+  const activeTab = searchParams.get('tab') ?? 'details';
+
+  useEffect(() => {
+    facultiesApi.list().then(setFaculties).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!isNew) {
+      groupsApi.get(id)
+        .then((g) => setGroupName(g.name))
+        .catch(() => {});
+    }
+  }, [id]);
+
+  function handleSaved(result) {
+    if (isNew) {
+      navigate(`/groups/${result.id}`);
+    } else {
+      setGroupName(result.name ?? groupName);
+    }
+  }
+
+  function handleDeleted() {
+    navigate('/groups');
+  }
+
+  const navLinks = [
+    { label: 'Home', to: '/' },
+    { label: 'Groups', to: '/groups' },
+    ...(can('group_records_all', 'create') ? [{ label: 'Add New Group', to: '/groups/new' }] : []),
+  ];
+
+  const tabs = [
+    { key: 'details',  label: 'Details',  available: true },
+    { key: 'members',  label: 'Members',  available: !isNew },
+    { key: 'schedule', label: 'Schedule', available: false },
+    { key: 'ledger',   label: 'Ledger',   available: false },
+  ];
+
+  return (
+    <div className="min-h-screen pb-10">
+      <PageHeader tenant={tenant} />
+      <NavBar links={navLinks} />
+
+      <div className="max-w-4xl mx-auto px-4 py-4">
+
+        {/* Title */}
+        <h1 className="text-xl font-bold text-center mb-3">
+          {isNew ? 'Add New Group' : (groupName || 'Group Record')}
+        </h1>
+
+        {/* Tab navigation (only when editing existing) */}
+        {!isNew && (
+          <div className="flex gap-0 mb-4 border-b border-slate-300">
+            {tabs.map((tab) => (
+              <button
+                key={tab.key}
+                disabled={!tab.available}
+                onClick={() => tab.available && setSearchParams(tab.key === 'details' ? {} : { tab: tab.key })}
+                className={[
+                  'px-5 py-2 text-sm font-medium border-b-2 -mb-px transition-colors',
+                  tab.available && activeTab === tab.key
+                    ? 'border-blue-600 text-blue-700'
+                    : tab.available
+                    ? 'border-transparent text-slate-600 hover:text-slate-900'
+                    : 'border-transparent text-slate-300 cursor-not-allowed',
+                ].join(' ')}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Tab content */}
+        <div className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6">
+          {(isNew || activeTab === 'details') && (
+            <GroupDetails
+              groupId={isNew ? null : id}
+              faculties={faculties}
+              onSaved={handleSaved}
+              onDeleted={handleDeleted}
+            />
+          )}
+          {!isNew && activeTab === 'members' && (
+            <GroupMembers groupId={id} />
+          )}
+        </div>
+      </div>
+
+      <NavBar links={navLinks} />
+    </div>
+  );
+}


### PR DESCRIPTION
Backend
- tenant_schema.sql: add faculties, groups and group_members tables (faculties: id/name; groups: name, faculty_id, status, when_text, start/end time, venue, enquiries, max_members, allow_online_join, enable_waiting_list, notify_leader, display_waiting_list, information, notes, show_addresses; group_members: group_id, member_id, is_leader, waiting_since + indexes)
- routes/faculties.js: CRUD for group faculties (group_faculties:view/create/change/delete)
- routes/groups.js: CRUD for groups (groups_list:view, group_records_all:view/create/change/delete) plus group-members sub-resource (GET/POST/PATCH/DELETE /groups/:id/members/:memberId; add by memberId or membershipNumber, toggle is_leader, remove)
- app.js: register /faculties and /groups routes
- __tests__/helpers.js: add groups_list, group_records_all and group_faculties privilege codes to ALL_PRIVS
- __tests__/faculties.test.js: 9 tests
- __tests__/groups.test.js: 21 tests

Frontend
- api.js: add faculties and groups API objects (including listMembers/addMember/updateMember/removeMember sub-methods)
- pages/groups/GroupList.jsx: groups list with active-only toggle, faculty dropdown filter, A-Z letter navigation, table with name link, when, leaders, member count, status, faculty
- pages/groups/GroupRecord.jsx: group record page with Details and Members tabs; Details form (all group fields); Members tab with member table (status colouring, leader indicator, remove/make- leader actions) and add-by-name dropdown + add-by-number input
- App.jsx: routes /groups, /groups/new, /groups/:id
- Home.jsx: wire Groups link (groups_list:view)

Tests: 106 backend + 34 frontend — all passing

https://claude.ai/code/session_01WdSsJg1nZ4vKZB2ncxM2Ej