### PR TITLE
fix: correct render.yaml startCommand to use server.js

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     plan: free
     rootDir: backend
     buildCommand: npm install && npm run build
-    startCommand: node src/app.js
+    startCommand: node src/server.js
     healthCheckPath: /health
 
     envVars:


### PR DESCRIPTION
app.js only exports the Express app without calling listen() — the process exited immediately. server.js is the correct entry point (runs migrateAndSeed then app.listen).

https://claude.ai/code/session_01WdSsJg1nZ4vKZB2ncxM2Ej