### PR TITLE
Add Data Export & Backup (doc 9.5) with Beacon migration support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -817,3 +817,63 @@ When `flagged.length === 0`, shows a green "All member data is valid!" banner wi
 ### Frontend test note: multiple instances of same text
 
 When a heading label also appears on a submit button (e.g. "Change Password"), `getByText` throws "Found multiple elements". Use `getAllByText(...).length > 0` instead.
+
+---
+
+## Data Export & Backup (March 2026)
+
+### Architecture
+
+- Backend: `backend/src/routes/backup.js` — mounted at `/backup` in `app.js`
+- Frontend: `frontend/src/pages/misc/DataBackup.jsx` at `/backup`
+- Privilege: `data_export_backup` (actions: `view`, `download`, `restore`) — granted to Administration
+
+### Export — 8 options
+
+`GET /backup/export?type=<type>` streams an `.xlsx` file. Types:
+
+| type | label | sheets |
+|------|-------|--------|
+| `members` | Members and addresses | Members |
+| `finance` | Finance ledger with detail | Ledger, Detail |
+| `groups` | Groups, with members, venues and faculties | Groups, Group members, Venues, Faculties |
+| `calendar` | Calendar | Calendar (empty — not yet implemented) |
+| `system` | System users, roles and privileges | System Users, Roles, Privileges |
+| `officers` | u3a Officers | u3a Officers |
+| `settings` | Site settings and set up | Site Settings 1/2, Finance Accounts/Categories, Membership Classes/Fees, Member Statuses, Polls, Poll assignments, System Messages |
+| `all` | Backup all data | All of the above |
+
+The frontend uses `fetch()` with auth header → blob → `URL.createObjectURL` trigger download. This is the `requestBlob` helper in `api.js`. Direct browser navigation cannot be used because the auth token is in memory (not cookies).
+
+### Restore — two modes, auto-detected
+
+`POST /backup/restore` accepts a multipart `backup` file upload. Detection: if the `Members` sheet first column is `mkey` → Beacon (legacy); if `id` → Beacon2.
+
+- **Beacon2 restore**: UUIDs preserved; all FK-dependent tables re-inserted in order.
+- **Beacon restore**: Maps `mkey`/`gkey`/`tkey`/etc to new UUIDs. Partner detection via shared `akey` (exactly 2 members sharing an `akey` are linked as partners). Beacon month `0` in `Membership Fees` = Beacon2 `month_index` 13 (Renewals). Beacon ledger amounts: positive = `in`, negative = `out`.
+
+Both modes use a single `prisma.$transaction` with 5-minute timeout for atomicity.
+
+**User accounts/roles are NOT affected** by restore — only member, group, finance, settings, and related data is replaced.
+
+### Libraries
+
+- `exceljs` — Excel generation (write) and parsing (read), installed in backend
+- `multer` — multipart file upload handling, installed in backend
+
+### Sequences reset after restore
+
+After inserting all data, `membership_number_seq` and `transaction_number_seq` are reset to `MAX + 1` so new records get correct sequential numbers.
+
+### Beacon Site Settings mapping (partial)
+
+| Beacon key | Beacon2 column |
+|-----------|----------------|
+| `AdvRenewals` | `advance_renewals_weeks` |
+| `GraceLapse` | `grace_lapse_weeks` |
+| `GiftAidEnable` | `gift_aid_enabled` |
+| `GiftAidOnlineRenew` | `gift_aid_online_renewals` |
+| `DefaultTown/County/STD` | `default_town/county/std_code` |
+| `defaultPaymentMethod` (1–6) | `default_payment_method` (Cash/Cheque/SO/DD/Online/Other) |
+| `EnqTelephone/Email/NewMem/Renew` | `public_phone/email/online_join_email/online_renew_email` |
+| Site Settings 2 `paypal_account` | `paypal_email` |

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,22 +1,24 @@
 {
   "name": "beacon2-backend",
-  "version": "0.1.0",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-backend",
-      "version": "0.1.0",
+      "version": "0.3.8",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
+        "exceljs": "^4.4.0",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^2.1.1",
         "redis": "^4.6.10",
         "uuid": "^9.0.0",
         "zod": "^3.22.4"
@@ -420,6 +422,47 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
@@ -975,6 +1018,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
@@ -1151,11 +1206,86 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/aproba": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
       "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
       "license": "ISC"
+    },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
@@ -1194,6 +1324,12 @@
         "node": "*"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1205,6 +1341,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/bcrypt": {
@@ -1220,6 +1376,45 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -1255,11 +1450,78 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1328,6 +1590,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -1391,11 +1665,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -1472,6 +1776,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -1489,6 +1799,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1503,6 +1838,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -1617,6 +1958,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1645,6 +2025,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -1757,6 +2146,35 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -1855,6 +2273,19 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -1931,6 +2362,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -1974,6 +2411,47 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -2108,6 +2586,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2241,6 +2725,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2289,6 +2799,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2331,6 +2847,48 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -2352,6 +2910,63 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
     "node_modules/local-pkg": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
@@ -2369,6 +2984,36 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -2381,10 +3026,29 @@
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "license": "MIT"
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
@@ -2405,10 +3069,28 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -2556,6 +3238,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -2628,6 +3319,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2695,6 +3405,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -2812,6 +3531,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -2954,6 +3679,12 @@
         "fsevents": "2.3.3"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3025,6 +3756,36 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/redis": {
@@ -3131,6 +3892,18 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3193,6 +3966,12 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3340,6 +4119,14 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -3496,6 +4283,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3523,6 +4326,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3537,6 +4349,15 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
@@ -3561,12 +4382,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -3575,6 +4411,54 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -3877,6 +4761,12 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3894,6 +4784,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/zod": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,10 +22,12 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
+    "exceljs": "^4.4.0",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.1.1",
     "redis": "^4.6.10",
     "uuid": "^9.0.0",
     "zod": "^3.22.4"

--- a/backend/src/__tests__/helpers.js
+++ b/backend/src/__tests__/helpers.js
@@ -26,6 +26,7 @@ export const ALL_PRIVS = [
   'audit_trail:view', 'audit_trail:delete',
   'offices:view', 'offices:create', 'offices:change', 'offices:delete',
   'settings:view', 'settings:change',
+  'data_export_backup:view', 'data_export_backup:download', 'data_export_backup:restore',
 ];
 
 export const TEST_TENANT = 'test-u3a';

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -26,6 +26,7 @@ import financeRoutes       from './routes/finance.js';
 import pollRoutes          from './routes/polls.js';
 import auditRoutes         from './routes/audit.js';
 import officeRoutes        from './routes/offices.js';
+import backupRoutes        from './routes/backup.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 const app = express();
@@ -59,6 +60,7 @@ app.use('/finance',         financeRoutes);
 app.use('/polls',           pollRoutes);
 app.use('/audit',           auditRoutes);
 app.use('/offices',         officeRoutes);
