### PR TITLE
Set cookie consent to 'accepted' so session restores after page reloads

### DIFF
--- a/e2e/global-setup.js
+++ b/e2e/global-setup.js
@@ -213,7 +213,7 @@ export default async function globalSetup() {
   const storageState = {
     cookies: [{
       name: 'beacon2_cookie_consent',
-      value: 'declined',
+      value: 'accepted',
       domain: baseURL.hostname,
       path: '/',
       expires: -1,


### PR DESCRIPTION
The adminPage fixture logs in via the browser, but subsequent page.goto() calls trigger full page reloads that lose the in-memory auth token. Session restoration requires the beacon_last_u3a cookie, which is only set when optional cookies are accepted. With consent set to 'declined', the cookie was never written, so ProtectedRoute redirected to /login on every full navigation — causing all member list tests to time out.

https://claude.ai/code/session_01PWTcKbfGFiX1qQjRqfn2TZ