### PR TITLE
fix: auto-migrate existing tenant schemas on startup

### DIFF
--- a/backend/prisma/tenant_schema.sql
+++ b/backend/prisma/tenant_schema.sql
@@ -1,8 +1,10 @@
 -- beacon2/backend/prisma/tenant_schema.sql
--- This SQL is executed for each new u3a tenant.
+-- This SQL is executed for each new u3a tenant AND re-run against every
+-- existing tenant on startup (to pick up new tables).
+-- All statements are idempotent: CREATE TABLE IF NOT EXISTS, etc.
 -- Replace :schema with the tenant slug, e.g. u3a_oxfordshire
 --
--- Usage: called by src/seed/createTenant.js
+-- Usage: called by src/seed/createTenant.js  and  src/utils/migrate.js
 
 -- Create the schema
 CREATE SCHEMA IF NOT EXISTS :schema;
@@ -10,7 +12,7 @@ CREATE SCHEMA IF NOT EXISTS :schema;
 -- ─────────────────────────────────────────────
 -- USERS
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.users (
+CREATE TABLE IF NOT EXISTS :schema.users (
   id            TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   email         TEXT NOT NULL UNIQUE,
   password_hash TEXT,                        -- NULL = no login access
@@ -25,7 +27,7 @@ CREATE TABLE :schema.users (
 -- ─────────────────────────────────────────────
 -- ROLES
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.roles (
+CREATE TABLE IF NOT EXISTS :schema.roles (
   id           TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   name         TEXT NOT NULL,
   is_committee BOOLEAN NOT NULL DEFAULT false,
@@ -37,7 +39,7 @@ CREATE TABLE :schema.roles (
 -- ─────────────────────────────────────────────
 -- USER ↔ ROLE ASSIGNMENTS
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.user_roles (
+CREATE TABLE IF NOT EXISTS :schema.user_roles (
   id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   user_id     TEXT NOT NULL REFERENCES :schema.users(id) ON DELETE CASCADE,
   role_id     TEXT NOT NULL REFERENCES :schema.roles(id) ON DELETE CASCADE,
@@ -48,7 +50,7 @@ CREATE TABLE :schema.user_roles (
 -- ─────────────────────────────────────────────
 -- PRIVILEGE RESOURCES  (system-seeded, not editable per tenant)
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.privilege_resources (
+CREATE TABLE IF NOT EXISTS :schema.privilege_resources (
   id      TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   code    TEXT NOT NULL UNIQUE,             -- e.g. "finance:transactions"
   label   TEXT NOT NULL,                   -- e.g. "Finance: transactions"
@@ -58,7 +60,7 @@ CREATE TABLE :schema.privilege_resources (
 -- ─────────────────────────────────────────────
 -- ROLE ↔ PRIVILEGE ASSIGNMENTS
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.role_privileges (
+CREATE TABLE IF NOT EXISTS :schema.role_privileges (
   id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   role_id     TEXT NOT NULL REFERENCES :schema.roles(id) ON DELETE CASCADE,
   resource_id TEXT NOT NULL REFERENCES :schema.privilege_resources(id) ON DELETE CASCADE,
@@ -69,7 +71,7 @@ CREATE TABLE :schema.role_privileges (
 -- ─────────────────────────────────────────────
 -- REFRESH TOKENS
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.refresh_tokens (
+CREATE TABLE IF NOT EXISTS :schema.refresh_tokens (
   id         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   user_id    TEXT NOT NULL REFERENCES :schema.users(id) ON DELETE CASCADE,
   token_hash TEXT NOT NULL UNIQUE,
@@ -81,7 +83,7 @@ CREATE TABLE :schema.refresh_tokens (
 -- ─────────────────────────────────────────────
 -- MEMBERSHIP CLASSES
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.member_classes (
+CREATE TABLE IF NOT EXISTS :schema.member_classes (
   id           TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   name         TEXT NOT NULL,
   current      BOOLEAN NOT NULL DEFAULT true,   -- may be used for new memberships
@@ -99,7 +101,7 @@ CREATE TABLE :schema.member_classes (
 -- ─────────────────────────────────────────────
 -- MEMBER STATUSES
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.member_statuses (
+CREATE TABLE IF NOT EXISTS :schema.member_statuses (
   id         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   name       TEXT NOT NULL UNIQUE,
   locked     BOOLEAN NOT NULL DEFAULT false,  -- locked system statuses cannot be edited/deleted
@@ -110,12 +112,12 @@ CREATE TABLE :schema.member_statuses (
 -- ─────────────────────────────────────────────
 -- MEMBERSHIP NUMBER SEQUENCE
 -- ─────────────────────────────────────────────
-CREATE SEQUENCE :schema.membership_number_seq START 1;
+CREATE SEQUENCE IF NOT EXISTS :schema.membership_number_seq START 1;
 
 -- ─────────────────────────────────────────────
 -- ADDRESSES  (may be shared between two members at the same address)
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.addresses (
+CREATE TABLE IF NOT EXISTS :schema.addresses (
   id         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   house_no   TEXT,                -- house/flat number or name
   street     TEXT,
@@ -132,10 +134,10 @@ CREATE TABLE :schema.addresses (
 -- ─────────────────────────────────────────────
 -- MEMBERS
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.members (
+CREATE TABLE IF NOT EXISTS :schema.members (
   id                TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   membership_number INTEGER NOT NULL UNIQUE
-                    DEFAULT nextval('membership_number_seq'),
+                    DEFAULT nextval(':schema.membership_number_seq'),
   title             TEXT,                              -- Mr, Mrs, Ms, Dr etc.
   forenames         TEXT NOT NULL,
   surname           TEXT NOT NULL,
@@ -161,7 +163,7 @@ CREATE TABLE :schema.members (
 -- ─────────────────────────────────────────────
 -- FACULTIES
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.faculties (
+CREATE TABLE IF NOT EXISTS :schema.faculties (
   id         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   name       TEXT NOT NULL UNIQUE,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -171,7 +173,7 @@ CREATE TABLE :schema.faculties (
 -- ─────────────────────────────────────────────
 -- GROUPS
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.groups (
+CREATE TABLE IF NOT EXISTS :schema.groups (
   id                   TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   name                 TEXT NOT NULL,
   faculty_id           TEXT REFERENCES :schema.faculties(id),
@@ -197,7 +199,7 @@ CREATE TABLE :schema.groups (
 -- ─────────────────────────────────────────────
 -- GROUP MEMBERS
 -- ─────────────────────────────────────────────
-CREATE TABLE :schema.group_members (
+CREATE TABLE IF NOT EXISTS :schema.group_members (
   id            TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   group_id      TEXT NOT NULL REFERENCES :schema.groups(id) ON DELETE CASCADE,
   member_id     TEXT NOT NULL REFERENCES :schema.members(id) ON DELETE CASCADE,
@@ -208,18 +210,18 @@ CREATE TABLE :schema.group_members (
 );
 
 -- ─────────────────────────────────────────────
--- INDEXES
+-- INDEXES  (named so IF NOT EXISTS works)
 -- ─────────────────────────────────────────────
-CREATE INDEX ON :schema.user_roles (user_id);
-CREATE INDEX ON :schema.user_roles (role_id);
-CREATE INDEX ON :schema.role_privileges (role_id);
-CREATE INDEX ON :schema.refresh_tokens (user_id);
-CREATE INDEX ON :schema.refresh_tokens (token_hash);
-CREATE INDEX ON :schema.members (surname, forenames);
-CREATE INDEX ON :schema.members (status_id);
-CREATE INDEX ON :schema.members (class_id);
-CREATE INDEX ON :schema.members (address_id);
-CREATE INDEX ON :schema.groups (faculty_id);
-CREATE INDEX ON :schema.groups (status);
-CREATE INDEX ON :schema.group_members (group_id);
-CREATE INDEX ON :schema.group_members (member_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_user_roles_user_id   ON :schema.user_roles (user_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_user_roles_role_id   ON :schema.user_roles (role_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_role_privs_role_id   ON :schema.role_privileges (role_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_refresh_tokens_user  ON :schema.refresh_tokens (user_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_refresh_tokens_hash  ON :schema.refresh_tokens (token_hash);
+CREATE INDEX IF NOT EXISTS :schema_idx_members_name         ON :schema.members (surname, forenames);
+CREATE INDEX IF NOT EXISTS :schema_idx_members_status       ON :schema.members (status_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_members_class        ON :schema.members (class_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_members_address      ON :schema.members (address_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_groups_faculty       ON :schema.groups (faculty_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_groups_status        ON :schema.groups (status);
+CREATE INDEX IF NOT EXISTS :schema_idx_group_members_group  ON :schema.group_members (group_id);
+CREATE INDEX IF NOT EXISTS :schema_idx_group_members_member ON :schema.group_members (member_id);

--- a/backend/src/utils/migrate.js
+++ b/backend/src/utils/migrate.js
@@ -2,9 +2,16 @@
 // Runs database migrations and seeds automatically on startup.
 // This means you never need shell access to set up the database.
 
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { prisma } from './db.js';
+import { tenantQuery } from './db.js';
 import { hashPassword } from './password.js';
+import { PRIVILEGE_RESOURCES } from '../seed/privilegeResources.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export async function migrateAndSeed() {
   // 1. Run Prisma migrations (creates system-level tables if they don't exist)
@@ -19,22 +26,89 @@ export async function migrateAndSeed() {
 
   // 2. Seed the system admin if one doesn't exist yet
   const existing = await prisma.sysAdmin.findFirst();
-  if (existing) {
-    console.log('Database already seeded — skipping.');
-    return;
+  if (!existing) {
+    const email    = process.env.SEED_ADMIN_EMAIL    ?? 'admin@beacon2.local';
+    const password = process.env.SEED_ADMIN_PASSWORD ?? 'ChangeMe123!';
+    const name     = process.env.SEED_ADMIN_NAME     ?? 'System Administrator';
+
+    const passwordHash = await hashPassword(password);
+    await prisma.sysAdmin.create({ data: { email, name, passwordHash, active: true } });
+
+    console.log('');
+    console.log('✓ System administrator created:');
+    console.log(`  Email:    ${email}`);
+    console.log(`  Password: ${password}`);
+    console.log('  IMPORTANT: Set SEED_ADMIN_PASSWORD in your environment variables.');
+    console.log('');
   }
 
-  const email    = process.env.SEED_ADMIN_EMAIL    ?? 'admin@beacon2.local';
-  const password = process.env.SEED_ADMIN_PASSWORD ?? 'ChangeMe123!';
-  const name     = process.env.SEED_ADMIN_NAME     ?? 'System Administrator';
+  // 3. Bring all existing tenant schemas up to date
+  await migrateTenantSchemas();
+}
 
-  const passwordHash = await hashPassword(password);
-  await prisma.sysAdmin.create({ data: { email, name, passwordHash, active: true } });
+/**
+ * Re-run tenant_schema.sql (idempotent) against every active tenant,
+ * then re-seed default data (privilege resources, member statuses, member classes).
+ * Safe to run on every startup — all DDL uses IF NOT EXISTS, inserts use ON CONFLICT DO NOTHING.
+ */
+async function migrateTenantSchemas() {
+  const tenants = await prisma.sysTenant.findMany({ where: { active: true } });
+  if (tenants.length === 0) return;
 
-  console.log('');
-  console.log('✓ System administrator created:');
-  console.log(`  Email:    ${email}`);
-  console.log(`  Password: ${password}`);
-  console.log('  IMPORTANT: Set SEED_ADMIN_PASSWORD in your environment variables.');
-  console.log('');
+  const schemaSQL = readFileSync(
+    resolve(__dirname, '../../prisma/tenant_schema.sql'),
+    'utf8',
+  );
+
+  for (const tenant of tenants) {
+    const slug       = tenant.slug;
+    const schemaName = `u3a_${slug}`;
+    console.log(`Migrating tenant schema: ${schemaName}`);
+
+    try {
+      // Run the idempotent DDL
+      const statements = schemaSQL
+        .replace(/:schema/g, schemaName)
+        .split(';')
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+      for (const stmt of statements) {
+        await prisma.$executeRawUnsafe(stmt);
+      }
+
+      // Re-seed privilege resources (ON CONFLICT DO NOTHING keeps existing rows)
+      for (const resource of PRIVILEGE_RESOURCES) {
+        await tenantQuery(
+          slug,
+          `INSERT INTO privilege_resources (id, code, label, actions)
+           VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+          [resource.id, resource.code, resource.label, resource.actions],
+        );
+      }
+
+      // Re-seed locked member statuses
+      for (const statusName of ['Current', 'Lapsed', 'Resigned', 'Deceased']) {
+        await tenantQuery(
+          slug,
+          `INSERT INTO member_statuses (name, locked) VALUES ($1, true)
+           ON CONFLICT (name) DO NOTHING`,
+          [statusName],
+        );
+      }
+
+      // Re-seed locked Individual member class (no UNIQUE on name, use WHERE NOT EXISTS)
+      await tenantQuery(
+        slug,
+        `INSERT INTO member_classes (name, current, locked)
+         SELECT 'Individual', true, true
+         WHERE NOT EXISTS (SELECT 1 FROM member_classes WHERE name = 'Individual' AND locked = true)`,
+      );
+
+      console.log(`  ✓ ${schemaName} up to date`);
+    } catch (err) {
+      // Log but don't crash — a broken tenant shouldn't stop the server
+      console.error(`  ✗ Failed to migrate ${schemaName}:`, err.message);
+    }
+  }
 }


### PR DESCRIPTION
Previously, tables added after a tenant was created (member_statuses, member_classes, groups, etc.) were missing from existing tenants, causing 500 errors.

Changes:
- tenant_schema.sql: all CREATE TABLE/SEQUENCE/INDEX now use IF NOT EXISTS, and indexes have explicit names so they are idempotent on re-run
- migrate.js: migrateTenantSchemas() loops over every active tenant on startup, re-runs the full tenant_schema.sql (idempotent DDL), then re-seeds privilege resources, default member statuses (Current/Lapsed/Resigned/Deceased, locked=true) and the Individual member class using ON CONFLICT DO NOTHING / WHERE NOT EXISTS

This means any deployment automatically brings all existing tenants up to the current schema without manual intervention.

https://claude.ai/code/session_01WdSsJg1nZ4vKZB2ncxM2Ej