+app.use('/backup',          backupRoutes);
 
 app.get('/health', (_req, res) => res.json({
   status:  'ok',

--- a/backend/src/routes/backup.js
+++ b/backend/src/routes/backup.js
@@ -1,0 +1,1177 @@
+// beacon2/backend/src/routes/backup.js
+// Data export and restore (doc 9.5)
+// Export: 8 Excel options (members, finance, groups, calendar, system, officers, settings, all)
+// Restore: auto-detects Beacon (mkey-based) vs Beacon2 (UUID-based) backup
+
+import { Router } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { tenantQuery, prisma } from '../utils/db.js';
+import multer from 'multer';
+import ExcelJS from 'exceljs';
+import { v4 as uuid } from 'uuid';
+
+const router = Router();
+router.use(requireAuth);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 50 * 1024 * 1024 },
+});
+
+// ── Utilities ──────────────────────────────────────────────────────────────────
+
+/** Parse all rows from a worksheet into plain objects (row 1 = headers) */
+function sheetRows(ws) {
+  if (!ws) return [];
+  const rows = [];
+  let headers = null;
+  ws.eachRow((row, rowNum) => {
+    const vals = row.values.slice(1); // ExcelJS rows are 1-indexed; slice removes leading undefined
+    if (rowNum === 1) {
+      headers = vals.map((v) => String(v ?? '').trim());
+    } else {
+      const obj = {};
+      headers.forEach((h, i) => { obj[h] = vals[i] ?? null; });
+      rows.push(obj);
+    }
+  });
+  return rows;
+}
+
+/** Parse date from ISO (YYYY-MM-DD) or UK (DD/MM/YYYY) string or Date → 'YYYY-MM-DD' or null */
+function parseDate(val) {
+  if (val == null) return null;
+  if (val instanceof Date) return isNaN(val.getTime()) ? null : val.toISOString().slice(0, 10);
+  const s = String(val).trim();
+  if (!s) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
+  const m = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (m) return `${m[3]}-${m[2].padStart(2, '0')}-${m[1].padStart(2, '0')}`;
+  return null;
+}
+
+function parseBool(val) {
+  return val === true || val === 1 || val === '1' || val === 'true';
+}
+
+function parseDec(val) {
+  if (val == null || val === '') return null;
+  const n = parseFloat(String(val));
+  return isNaN(n) ? null : n;
+}
+
+function str(v) {
+  if (v == null) return null;
+  const s = String(v);
+  return s === '' ? null : s;
+}
+
+function dateToStr(v) {
+  if (!v) return null;
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  return String(v).slice(0, 10) || null;
+}
+
+function boolInt(v) { return v ? 1 : 0; }
+
+/** Add a styled worksheet with given column keys and data rows */
+function addSheet(wb, name, columns, rows) {
+  const ws = wb.addWorksheet(name);
+  ws.columns = columns.map((c) => ({
+    header: c,
+    key: c,
+    width: Math.max(14, c.length + 2),
+  }));
+  ws.getRow(1).font = { bold: true };
+  ws.getRow(1).fill = {
+    type: 'pattern',
+    pattern: 'solid',
+    fgColor: { argb: 'FFD9E1F2' },
+  };
+  rows.forEach((r) => {
+    const rowData = {};
+    columns.forEach((c) => { rowData[c] = r[c] ?? null; });
+    ws.addRow(rowData);
+  });
+  return ws;
+}
+
+// ── Export: sheet builders ─────────────────────────────────────────────────────
+
+async function buildMembersSheet(wb, slug) {
+  const rows = await tenantQuery(slug, `
+    SELECT m.id, m.membership_number, m.title, m.forenames, m.surname, m.suffix,
+           m.known_as, m.initials, m.mobile, m.email, m.home_u3a,
+           m.joined_on, m.next_renewal, m.gift_aid_from, m.notes, m.hide_contact,
+           m.status_id, s.name AS status_name,
+           m.class_id, c.name AS class_name,
+           m.partner_id,
+           m.address_id, a.house_no, a.street, a.add_line1, a.add_line2,
+           a.town, a.county, a.postcode, a.telephone
+    FROM members m
+    LEFT JOIN member_statuses s ON m.status_id = s.id
+    LEFT JOIN member_classes  c ON m.class_id  = c.id
+    LEFT JOIN addresses       a ON m.address_id = a.id
+    ORDER BY m.surname, m.forenames
+  `);
+
+  addSheet(wb, 'Members', [
+    'id', 'membership_number', 'title', 'forenames', 'surname', 'suffix',
+    'known_as', 'initials', 'mobile', 'email', 'home_u3a',
+    'joined_on', 'next_renewal', 'gift_aid_from', 'notes', 'hide_contact',
+    'status_id', 'status_name', 'class_id', 'class_name', 'partner_id',
+    'address_id', 'house_no', 'street', 'add_line1', 'add_line2',
+    'town', 'county', 'postcode', 'telephone',
+  ], rows.map((r) => ({
+    ...r,
+    joined_on:    dateToStr(r.joined_on),
+    next_renewal: dateToStr(r.next_renewal),
+    gift_aid_from: dateToStr(r.gift_aid_from),
+    hide_contact: boolInt(r.hide_contact),
+  })));
+}
+
+async function buildFinanceSheets(wb, slug) {
+  const [txns, cats] = await Promise.all([
+    tenantQuery(slug, `
+      SELECT t.id, t.transaction_number, t.date, t.type, t.from_to, t.amount,
+             t.payment_method, t.payment_ref, t.detail, t.remarks, t.cleared_at,
+             t.account_id, a.name AS account_name,
+             t.member_id_1, t.member_id_2, t.group_id
+      FROM transactions t
+      LEFT JOIN finance_accounts a ON t.account_id = a.id
+      ORDER BY t.date, t.transaction_number
+    `),
+    tenantQuery(slug, `
+      SELECT tc.transaction_id, tc.category_id, c.name AS category_name, tc.amount
+      FROM transaction_categories tc
+      LEFT JOIN finance_categories c ON tc.category_id = c.id
+      ORDER BY tc.transaction_id
+    `),
+  ]);
+
+  addSheet(wb, 'Ledger', [
+    'id', 'transaction_number', 'date', 'type', 'from_to', 'amount',
+    'payment_method', 'payment_ref', 'detail', 'remarks', 'cleared_at',
+    'account_id', 'account_name', 'member_id_1', 'member_id_2', 'group_id',
+  ], txns.map((r) => ({
+    ...r,
+    date:       dateToStr(r.date),
+    cleared_at: dateToStr(r.cleared_at),
+    amount:     r.amount != null ? Number(r.amount) : null,
+  })));
+
+  addSheet(wb, 'Detail', [
+    'transaction_id', 'category_id', 'category_name', 'amount',
+  ], cats.map((r) => ({ ...r, amount: r.amount != null ? Number(r.amount) : null })));
+}
+
+async function buildGroupsSheets(wb, slug) {
+  const [groups, gm, faculties] = await Promise.all([
+    tenantQuery(slug, `
+      SELECT g.id, g.name, g.faculty_id, f.name AS faculty_name, g.status,
+             g.when_text,
+             g.start_time::text AS start_time, g.end_time::text AS end_time,
+             g.venue, g.enquiries, g.max_members,
+             g.allow_online_join, g.enable_waiting_list, g.notify_leader,
+             g.display_waiting_list, g.information, g.notes, g.show_addresses
+      FROM groups g
+      LEFT JOIN faculties f ON g.faculty_id = f.id
+      ORDER BY g.name
+    `),
+    tenantQuery(slug, `
+      SELECT gm.id, gm.group_id, g.name AS group_name,
+             gm.member_id, m.membership_number, m.forenames, m.surname,
+             gm.is_leader, gm.waiting_since
+      FROM group_members gm
+      JOIN groups  g ON gm.group_id  = g.id
+      JOIN members m ON gm.member_id = m.id
+      ORDER BY g.name, m.surname, m.forenames
+    `),
+    tenantQuery(slug, `SELECT id, name FROM faculties ORDER BY name`),
+  ]);
+
+  addSheet(wb, 'Groups', [
+    'id', 'name', 'faculty_id', 'faculty_name', 'status',
+    'when_text', 'start_time', 'end_time', 'venue', 'enquiries', 'max_members',
+    'allow_online_join', 'enable_waiting_list', 'notify_leader',
+    'display_waiting_list', 'information', 'notes', 'show_addresses',
+  ], groups.map((r) => ({
+    ...r,
+    allow_online_join:    boolInt(r.allow_online_join),
+    enable_waiting_list:  boolInt(r.enable_waiting_list),
+    notify_leader:        boolInt(r.notify_leader),
+    display_waiting_list: boolInt(r.display_waiting_list),
+    show_addresses:       boolInt(r.show_addresses),
+  })));
+
+  addSheet(wb, 'Group members', [
+    'id', 'group_id', 'group_name', 'member_id', 'membership_number',
+    'forenames', 'surname', 'is_leader', 'waiting_since',
+  ], gm.map((r) => ({
+    ...r,
+    is_leader:    boolInt(r.is_leader),
+    waiting_since: dateToStr(r.waiting_since),
+  })));
+
+  // Venues: Beacon2 stores venue as free text on group; no separate table
+  const wsV = wb.addWorksheet('Venues');
+  wsV.addRow(['note']);
+  wsV.addRow(['Beacon2 does not have a venues table. Venues are text on each group record.']);
+
+  addSheet(wb, 'Faculties', ['id', 'name'], faculties);
+}
+
+async function buildCalendarSheet(wb) {
+  const ws = wb.addWorksheet('Calendar');
+  ws.addRow(['note']);
+  ws.addRow(['Calendar is not yet implemented in Beacon2.']);
+}
+
+async function buildSystemSheets(wb, slug) {
+  const [users, roles, privs] = await Promise.all([
+    tenantQuery(slug, `SELECT id, username, name, email FROM users ORDER BY name`),
+    tenantQuery(slug, `SELECT id, name, is_committee, notes FROM roles ORDER BY name`),
+    tenantQuery(slug, `
+      SELECT rp.role_id, r.name AS role_name, rp.resource_code, rp.action
+      FROM role_privileges rp
+      JOIN roles r ON rp.role_id = r.id
+      ORDER BY r.name, rp.resource_code, rp.action
+    `),
+  ]);
+
+  addSheet(wb, 'System Users', ['id', 'username', 'name', 'email'], users);
+  addSheet(wb, 'Roles', ['id', 'name', 'is_committee', 'notes'],
+    roles.map((r) => ({ ...r, is_committee: boolInt(r.is_committee) })));
+  addSheet(wb, 'Privileges', ['role_id', 'role_name', 'resource_code', 'action'], privs);
+}
+
+async function buildOfficersSheet(wb, slug) {
+  const rows = await tenantQuery(slug, `
+    SELECT o.id, o.name, o.member_id, m.forenames AS member_forenames,
+           m.surname AS member_surname, o.office_email, o.notify_online_join
+    FROM offices o
+    LEFT JOIN members m ON o.member_id = m.id
+    ORDER BY o.name
+  `);
+
+  addSheet(wb, 'u3a Officers', [
+    'id', 'name', 'member_id', 'member_forenames', 'member_surname',
+    'office_email', 'notify_online_join',
+  ], rows.map((r) => ({ ...r, notify_online_join: boolInt(r.notify_online_join) })));
+}
+
+async function buildSettingsSheets(wb, slug) {
+  const [
+    settings, accounts, categories, classes, fees,
+    statuses, polls, pollMembers,
+  ] = await Promise.all([
+    tenantQuery(slug, `
+      SELECT card_colour, email_cards, public_phone, public_email, home_page,
+             online_join_email, online_renew_email, fee_variation,
+             extended_membership_month, advance_renewals_weeks, grace_lapse_weeks,
+             deletion_years, default_payment_method, gift_aid_enabled, gift_aid_online_renewals,
+             default_town, default_county, default_std_code,
+             paypal_email, paypal_cancel_url, shared_address_warning
+      FROM tenant_settings
+    `),
+    tenantQuery(slug, `
+      SELECT id, name, active, locked, sort_order, pending_config, pending_types, enable_refunds
+      FROM finance_accounts ORDER BY sort_order, name
+    `),
+    tenantQuery(slug, `
+      SELECT id, name, active, locked, sort_order
+      FROM finance_categories ORDER BY sort_order, name
+    `),
+    tenantQuery(slug, `
+      SELECT id, name, current, explanation, is_joint, is_associate, show_online,
+             fee, gift_aid_fee, locked
+      FROM member_classes ORDER BY name
+    `),
+    tenantQuery(slug, `
+      SELECT cmf.class_id, mc.name AS class_name, cmf.month_index, cmf.fee, cmf.gift_aid_fee
+      FROM class_monthly_fees cmf
+      JOIN member_classes mc ON cmf.class_id = mc.id
+      ORDER BY mc.name, cmf.month_index
+    `),
+    tenantQuery(slug, `SELECT id, name, locked FROM member_statuses ORDER BY name`),
+    tenantQuery(slug, `SELECT id, name, description, member_can_set FROM polls ORDER BY name`),
+    tenantQuery(slug, `
+      SELECT pm.poll_id, p.name AS poll_name, pm.member_id, m.membership_number
+      FROM poll_members pm
+      JOIN polls   p ON pm.poll_id   = p.id
+      JOIN members m ON pm.member_id = m.id
+      ORDER BY p.name
+    `),
+  ]);
+
+  const s = settings[0] || {};
+  const settingsRows = [
+    { setting: 'card_colour',               value: str(s.card_colour) },
+    { setting: 'email_cards',               value: boolInt(s.email_cards) },
+    { setting: 'public_phone',              value: str(s.public_phone) },
+    { setting: 'public_email',              value: str(s.public_email) },
+    { setting: 'home_page',                 value: str(s.home_page) },
+    { setting: 'online_join_email',         value: str(s.online_join_email) },
+    { setting: 'online_renew_email',        value: str(s.online_renew_email) },
+    { setting: 'fee_variation',             value: str(s.fee_variation) },
+    { setting: 'extended_membership_month', value: s.extended_membership_month ?? '' },
+    { setting: 'advance_renewals_weeks',    value: s.advance_renewals_weeks ?? '' },
+    { setting: 'grace_lapse_weeks',         value: s.grace_lapse_weeks ?? '' },
+    { setting: 'deletion_years',            value: s.deletion_years ?? '' },
+    { setting: 'default_payment_method',    value: str(s.default_payment_method) },
+    { setting: 'gift_aid_enabled',          value: boolInt(s.gift_aid_enabled) },
+    { setting: 'gift_aid_online_renewals',  value: boolInt(s.gift_aid_online_renewals) },
+    { setting: 'default_town',              value: str(s.default_town) },
+    { setting: 'default_county',            value: str(s.default_county) },
+    { setting: 'default_std_code',          value: str(s.default_std_code) },
+    { setting: 'paypal_email',              value: str(s.paypal_email) },
+    { setting: 'paypal_cancel_url',         value: str(s.paypal_cancel_url) },
+    { setting: 'shared_address_warning',    value: boolInt(s.shared_address_warning) },
+  ];
+  addSheet(wb, 'Site Settings 1', ['setting', 'value'], settingsRows);
+
+  // Site Settings 2: not used in Beacon2 (all settings are in Site Settings 1)
+  const ws2 = wb.addWorksheet('Site Settings 2');
+  ws2.addRow(['note']);
+  ws2.addRow(['Beacon2 stores all settings in Site Settings 1.']);
+
+  addSheet(wb, 'Finance Accounts', [
+    'id', 'name', 'active', 'locked', 'sort_order',
+    'pending_config', 'pending_types', 'enable_refunds',
+  ], accounts.map((r) => ({
+    ...r,
+    active: boolInt(r.active),
+    locked: boolInt(r.locked),
+    enable_refunds: boolInt(r.enable_refunds),
+    pending_types: JSON.stringify(r.pending_types || []),
+  })));
+
+  addSheet(wb, 'Finance Categories', [
+    'id', 'name', 'active', 'locked', 'sort_order',
+  ], categories.map((r) => ({ ...r, active: boolInt(r.active), locked: boolInt(r.locked) })));
+
+  addSheet(wb, 'Membership Classes', [
+    'id', 'name', 'current', 'explanation', 'is_joint', 'is_associate', 'show_online',
+    'fee', 'gift_aid_fee', 'locked',
+  ], classes.map((r) => ({
+    ...r,
+    current:      boolInt(r.current),
+    is_joint:     boolInt(r.is_joint),
+    is_associate: boolInt(r.is_associate),
+    show_online:  boolInt(r.show_online),
+    locked:       boolInt(r.locked),
+    fee:          r.fee != null ? Number(r.fee) : null,
+    gift_aid_fee: r.gift_aid_fee != null ? Number(r.gift_aid_fee) : null,
+  })));
+
+  addSheet(wb, 'Membership Fees', [
+    'class_id', 'class_name', 'month_index', 'fee', 'gift_aid_fee',
+  ], fees.map((r) => ({
+    ...r,
+    fee:          r.fee != null ? Number(r.fee) : null,
+    gift_aid_fee: r.gift_aid_fee != null ? Number(r.gift_aid_fee) : null,
+  })));
+
+  addSheet(wb, 'Member Statuses', ['id', 'name', 'locked'],
+    statuses.map((r) => ({ ...r, locked: boolInt(r.locked) })));
+
+  addSheet(wb, 'Polls', ['id', 'name', 'description', 'member_can_set'],
+    polls.map((r) => ({ ...r, member_can_set: boolInt(r.member_can_set) })));
+
+  addSheet(wb, 'Poll assignments', [
+    'poll_id', 'poll_name', 'member_id', 'membership_number',
+  ], pollMembers);
+
+  // System Messages not yet implemented
+  const wsSM = wb.addWorksheet('System Messages');
+  wsSM.addRow(['note']);
+  wsSM.addRow(['System Messages are not yet implemented in Beacon2.']);
+}
+
+// ── Export route ───────────────────────────────────────────────────────────────
+
+const EXPORT_TYPES = {
+  members:  'members_and_addresses',
+  finance:  'finance_ledger_with_detail',
+  groups:   'groups_members_venues_faculties',
+  calendar: 'calendar',
+  system:   'system_users_roles_privileges',
+  officers: 'u3a_officers',
+  settings: 'site_settings_and_setup',
+  all:      'beacon2_backup_all_data',
+};
+
+router.get('/export', requirePrivilege('data_export_backup', 'download'), async (req, res, next) => {
+  const { type = 'all' } = req.query;
+  if (!EXPORT_TYPES[type]) return res.status(400).json({ error: 'Invalid export type' });
+
+  const slug = req.user.tenantSlug;
+
+  try {
+    const wb = new ExcelJS.Workbook();
+    wb.creator = 'Beacon2';
+    wb.created = new Date();
+
+    const builders = {
+      members:  () => buildMembersSheet(wb, slug),
+      finance:  () => buildFinanceSheets(wb, slug),
+      groups:   () => buildGroupsSheets(wb, slug),
+      calendar: () => buildCalendarSheet(wb),
+      system:   () => buildSystemSheets(wb, slug),
+      officers: () => buildOfficersSheet(wb, slug),
+      settings: () => buildSettingsSheets(wb, slug),
+    };
+
+    if (type === 'all') {
+      for (const fn of Object.values(builders)) await fn();
+    } else {
+      await builders[type]();
+    }
+
+    const date = new Date().toISOString().slice(0, 10);
+    const filename = `${EXPORT_TYPES[type]}_${date}.xlsx`;
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ── Restore: helpers ───────────────────────────────────────────────────────────
+
+async function clearTenantData(tx) {
+  const statements = [
+    'DELETE FROM poll_members',
+    'DELETE FROM polls',
+    'DELETE FROM transaction_categories',
+    'DELETE FROM transactions',
+    'DELETE FROM offices',
+    'DELETE FROM group_members',
+    'DELETE FROM groups',
+    'DELETE FROM faculties',
+    'DELETE FROM finance_accounts',
+    'DELETE FROM finance_categories',
+    'UPDATE members SET partner_id = NULL',
+    'DELETE FROM members',
+    'DELETE FROM addresses',
+    'DELETE FROM class_monthly_fees',
+    'DELETE FROM member_classes',
+    'DELETE FROM member_statuses',
+    'DELETE FROM audit_log',
+    'DELETE FROM refresh_tokens',
+  ];
+  for (const sql of statements) {
+    await tx.$executeRawUnsafe(sql);
+  }
+}
+
+async function resetSequences(tx) {
+  await tx.$executeRawUnsafe(`
+    SELECT setval('membership_number_seq',
+      COALESCE((SELECT MAX(membership_number) FROM members), 0) + 1, false)
+  `);
+  await tx.$executeRawUnsafe(`
+    SELECT setval('transaction_number_seq',
+      COALESCE((SELECT MAX(transaction_number) FROM transactions), 0) + 1, false)
+  `);
+}
+
+// ── Restore: Beacon2 format ────────────────────────────────────────────────────
+
+async function restoreBeacon2(tx, wb) {
+  const get = (name) => sheetRows(wb.getWorksheet(name));
+
+  // 1. Member statuses
+  for (const r of get('Member Statuses')) {
+    if (!r.id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO member_statuses (id, name, locked) VALUES ($1,$2,$3) ON CONFLICT (id) DO NOTHING`,
+      r.id, String(r.name || ''), parseBool(r.locked),
+    );
+  }
+
+  // 2. Member classes
+  for (const r of get('Membership Classes')) {
+    if (!r.id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO member_classes
+         (id, name, current, explanation, is_joint, is_associate, show_online, fee, gift_aid_fee, locked)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8::numeric,$9::numeric,$10) ON CONFLICT (id) DO NOTHING`,
+      r.id, String(r.name || ''), parseBool(r.current), str(r.explanation),
+      parseBool(r.is_joint), parseBool(r.is_associate), parseBool(r.show_online),
+      parseDec(r.fee), parseDec(r.gift_aid_fee), parseBool(r.locked),
+    );
+  }
+
+  // 3. Class monthly fees
+  for (const r of get('Membership Fees')) {
+    if (!r.class_id || r.month_index == null) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO class_monthly_fees (id, class_id, month_index, fee, gift_aid_fee)
+       VALUES (gen_random_uuid()::text,$1,$2,$3::numeric,$4::numeric)
+       ON CONFLICT (class_id, month_index) DO NOTHING`,
+      r.class_id, parseInt(r.month_index), parseDec(r.fee), parseDec(r.gift_aid_fee),
+    );
+  }
+
+  // 4. Addresses (unique address_id values from Members sheet)
+  const membersData = get('Members');
+  const seenAddresses = new Set();
+  for (const r of membersData) {
+    if (!r.address_id || seenAddresses.has(r.address_id)) continue;
+    seenAddresses.add(r.address_id);
+    await tx.$executeRawUnsafe(
+      `INSERT INTO addresses (id, house_no, street, add_line1, add_line2, town, county, postcode, telephone)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) ON CONFLICT (id) DO NOTHING`,
+      r.address_id, str(r.house_no), str(r.street), str(r.add_line1), str(r.add_line2),
+      str(r.town), str(r.county), str(r.postcode), str(r.telephone),
+    );
+  }
+
+  // 5. Members (without partner_id to avoid self-ref constraint)
+  for (const r of membersData) {
+    if (!r.id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO members
+         (id, membership_number, title, forenames, surname, suffix, known_as, initials,
+          mobile, email, home_u3a, joined_on, next_renewal, gift_aid_from, notes, hide_contact,
+          status_id, class_id, address_id)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::date,$13::date,$14::date,$15,$16,$17,$18,$19)
+       ON CONFLICT (id) DO NOTHING`,
+      r.id, parseInt(r.membership_number), str(r.title),
+      String(r.forenames || ''), String(r.surname || ''),
+      str(r.suffix), str(r.known_as), str(r.initials),
+      str(r.mobile), str(r.email), str(r.home_u3a),
+      parseDate(r.joined_on), parseDate(r.next_renewal), parseDate(r.gift_aid_from),
+      str(r.notes), parseBool(r.hide_contact),
+      str(r.status_id), str(r.class_id), str(r.address_id),
+    );
+  }
+
+  // 6. Restore partner links
+  for (const r of membersData) {
+    if (!r.id || !r.partner_id) continue;
+    await tx.$executeRawUnsafe(
+      `UPDATE members SET partner_id = $1 WHERE id = $2`,
+      r.partner_id, r.id,
+    );
+  }
+
+  // 7. Faculties
+  for (const r of get('Faculties')) {
+    if (!r.id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO faculties (id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING`,
+      r.id, String(r.name || ''),
+    );
+  }
+
+  // 8. Groups
+  for (const r of get('Groups')) {
+    if (!r.id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO groups
+         (id, name, faculty_id, status, when_text, start_time, end_time, venue,
+          enquiries, max_members, allow_online_join, enable_waiting_list, notify_leader,
+          display_waiting_list, information, notes, show_addresses)
+       VALUES ($1,$2,$3,$4,$5,$6::time,$7::time,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
+       ON CONFLICT (id) DO NOTHING`,
+      r.id, String(r.name || ''), str(r.faculty_id),
+      String(r.status || 'active'), str(r.when_text),
+      str(r.start_time) || null, str(r.end_time) || null,
+      str(r.venue), str(r.enquiries),
+      r.max_members ? parseInt(r.max_members) : null,
+      parseBool(r.allow_online_join), parseBool(r.enable_waiting_list),
+      parseBool(r.notify_leader), parseBool(r.display_waiting_list),
+      str(r.information), str(r.notes), parseBool(r.show_addresses),
+    );
+  }
+
+  // 9. Group members
+  for (const r of get('Group members')) {
+    if (!r.id || !r.group_id || !r.member_id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO group_members (id, group_id, member_id, is_leader, waiting_since)
+       VALUES ($1,$2,$3,$4,$5::date) ON CONFLICT (id) DO NOTHING`,
+      r.id, r.group_id, r.member_id,
+      parseBool(r.is_leader), parseDate(r.waiting_since),
+    );
+  }
+
+  // 10. Finance Accounts
+  for (const r of get('Finance Accounts')) {
+    if (!r.id) continue;
+    let pendingTypes;
+    try { pendingTypes = JSON.parse(r.pending_types || '[]'); } catch { pendingTypes = []; }
+    const ptArr = Array.isArray(pendingTypes) ? pendingTypes : [];
+    const ptStr = '{' + ptArr.map((s) => '"' + String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"').join(',') + '}';
+    await tx.$executeRawUnsafe(
+      `INSERT INTO finance_accounts
+         (id, name, active, locked, sort_order, pending_config, pending_types, enable_refunds)
+       VALUES ($1,$2,$3,$4,$5,$6,$7::text[],$8) ON CONFLICT (id) DO NOTHING`,
+      r.id, String(r.name || ''), parseBool(r.active), parseBool(r.locked),
+      r.sort_order ? parseInt(r.sort_order) : 0,
+      String(r.pending_config || 'disabled'), ptStr, parseBool(r.enable_refunds),
+    );
+  }
+
+  // 11. Finance Categories
+  for (const r of get('Finance Categories')) {
+    if (!r.id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO finance_categories (id, name, active, locked, sort_order)
+       VALUES ($1,$2,$3,$4,$5) ON CONFLICT (id) DO NOTHING`,
+      r.id, String(r.name || ''), parseBool(r.active), parseBool(r.locked),
+      r.sort_order ? parseInt(r.sort_order) : 0,
+    );
+  }
+
+  // 12. Transactions
+  for (const r of get('Ledger')) {
+    if (!r.id || !r.account_id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO transactions
+         (id, transaction_number, account_id, date, type, from_to, amount,
+          payment_method, payment_ref, detail, remarks,
+          member_id_1, member_id_2, group_id, cleared_at)
+       VALUES ($1,$2,$3,$4::date,$5,$6,$7::numeric,$8,$9,$10,$11,$12,$13,$14,$15::date)
+       ON CONFLICT (id) DO NOTHING`,
+      r.id, parseInt(r.transaction_number), r.account_id, parseDate(r.date),
+      String(r.type || 'in'), str(r.from_to), parseDec(r.amount),
+      str(r.payment_method), str(r.payment_ref), str(r.detail), str(r.remarks),
+      str(r.member_id_1), str(r.member_id_2), str(r.group_id), parseDate(r.cleared_at),
+    );
+  }
+
+  // 13. Transaction categories
+  for (const r of get('Detail')) {
+    if (!r.transaction_id || !r.category_id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO transaction_categories (id, transaction_id, category_id, amount)
+       VALUES (gen_random_uuid()::text,$1,$2,$3::numeric)
+       ON CONFLICT (transaction_id, category_id) DO NOTHING`,
+      r.transaction_id, r.category_id, parseDec(r.amount),
+    );
+  }
+
+  // 14. Offices
+  for (const r of get('u3a Officers')) {
+    if (!r.id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO offices (id, name, member_id, office_email, notify_online_join)
+       VALUES ($1,$2,$3,$4,$5) ON CONFLICT (id) DO NOTHING`,
+      r.id, String(r.name || ''), str(r.member_id), str(r.office_email),
+      parseBool(r.notify_online_join),
+    );
+  }
+
+  // 15. Polls
+  for (const r of get('Polls')) {
+    if (!r.id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO polls (id, name, description, member_can_set)
+       VALUES ($1,$2,$3,$4) ON CONFLICT (id) DO NOTHING`,
+      r.id, String(r.name || ''), String(r.description || ''), parseBool(r.member_can_set),
+    );
+  }
+
+  // 16. Poll members
+  for (const r of get('Poll assignments')) {
+    if (!r.poll_id || !r.member_id) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO poll_members (poll_id, member_id) VALUES ($1,$2) ON CONFLICT DO NOTHING`,
+      r.poll_id, r.member_id,
+    );
+  }
+
+  // 17. Settings
+  const settingsData = get('Site Settings 1');
+  if (settingsData.length > 0) {
+    const sm = Object.fromEntries(settingsData.map((r) => [String(r.setting || ''), r.value]));
+    const v = (key) => { const val = sm[key]; return (val == null || val === '') ? null : val; };
+    const vBool = (key) => { const val = sm[key]; return val == null ? null : parseBool(val); };
+    const vInt = (key) => { const val = sm[key]; return (val != null && val !== '') ? parseInt(val) : null; };
+
+    await tx.$executeRawUnsafe(`
+      UPDATE tenant_settings SET
+        card_colour               = COALESCE($1, card_colour),
+        email_cards               = COALESCE($2, email_cards),
+        public_phone              = $3,
+        public_email              = $4,
+        home_page                 = $5,
+        online_join_email         = $6,
+        online_renew_email        = $7,
+        fee_variation             = COALESCE($8, fee_variation),
+        extended_membership_month = $9,
+        advance_renewals_weeks    = COALESCE($10, advance_renewals_weeks),
+        grace_lapse_weeks         = COALESCE($11, grace_lapse_weeks),
+        deletion_years            = COALESCE($12, deletion_years),
+        default_payment_method    = COALESCE($13, default_payment_method),
+        gift_aid_enabled          = COALESCE($14, gift_aid_enabled),
+        gift_aid_online_renewals  = COALESCE($15, gift_aid_online_renewals),
+        default_town              = $16,
+        default_county            = $17,
+        default_std_code          = $18,
+        paypal_email              = $19,
+        paypal_cancel_url         = $20,
+        shared_address_warning    = COALESCE($21, shared_address_warning)
+      WHERE id = 'singleton'`,
+      v('card_colour'), vBool('email_cards'),
+      v('public_phone'), v('public_email'), v('home_page'),
+      v('online_join_email'), v('online_renew_email'),
+      v('fee_variation'), vInt('extended_membership_month'),
+      vInt('advance_renewals_weeks'), vInt('grace_lapse_weeks'), vInt('deletion_years'),
+      v('default_payment_method'),
+      vBool('gift_aid_enabled'), vBool('gift_aid_online_renewals'),
+      v('default_town'), v('default_county'), v('default_std_code'),
+      v('paypal_email'), v('paypal_cancel_url'), vBool('shared_address_warning'),
+    );
+  }
+
+  await resetSequences(tx);
+}
+
+// ── Restore: Beacon (legacy) format ───────────────────────────────────────────
+
+// Maps Beacon numeric payment method IDs to Beacon2 payment method names
+const BEACON_PAYMENT = {
+  '1': 'Cash', '2': 'Cheque', '3': 'Standing Order',
+  '4': 'Direct Debit', '5': 'Online', '6': 'Other',
+};
+
+async function restoreBeacon(tx, wb) {
+  const get = (name) => sheetRows(wb.getWorksheet(name));
+
+  // ── Build ID maps (Beacon key → new UUID) ──────────────────────────────────
+  const statusMap  = {};  // stakey → { id, name }
+  const classMap   = {};  // mckey  → { id, name }
+  const addressMap = {};  // akey   → id
+  const memberMap  = {};  // mkey   → id
+  const memberByNo = {};  // mem_no → id
+  const facultyMap = {};  // gfkey  → id
+  const groupMap   = {};  // gkey   → id
+  const accountMap = {};  // acckey → id
+  const catMap     = {};  // catkey → id
+  const transMap   = {};  // tkey   → id
+  const pollMap    = {};  // pkey   → id
+
+  // 1. Member statuses
+  for (const r of get('Member Statuses')) {
+    const stakey = String(r.stakey || '').trim();
+    if (!stakey) continue;
+    const newId = uuid();
+    statusMap[stakey] = { id: newId, name: String(r.status || '') };
+    await tx.$executeRawUnsafe(
+      `INSERT INTO member_statuses (id, name, locked) VALUES ($1,$2,$3)`,
+      newId, String(r.status || ''), parseBool(r.locked),
+    );
+  }
+
+  // 2. Member classes
+  for (const r of get('Membership Classes')) {
+    const mckey = String(r.mckey || '').trim();
+    if (!mckey) continue;
+    const newId = uuid();
+    classMap[mckey] = { id: newId, name: String(r.class || '') };
+    await tx.$executeRawUnsafe(
+      `INSERT INTO member_classes
+         (id, name, current, is_joint, is_associate, fee, locked)
+       VALUES ($1,$2,$3,$4,$5,$6::numeric,$7)`,
+      newId, String(r.class || ''), parseBool(r.status),
+      parseBool(r.family), parseBool(r.associate),
+      parseDec(r.fee), parseBool(r.locked),
+    );
+  }
+
+  // 3. Class monthly fees (Beacon month=0 → Beacon2 month_index=13 = Renewals)
+  for (const r of get('Membership Fees')) {
+    const mckey = String(r.mckey || '').trim();
+    const cm = classMap[mckey];
+    if (!cm) continue;
+    const rawMonth = parseInt(r.month);
+    const monthIdx = rawMonth === 0 ? 13 : rawMonth;
+    if (monthIdx < 1 || monthIdx > 13) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO class_monthly_fees (id, class_id, month_index, fee)
+       VALUES (gen_random_uuid()::text,$1,$2,$3::numeric)
+       ON CONFLICT (class_id, month_index) DO NOTHING`,
+      cm.id, monthIdx, parseDec(r.fee),
+    );
+  }
+
+  // 4. Addresses (group Members sheet by unique akey)
+  const memberRows = get('Members');
+  const addrData = {};
+  for (const r of memberRows) {
+    const akey = String(r.akey || '').trim();
+    if (!akey || addrData[akey]) continue;
+    addrData[akey] = {
+      house_no: str(r.house), street:   str(r.address1),
+      add_line1: str(r.address2), add_line2: str(r.address3),
+      town: str(r.town), county: str(r.county),
+      postcode: str(r.postcode), telephone: str(r.telephone),
+    };
+  }
+  for (const [akey, data] of Object.entries(addrData)) {
+    const newId = uuid();
+    addressMap[akey] = newId;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO addresses (id, house_no, street, add_line1, add_line2, town, county, postcode, telephone)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+      newId, data.house_no, data.street, data.add_line1, data.add_line2,
+      data.town, data.county, data.postcode, data.telephone,
+    );
+  }
+
+  // 5. Members (without partner_id)
+  const statusByName = Object.fromEntries(
+    Object.values(statusMap).map((s) => [s.name.toLowerCase(), s.id]),
+  );
+  const classByName = Object.fromEntries(
+    Object.values(classMap).map((c) => [c.name.toLowerCase(), c.id]),
+  );
+  // Track who shares each akey for partner detection
+  const membersByAkey = {};
+  for (const r of memberRows) {
+    const akey = String(r.akey || '').trim();
+    if (akey) {
+      if (!membersByAkey[akey]) membersByAkey[akey] = [];
+      membersByAkey[akey].push(String(r.mkey || '').trim());
+    }
+  }
+
+  for (const r of memberRows) {
+    const mkey = String(r.mkey || '').trim();
+    if (!mkey) continue;
+    const newId = uuid();
+    memberMap[mkey] = newId;
+    const memNo = parseInt(r.mem_no);
+    if (!isNaN(memNo)) memberByNo[memNo] = newId;
+
+    const akey = String(r.akey || '').trim();
+    const statusId = statusByName[String(r.status || '').toLowerCase()] || null;
+    const classId  = classByName[String(r.class  || '').toLowerCase()] || null;
+
+    await tx.$executeRawUnsafe(
+      `INSERT INTO members
+         (id, membership_number, title, forenames, surname, suffix, known_as, initials,
+          mobile, email, home_u3a, joined_on, next_renewal, gift_aid_from, notes, hide_contact,
+          status_id, class_id, address_id)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::date,$13::date,$14::date,$15,$16,$17,$18,$19)`,
+      newId, isNaN(memNo) ? 0 : memNo, str(r.title),
+      String(r.forename || ''), String(r.surname || ''),
+      str(r.suffix), str(r.known_as), str(r.initials),
+      str(r.mobile), str(r['e-mail']), str(r.affiliation),
+      parseDate(r.joined), parseDate(r.renew), parseDate(r.gift_aid),
+      str(r.mem_notes), parseBool(r.enhanced_privacy),
+      statusId, classId, akey ? (addressMap[akey] || null) : null,
+    );
+  }
+
+  // 6. Partner links (exactly 2 members sharing an akey → mark as partners)
+  for (const mkeyList of Object.values(membersByAkey)) {
+    if (mkeyList.length !== 2) continue;
+    const [id1, id2] = [memberMap[mkeyList[0]], memberMap[mkeyList[1]]];
+    if (!id1 || !id2) continue;
+    await tx.$executeRawUnsafe(`UPDATE members SET partner_id = $1 WHERE id = $2`, id2, id1);
+    await tx.$executeRawUnsafe(`UPDATE members SET partner_id = $1 WHERE id = $2`, id1, id2);
+  }
+
+  // 7. Faculties
+  const facRows = get('Faculties');
+  for (const r of facRows) {
+    const gfkey = String(r.gfkey || '').trim();
+    if (!gfkey) continue;
+    const newId = uuid();
+    facultyMap[gfkey] = newId;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO faculties (id, name) VALUES ($1,$2)`,
+      newId, String(r.faculty || ''),
+    );
+  }
+  const facultyByName = Object.fromEntries(
+    facRows.map((r) => [String(r.faculty || '').trim().toLowerCase(), facultyMap[String(r.gfkey || '').trim()]]),
+  );
+
+  // 8. Groups (deduplicate by gkey — Groups sheet may have multiple rows per group for each leader)
+  const groupRows = get('Groups');
+  const seenGroups = new Set();
+  // Build group name→id map for ledger lookup later
+  const groupByName = {};
+  for (const r of groupRows) {
+    const gkey = String(r.gkey || '').trim();
+    if (!gkey || seenGroups.has(gkey)) continue;
+    seenGroups.add(gkey);
+    const newId = uuid();
+    groupMap[gkey] = newId;
+    groupByName[String(r.group_name || '').trim().toLowerCase()] = newId;
+
+    const facId = facultyByName[String(r.faculty || '').trim().toLowerCase()] || null;
+    const isActive = String(r.status || '').toLowerCase() !== 'inactive';
+
+    await tx.$executeRawUnsafe(
+      `INSERT INTO groups
+         (id, name, faculty_id, status, when_text, start_time, end_time, venue, enquiries,
+          max_members, allow_online_join, enable_waiting_list, notify_leader)
+       VALUES ($1,$2,$3,$4,$5,$6::time,$7::time,$8,$9,$10,$11,$12,$13)`,
+      newId, String(r.group_name || ''), facId,
+      isActive ? 'active' : 'inactive',
+      str(r.meets_when), str(r.start_time) || null, str(r.end_time) || null,
+      str(r.venue), str(r.contact),
+      r.max_members ? parseInt(r.max_members) : null,
+      parseBool(r.join_online), parseBool(r.waiting_list), parseBool(r.notify_leader),
+    );
+  }
+
+  // 9. Group members
+  const seenGm = new Set();
+  for (const r of get('Group members')) {
+    const gkey  = String(r.gkey || '').trim();
+    const memNo = parseInt(r.mem_no);
+    const groupId  = groupMap[gkey];
+    const memberId = isNaN(memNo) ? null : memberByNo[memNo];
+    if (!groupId || !memberId) continue;
+    const gmKey = `${groupId}:${memberId}`;
+    if (seenGm.has(gmKey)) continue;
+    seenGm.add(gmKey);
+
+    const waitingRaw = str(r.waiting);
+    const waitingDate = (waitingRaw && waitingRaw !== '0') ? parseDate(waitingRaw) : null;
+
+    await tx.$executeRawUnsafe(
+      `INSERT INTO group_members (id, group_id, member_id, is_leader, waiting_since)
+       VALUES (gen_random_uuid()::text,$1,$2,$3,$4::date)
+       ON CONFLICT (group_id, member_id) DO NOTHING`,
+      groupId, memberId, parseBool(r.leader), waitingDate,
+    );
+  }
+
+  // 10. Finance Accounts
+  const accRows = get('Finance Accounts');
+  for (const r of accRows) {
+    const acckey = String(r.acckey || '').trim();
+    if (!acckey) continue;
+    const newId = uuid();
+    accountMap[acckey] = newId;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO finance_accounts (id, name, active, locked) VALUES ($1,$2,$3,$4)`,
+      newId, String(r.name || ''), parseBool(r.status), parseBool(r.locked),
+    );
+  }
+  const accountByName = Object.fromEntries(
+    accRows
+      .filter((r) => String(r.acckey || '').trim())
+      .map((r) => [String(r.name || '').trim().toLowerCase(), accountMap[String(r.acckey || '').trim()]]),
+  );
+
+  // 11. Finance Categories
+  const catRows = get('Finance Categories');
+  for (const r of catRows) {
+    const catkey = String(r.catkey || '').trim();
+    if (!catkey) continue;
+    const newId = uuid();
+    catMap[catkey] = newId;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO finance_categories (id, name, active, locked) VALUES ($1,$2,$3,$4)`,
+      newId, String(r.name || ''), parseBool(r.status), parseBool(r.locked),
+    );
+  }
+  const catByName = Object.fromEntries(
+    catRows
+      .filter((r) => String(r.catkey || '').trim())
+      .map((r) => [String(r.name || '').trim().toLowerCase(), catMap[String(r.catkey || '').trim()]]),
+  );
+
+  // 12. Transactions (Beacon: positive amount = in, negative = out)
+  for (const r of get('Ledger')) {
+    const tkey = String(r.tkey || '').trim();
+    if (!tkey) continue;
+    const rawAmount = parseDec(r.amount);
+    if (rawAmount == null) continue;
+    const type   = rawAmount >= 0 ? 'in' : 'out';
+    const amount = Math.abs(rawAmount);
+    const acctId = accountByName[String(r.account || '').trim().toLowerCase()] || null;
+    if (!acctId) continue;
+
+    const newId = uuid();
+    transMap[tkey] = newId;
+
+    const groupId  = r.group ? (groupByName[String(r.group || '').trim().toLowerCase()] || null) : null;
+    const mem1Id   = r.member_1 ? (memberByNo[parseInt(r.member_1)] || null) : null;
+    const mem2Id   = r.member_2 ? (memberByNo[parseInt(r.member_2)] || null) : null;
+    const clearedAt = r.cleared ? parseDate(r.cleared) : null;
+
+    await tx.$executeRawUnsafe(
+      `INSERT INTO transactions
+         (id, transaction_number, account_id, date, type, from_to, amount,
+          payment_method, payment_ref, detail, remarks,
+          member_id_1, member_id_2, group_id, cleared_at)
+       VALUES ($1,$2,$3,$4::date,$5,$6,$7::numeric,$8,$9,$10,$11,$12,$13,$14,$15::date)`,
+      newId, parseInt(r.trans_no), acctId, parseDate(r.date),
+      type, str(r.payee), amount,
+      str(r.payment_method), str(r.cheque), str(r.detail), str(r.notes),
+      mem1Id, mem2Id, groupId, clearedAt,
+    );
+  }
+
+  // 13. Transaction categories
+  for (const r of get('Detail')) {
+    const tkey = String(r.tkey || '').trim();
+    const txnId = transMap[tkey];
+    if (!txnId) continue;
+    const catId = catByName[String(r.category || '').trim().toLowerCase()] || null;
+    if (!catId) continue;
+    const rawAmt = parseDec(r.amount);
+    if (rawAmt == null) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO transaction_categories (id, transaction_id, category_id, amount)
+       VALUES (gen_random_uuid()::text,$1,$2,$3::numeric)
+       ON CONFLICT (transaction_id, category_id) DO NOTHING`,
+      txnId, catId, Math.abs(rawAmt),
+    );
+  }
+
+  // 14. Offices
+  for (const r of get('u3a Officers')) {
+    const ofkey = String(r.ofkey || '').trim();
+    if (!ofkey) continue;
+    const mkey    = String(r.mkey || '').trim();
+    const memberId = mkey ? (memberMap[mkey] || null) : null;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO offices (id, name, member_id, office_email) VALUES ($1,$2,$3,$4)`,
+      uuid(), String(r.office || ''), memberId, str(r['e-mail']),
+    );
+  }
+
+  // 15. Polls
+  for (const r of get('Polls')) {
+    const pkey = String(r.pkey || '').trim();
+    if (!pkey) continue;
+    const newId = uuid();
+    pollMap[pkey] = newId;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO polls (id, name, description, member_can_set) VALUES ($1,$2,$3,$4)`,
+      newId, String(r.poll || ''), '', false,
+    );
+  }
+
+  // 16. Poll assignments
+  for (const r of get('Poll assignments')) {
+    const pkey = String(r.pkey || '').trim();
+    const mkey = String(r.mkey || '').trim();
+    const pollId   = pollMap[pkey];
+    const memberId = memberMap[mkey];
+    if (!pollId || !memberId) continue;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO poll_members (poll_id, member_id) VALUES ($1,$2) ON CONFLICT DO NOTHING`,
+      pollId, memberId,
+    );
+  }
+
+  // 17. Settings from Beacon Site Settings 1
+  const ss1 = get('Site Settings 1');
+  const ss1Map = Object.fromEntries(ss1.map((r) => [String(r.name || ''), String(r.value ?? '')]));
+
+  const updates = {
+    advance_renewals_weeks:   ss1Map['AdvRenewals']          ? parseInt(ss1Map['AdvRenewals'])          : null,
+    grace_lapse_weeks:        ss1Map['GraceLapse']           ? parseInt(ss1Map['GraceLapse'])           : null,
+    gift_aid_enabled:         ss1Map['GiftAidEnable']    != null ? ss1Map['GiftAidEnable'] === '1'     : null,
+    gift_aid_online_renewals: ss1Map['GiftAidOnlineRenew'] != null ? ss1Map['GiftAidOnlineRenew'] === '1' : null,
+    default_town:             ss1Map['DefaultTown']  || null,
+    default_county:           ss1Map['DefaultCounty'] || null,
+    default_std_code:         ss1Map['DefaultSTD']   || null,
+    default_payment_method:   BEACON_PAYMENT[ss1Map['defaultPaymentMethod']] || null,
+    public_phone:             ss1Map['EnqTelephone'] || null,
+    public_email:             ss1Map['EnqEmail']     || null,
+    online_join_email:        ss1Map['EnqNewMem']    || null,
+    online_renew_email:       ss1Map['EnqRenew']     || null,
+  };
+
+  const setClauses = [];
+  const params = [];
+  let pi = 1;
+  for (const [col, val] of Object.entries(updates)) {
+    if (val !== null) {
+      setClauses.push(`${col} = $${pi++}`);
+      params.push(val);
+    }
+  }
+  if (setClauses.length > 0) {
+    await tx.$executeRawUnsafe(
+      `UPDATE tenant_settings SET ${setClauses.join(', ')} WHERE id = 'singleton'`,
+      ...params,
+    );
+  }
+
+  // PayPal from Site Settings 2
+  const ss2 = get('Site Settings 2');
+  const ss2Map = Object.fromEntries(ss2.map((r) => [String(r.setting || ''), String(r.value ?? '')]));
+  if (ss2Map['paypal_account']) {
+    await tx.$executeRawUnsafe(
+      `UPDATE tenant_settings SET paypal_email = $1 WHERE id = 'singleton'`,
+      ss2Map['paypal_account'],
+    );
+  }
+
+  await resetSequences(tx);
+}
+
+// ── Restore route ──────────────────────────────────────────────────────────────
+
+router.post(
+  '/restore',
+  requirePrivilege('data_export_backup', 'restore'),
+  upload.single('backup'),
+  async (req, res, next) => {
+    if (!req.file) return res.status(400).json({ error: 'No file uploaded' });
+
+    try {
+      const wb = new ExcelJS.Workbook();
+      await wb.xlsx.load(req.file.buffer);
+
+      const membersWs = wb.getWorksheet('Members');
+      if (!membersWs) {
+        return res.status(400).json({ error: 'Invalid backup file: no Members sheet found' });
+      }
+
+      // Detect format from first column header of Members sheet
+      const firstCol = String((membersWs.getRow(1).values || [])[1] ?? '').trim();
+      let format;
+      if (firstCol === 'mkey')      format = 'beacon';
+      else if (firstCol === 'id')   format = 'beacon2';
+      else return res.status(400).json({
+        error: `Cannot determine backup format (Members first column: "${firstCol}")`,
+      });
+
+      const slug   = req.user.tenantSlug;
+      const schema = `u3a_${slug}`;
+
+      await prisma.$transaction(
+        async (tx) => {
+          await tx.$executeRawUnsafe(`SET search_path TO ${schema}, public`);
+          await clearTenantData(tx);
+          if (format === 'beacon2') {
+            await restoreBeacon2(tx, wb);
+          } else {
+            await restoreBeacon(tx, wb);
+          }
+        },
+        { timeout: 300_000 }, // 5-minute timeout for large backups
+      );
+
+      res.json({
+        ok: true,
+        format,
+        message: `Data restored successfully from ${format === 'beacon' ? 'Beacon' : 'Beacon2'} backup.`,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/backend/src/seed/defaultRoles.js
+++ b/backend/src/seed/defaultRoles.js
@@ -28,6 +28,7 @@ export const DEFAULT_ROLES = [
       { code: 'calendar',                 action: 'download' },           // vo
       { code: 'data_export_backup',       action: 'view' },
       { code: 'data_export_backup',       action: 'download' },           // vo
+      { code: 'data_export_backup',       action: 'restore' },
 
       // Email
       { code: 'email',                    action: 'view' },

--- a/backend/src/seed/privilegeResources.js
+++ b/backend/src/seed/privilegeResources.js
@@ -14,7 +14,7 @@ export const PRIVILEGE_RESOURCES = [
   r('audit_detail',              'Audit detail',                    ['view']),
   r('audit_trail',               'Audit trail',                     ['view', 'delete']),
   r('calendar',                  'Calendar',                        ['view', 'download']),
-  r('data_export_backup',        'Data export + backup',            ['view', 'download']),
+  r('data_export_backup',        'Data export + backup',            ['view', 'download', 'restore']),
   r('email',                     'E-mail',                          ['view', 'send']),
   r('email_addresses',           'E-mail addresses',                ['download']),
   r('email_delivery',            'E-mail delivery',                 ['view', 'all']),

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,7 @@ import MemberValidator    from './pages/admin/MemberValidator.jsx';
 import PollList           from './pages/admin/PollList.jsx';
 import AuditLog           from './pages/misc/AuditLog.jsx';
 import OfficerList        from './pages/misc/OfficerList.jsx';
+import DataBackup         from './pages/misc/DataBackup.jsx';
 import PersonalPreferences from './pages/settings/PersonalPreferences.jsx';
 
 function ProtectedRoute({ children }) {
@@ -74,6 +75,7 @@ export default function App() {
           <Route path="/polls"                               element={<ProtectedRoute><PollList /></ProtectedRoute>} />
           <Route path="/audit"                               element={<ProtectedRoute><AuditLog /></ProtectedRoute>} />
           <Route path="/officers"                            element={<ProtectedRoute><OfficerList /></ProtectedRoute>} />
+          <Route path="/backup"                              element={<ProtectedRoute><DataBackup /></ProtectedRoute>} />
           <Route path="/preferences"                         element={<ProtectedRoute><PersonalPreferences /></ProtectedRoute>} />
         </Routes>
       </BrowserRouter>

--- a/frontend/src/__tests__/DataBackup.test.jsx
+++ b/frontend/src/__tests__/DataBackup.test.jsx
@@ -1,0 +1,51 @@
+// beacon2/frontend/src/__tests__/DataBackup.test.jsx
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DataBackup from '../pages/misc/DataBackup.jsx';
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({ tenant: 'test-u3a', can: vi.fn().mockReturnValue(true) }),
+}));
+
+vi.mock('../lib/api.js', () => ({
+  backup: {
+    export:  vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue({ ok: true, format: 'beacon2', message: 'Restored.' }),
+  },
+}));
+
+describe('DataBackup page', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<MemoryRouter><DataBackup /></MemoryRouter>);
+    expect(container).toBeTruthy();
+  });
+
+  it('shows the page heading', () => {
+    const { getAllByText } = render(<MemoryRouter><DataBackup /></MemoryRouter>);
+    expect(getAllByText('Data Export & Backup').length).toBeGreaterThan(0);
+  });
+
+  it('shows all 7 individual export options', () => {
+    const { getByText } = render(<MemoryRouter><DataBackup /></MemoryRouter>);
+    expect(getByText('Members and addresses')).toBeInTheDocument();
+    expect(getByText('Finance ledger with detail')).toBeInTheDocument();
+    expect(getByText('Groups, with members, venues and faculties')).toBeInTheDocument();
+    expect(getByText('Calendar')).toBeInTheDocument();
+    expect(getByText('System users, roles and privileges')).toBeInTheDocument();
+    expect(getByText('u3a Officers')).toBeInTheDocument();
+    expect(getByText('Site settings and set up')).toBeInTheDocument();
+  });
+
+  it('shows the Backup all data button', () => {
+    const { getAllByText } = render(<MemoryRouter><DataBackup /></MemoryRouter>);
+    expect(getAllByText('Backup all data').length).toBeGreaterThan(0);
+  });
+
+  it('shows the restore section with warning', () => {
+    const { getByText } = render(<MemoryRouter><DataBackup /></MemoryRouter>);
+    expect(getByText('Restore from Backup')).toBeInTheDocument();
+    expect(getByText(/permanently delete all current data/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -311,3 +311,67 @@ export const offices = {
   update:      (id, data) => request(`/offices/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   delete:      (id)       => request(`/offices/${id}`, { method: 'DELETE' }),
 };
