### PR TITLE
fix(e2e): read test tenant slug from .e2e-state.json in auth tests

### DIFF
--- a/e2e/tests/01-auth.spec.js
+++ b/e2e/tests/01-auth.spec.js
@@ -9,12 +9,24 @@
 //  ✓ Logout           → returns to /login, home redirects back to /login
 
 import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { config as loadDotenv } from 'dotenv';
 import { LoginPage } from '../pages/LoginPage.js';
 import { HomePage } from '../pages/HomePage.js';
 loadDotenv();
 
-const SLUG     = process.env.BEACON2_TEST_TENANT_SLUG    ?? 'e2etest';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readSlug() {
+  try {
+    const state = JSON.parse(readFileSync(resolve(__dirname, '../.e2e-state.json'), 'utf8'));
+    return state.slug;
+  } catch { /* state file missing — use env/default */ }
+  return process.env.BEACON2_TEST_TENANT_SLUG ?? 'e2etest';
+}
+const SLUG     = readSlug();
 const USERNAME = process.env.BEACON2_TEST_ADMIN_USERNAME ?? 'testadmin';
 const PASSWORD = process.env.BEACON2_TEST_ADMIN_PASSWORD ?? 'TestAdmin99!';
 


### PR DESCRIPTION
The global setup generates a random slug (e2e_<hash>) and writes it to .e2e-state.json, but 01-auth.spec.js was hardcoded to fall back to 'e2etest' from the env var only. This caused every auth test to fail because it tried to log in with a non-existent tenant slug.

Use the same readSlug() pattern as fixtures/admin.js: read the state file first, then fall back to the env var.

https://claude.ai/code/session_011E5xj4XkVJejmPyH8o2EzH