+
+// ─── Backup ────────────────────────────────────────────────────────────────
+
+/** Download an export as a blob (sends auth header, triggers browser download) */
+async function requestBlob(path, filename) {
+  const headers = {
+    ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+    ...(tenantSlug  && { 'x-tenant-slug': tenantSlug }),
+  };
+  const res = await fetch(`${BASE}${path}`, { headers, credentials: 'include' });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new ApiError(body.error ?? `HTTP ${res.status}`, res.status, body);
+  }
+  const blob = await res.blob();
+  const url  = URL.createObjectURL(blob);
+  const a    = document.createElement('a');
+  a.href     = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/** Upload a backup file (multipart) — no Content-Type header so browser sets it with boundary */
+async function requestMultipart(path, formData) {
+  const headers = {
+    ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+    ...(tenantSlug  && { 'x-tenant-slug': tenantSlug }),
+  };
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST', body: formData, headers, credentials: 'include',
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new ApiError(body.error ?? `HTTP ${res.status}`, res.status, body);
+  }
+  return res.json();
+}
+
+const EXPORT_FILENAMES = {
+  members:  'members_and_addresses',
+  finance:  'finance_ledger_with_detail',
+  groups:   'groups_members_venues_faculties',
+  calendar: 'calendar',
+  system:   'system_users_roles_privileges',
+  officers: 'u3a_officers',
+  settings: 'site_settings_and_setup',
+  all:      'beacon2_backup_all_data',
+};
+
+export const backup = {
+  export: (type) => {
+    const date = new Date().toISOString().slice(0, 10);
+    const base = EXPORT_FILENAMES[type] || type;
+    return requestBlob(`/backup/export?type=${type}`, `${base}_${date}.xlsx`);
+  },
+  restore: (file) => {
+    const form = new FormData();
+    form.append('backup', file);
+    return requestMultipart('/backup/restore', form);
+  },
+};

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -58,7 +58,7 @@ export default function Home() {
         { label: 'Gift aid log',          to: null },
         { label: 'u3a Officers',          to: can('offices', 'view') ? '/officers' : null },
         { label: 'Public links',          to: null },
-        { label: 'Data export & backup',  to: null },
+        { label: 'Data export & backup',  to: can('data_export_backup', 'view') ? '/backup' : null },
         { label: 'E-mail delivery',       to: null },
         { label: 'Personal preferences',  to: '/preferences' },
         { label: 'Validate member data',  to: can('member_data_validation', 'view') ? '/admin/validate-members' : null },

--- a/frontend/src/pages/misc/DataBackup.jsx
+++ b/frontend/src/pages/misc/DataBackup.jsx
@@ -1,0 +1,303 @@
+// beacon2/frontend/src/pages/misc/DataBackup.jsx
+// Data Export & Backup (doc 9.5)
+// Provides 8 Excel export options and a restore facility.
+// Restore auto-detects Beacon (legacy) vs Beacon2 format from the uploaded file.
+
+import { useState, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import PageHeader from '../../components/PageHeader.jsx';
+import NavBar from '../../components/NavBar.jsx';
+import { useAuth } from '../../context/AuthContext.jsx';
+import { backup as backupApi } from '../../lib/api.js';
+
+const EXPORT_OPTIONS = [
+  {
+    type: 'members',
+    label: 'Members and addresses',
+    desc: 'All member records including address details.',
+    sheets: 'Members',
+  },
+  {
+    type: 'finance',
+    label: 'Finance ledger with detail',
+    desc: 'All transactions and category splits.',
+    sheets: 'Ledger, Detail',
+  },
+  {
+    type: 'groups',
+    label: 'Groups, with members, venues and faculties',
+    desc: 'Group records, membership lists, and faculties.',
+    sheets: 'Groups, Group members, Venues, Faculties',
+  },
+  {
+    type: 'calendar',
+    label: 'Calendar',
+    desc: 'Calendar events (not yet implemented in Beacon2).',
+    sheets: 'Calendar',
+  },
+  {
+    type: 'system',
+    label: 'System users, roles and privileges',
+    desc: 'User accounts, roles, and privilege assignments.',
+    sheets: 'System Users, Roles, Privileges',
+  },
+  {
+    type: 'officers',
+    label: 'u3a Officers',
+    desc: 'Office holders and their contact details.',
+    sheets: 'u3a Officers',
+  },
+  {
+    type: 'settings',
+    label: 'Site settings and set up',
+    desc: 'System settings, finance accounts/categories, classes, statuses, polls.',
+    sheets: 'Site Settings 1/2, Finance Accounts/Categories, Membership Classes/Fees, Member Statuses, Polls, Poll assignments, System Messages',
+  },
+];
+
+export default function DataBackup() {
+  const { tenant } = useAuth();
+
+  // Export state: track which type is downloading
+  const [downloading, setDownloading] = useState(null);
+  const [exportError, setExportError] = useState('');
+
+  // Restore state
+  const fileRef       = useRef(null);
+  const [file, setFile]           = useState(null);
+  const [restoring, setRestoring] = useState(false);
+  const [restoreResult, setRestoreResult] = useState(null); // { ok, format, message } | null
+  const [restoreError, setRestoreError]   = useState('');
+  const [confirmOpen, setConfirmOpen]     = useState(false);
+
+  async function handleExport(type) {
+    setExportError('');
+    setDownloading(type);
+    try {
+      await backupApi.export(type);
+    } catch (err) {
+      setExportError(err.message || 'Download failed');
+    } finally {
+      setDownloading(null);
+    }
+  }
+
+  function handleFileChange(e) {
+    const f = e.target.files[0] || null;
+    setFile(f);
+    setRestoreResult(null);
+    setRestoreError('');
+  }
+
+  function handleRestoreClick() {
+    if (!file) return;
+    setConfirmOpen(true);
+  }
+
+  async function handleConfirmRestore() {
+    setConfirmOpen(false);
+    setRestoring(true);
+    setRestoreResult(null);
+    setRestoreError('');
+    try {
+      const result = await backupApi.restore(file);
+      setRestoreResult(result);
+      setFile(null);
+      if (fileRef.current) fileRef.current.value = '';
+    } catch (err) {
+      setRestoreError(err.message || 'Restore failed');
+    } finally {
+      setRestoring(false);
+    }
+  }
+
+  const btnBase = 'inline-flex items-center gap-2 rounded px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
+  const btnPrimary = `${btnBase} bg-blue-600 hover:bg-blue-700 text-white`;
+  const btnGreen   = `${btnBase} bg-green-600 hover:bg-green-700 text-white`;
+
+  return (
+    <div className="min-h-screen pb-10">
+      <PageHeader tenant={tenant} />
+      <NavBar links={[{ label: 'Home', to: '/' }, { label: 'Data Export & Backup' }]} />
+
+      <div className="max-w-3xl mx-auto px-4 mt-6 space-y-8">
+
+        {/* ── Export ──────────────────────────────────────────────────────── */}
+        <section className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6">
+          <h1 className="text-xl font-bold text-slate-800 mb-1">Data Export &amp; Backup</h1>
+          <p className="text-sm text-slate-600 mb-5">
+            Download your data as an Excel spreadsheet. Files may contain personal
+            information — encrypt them if stored externally (e.g. with Excel&apos;s
+            Protect Workbook or 7-zip).
+          </p>
+
+          {exportError && (
+            <div className="mb-4 rounded-md bg-red-50 border border-red-300 px-4 py-3 text-red-700 text-sm font-medium">
+              {exportError}
+            </div>
+          )}
+
+          {/* Individual options */}
+          <div className="space-y-3 mb-6">
+            {EXPORT_OPTIONS.map(({ type, label, desc, sheets }) => (
+              <div
+                key={type}
+                className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 border border-slate-200 rounded-md px-4 py-3"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-slate-800 text-sm">{label}</div>
+                  <div className="text-xs text-slate-500 mt-0.5">{desc}</div>
+                  <div className="text-xs text-slate-400 mt-0.5">Sheets: {sheets}</div>
+                </div>
+                <button
+                  onClick={() => handleExport(type)}
+                  disabled={downloading !== null}
+                  className={`${btnPrimary} shrink-0`}
+                >
+                  {downloading === type ? (
+                    <span className="animate-spin inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                  )}
+                  Download
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {/* Backup all data */}
+          <div className="border-2 border-blue-200 bg-blue-50 rounded-md px-4 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+            <div>
+              <div className="font-semibold text-blue-800 text-sm">Backup all data</div>
+              <div className="text-xs text-blue-700 mt-0.5">
+                All of the above combined in a single spreadsheet. Best option for a full backup.
+              </div>
+            </div>
+            <button
+              onClick={() => handleExport('all')}
+              disabled={downloading !== null}
+              className={`${btnGreen} shrink-0`}
+            >
+              {downloading === 'all' ? (
+                <span className="animate-spin inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
+              ) : (
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+              )}
+              Backup all data
+            </button>
+          </div>
+        </section>
+
+        {/* ── Restore ─────────────────────────────────────────────────────── */}
+        <section className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6">
+          <h2 className="text-lg font-bold text-slate-800 mb-1">Restore from Backup</h2>
+          <p className="text-sm text-slate-600 mb-1">
+            Upload a Beacon2 backup or a legacy Beacon export file. The system will
+            detect the format automatically.
+          </p>
+          <p className="text-sm text-slate-600 mb-4">
+            <strong>Note:</strong> System user accounts and roles are not affected by a
+            restore — only member, group, finance, settings, and related data is replaced.
+          </p>
+
+          <div className="rounded-md bg-amber-50 border border-amber-300 px-4 py-3 text-amber-800 text-sm mb-5">
+            <strong>Warning:</strong> Restoring will <strong>permanently delete all current data</strong> for
+            this u3a and replace it with the contents of the uploaded file. This cannot be undone.
+          </div>
+
+          {restoreError && (
+            <div className="mb-4 rounded-md bg-red-50 border border-red-300 px-4 py-3 text-red-700 text-sm font-medium">
+              {restoreError}
+            </div>
+          )}
+
+          {restoreResult && (
+            <div className="mb-4 rounded-md bg-green-50 border border-green-300 px-4 py-3 text-green-800 text-sm font-medium">
+              ✓ {restoreResult.message}
+              {restoreResult.format === 'beacon' && (
+                <span className="ml-2 text-xs font-normal">(migrated from Beacon)</span>
+              )}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">
+                Select backup file (.xlsx)
+              </label>
+              <input
+                ref={fileRef}
+                type="file"
+                accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                onChange={handleFileChange}
+                className="block text-sm text-slate-600
+                  file:mr-3 file:py-2 file:px-4 file:rounded file:border-0
+                  file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700
+                  hover:file:bg-blue-100"
+              />
+              {file && (
+                <p className="text-xs text-slate-500 mt-1">{file.name} ({(file.size / 1024).toFixed(0)} KB)</p>
+              )}
+            </div>
+
+            <button
+              onClick={handleRestoreClick}
+              disabled={!file || restoring}
+              className={`${btnBase} bg-red-600 hover:bg-red-700 text-white disabled:bg-red-300`}
+            >
+              {restoring ? (
+                <>
+                  <span className="animate-spin inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
+                  Restoring…
+                </>
+              ) : (
+                'Restore from this file'
+              )}
+            </button>
+          </div>
+        </section>
+
+        <div className="text-sm text-center">
+          <Link to="/" className="text-blue-700 hover:underline">← Back to Home</Link>
+        </div>
+      </div>
+
+      {/* ── Confirmation modal ────────────────────────────────────────────── */}
+      {confirmOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-lg shadow-xl p-6 max-w-md mx-4">
+            <h3 className="text-lg font-bold text-slate-800 mb-3">Confirm restore</h3>
+            <p className="text-sm text-slate-600 mb-2">
+              You are about to restore from:
+            </p>
+            <p className="text-sm font-medium text-slate-800 bg-slate-100 rounded px-3 py-2 mb-4 break-all">
+              {file?.name}
+            </p>
+            <p className="text-sm text-red-700 font-medium mb-5">
+              All current member, group, and finance data will be permanently deleted and
+              replaced. This cannot be undone.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setConfirmOpen(false)}
+                className="border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-5 py-2 text-sm"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmRestore}
+                className="bg-red-600 hover:bg-red-700 text-white rounded px-5 py-2 text-sm font-medium"
+              >
+                Yes, restore now
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Implements all 8 Excel export options and a restore facility that auto-detects Beacon (legacy mkey/gkey) vs Beacon2 (UUID) format.

Export (GET /backup/export?type=):
  members, finance, groups, calendar, system, officers, settings, all

Restore (POST /backup/restore):
  - Full replace (all member/group/finance/settings data)
  - Beacon format: maps old numeric keys to new UUIDs, detects partners via shared akey, maps Site Settings to Beacon2 columns
  - Beacon2 format: preserves UUIDs, restores in FK dependency order
  - Runs in single 5-minute prisma transaction for atomicity
  - User accounts and roles are NOT affected by restore

Libraries: exceljs + multer added to backend.

https://claude.ai/code/session_01WdSsJg1nZ4vKZB2ncxM2Ej