### PR TITLE
Fix E2E member creation: status select doesn't exist for new members

### DIFF
--- a/e2e/pages/MemberEditorPage.js
+++ b/e2e/pages/MemberEditorPage.js
@@ -11,39 +11,13 @@ export class MemberEditorPage {
   async gotoNew() {
     // Prefer SPA link-click navigation to preserve the in-memory auth token.
     // page.goto() causes a full page reload which loses auth state.
-    const currentUrl = this.page.url();
-    console.log(`[MemberEditorPage.gotoNew] Current URL before navigation: ${currentUrl}`);
-
-    const debugInfo = await this.page.evaluate(() => {
-      const link = document.querySelector('a[href="/members/new"]');
-      const allLinks = [...document.querySelectorAll('a')].map(a => a.getAttribute('href')).slice(0, 20);
-      return { found: !!link, allLinks, bodyLength: document.body.innerHTML.length };
-    });
-    console.log(`[MemberEditorPage.gotoNew] Link found: ${debugInfo.found}, body length: ${debugInfo.bodyLength}`);
-    console.log(`[MemberEditorPage.gotoNew] First 20 links on page: ${JSON.stringify(debugInfo.allLinks)}`);
-
-    if (debugInfo.found) {
-      await this.page.evaluate(() => {
-        document.querySelector('a[href="/members/new"]').click();
-      });
-      console.log(`[MemberEditorPage.gotoNew] SPA click succeeded`);
+    const link = this.page.locator('a[href="/members/new"]');
+    if (await link.count() > 0) {
+      await link.click();
     } else {
-      console.log(`[MemberEditorPage.gotoNew] Link NOT found — falling back to page.goto (full reload)`);
       await this.page.goto('/members/new');
     }
-
-    const urlAfterNav = this.page.url();
-    console.log(`[MemberEditorPage.gotoNew] URL after navigation: ${urlAfterNav}`);
-
-    await this.page.getByRole('heading', { name: 'Add New Member' }).waitFor({ timeout: 10_000 })
-      .catch(async (err) => {
-        const finalUrl = this.page.url();
-        const pageTitle = await this.page.title();
-        const bodyText = await this.page.locator('body').innerText().catch(() => '(could not read body)');
-        console.log(`[MemberEditorPage.gotoNew] HEADING NOT FOUND. URL: ${finalUrl}, title: ${pageTitle}`);
-        console.log(`[MemberEditorPage.gotoNew] Body text (first 500 chars): ${bodyText.slice(0, 500)}`);
-        throw err;
-      });
+    await this.page.getByRole('heading', { name: 'Add New Member' }).waitFor({ timeout: 10_000 });
   }
 
   heading() {
@@ -93,65 +67,48 @@ export class MemberEditorPage {
   /**
    * Fill in the minimum required fields to create a member.
    * statusName / className must already exist in the test tenant.
+   *
+   * NOTE: On the "new member" form the status select is hidden — the
+   * component auto-sets status to "Current" via useEffect. We only
+   * interact with the status select when it exists (editing an
+   * existing member).
    */
   async fillMinimal({ forenames, surname, statusName, className, postcode, joinedOn }) {
-    console.log(`[fillMinimal] Starting...`);
-
-    console.log(`[fillMinimal] Filling forenames...`);
     await this.forenamesInput().fill(forenames);
-    console.log(`[fillMinimal] Forenames done`);
-
-    console.log(`[fillMinimal] Filling surname...`);
     await this.surnameInput().fill(surname);
-    console.log(`[fillMinimal] Surname done`);
 
-    // Debug: list available status options
-    const statusOptions = await this.statusSelect().locator('option').allInnerTexts();
-    console.log(`[fillMinimal] Status options: ${JSON.stringify(statusOptions)}`);
-    console.log(`[fillMinimal] Selecting status "${statusName}"...`);
-    await this.statusSelect().selectOption({ label: statusName });
-    console.log(`[fillMinimal] Status done`);
+    // Status select only exists on the edit form, not on "Add New Member".
+    // The new-member form auto-sets status to "Current" in a useEffect.
+    const statusCount = await this.statusSelect().count();
+    if (statusCount > 0) {
+      await this.statusSelect().selectOption({ label: statusName });
+    }
 
-    // Debug: list available class options
-    const classOptions = await this.classSelect().locator('option').allInnerTexts();
-    console.log(`[fillMinimal] Class options: ${JSON.stringify(classOptions)}`);
-    console.log(`[fillMinimal] Selecting class "${className}"...`);
+    // Class options load async from the API — wait for at least one
+    // real option (beyond the "— select —" placeholder) before selecting.
+    await this.page.waitForFunction(
+      (sel) => {
+        const select = document.querySelector(sel);
+        return select && select.options.length > 1;
+      },
+      'select[name="classId"]',
+      { timeout: 10_000 },
+    );
     await this.classSelect().selectOption({ label: className });
-    console.log(`[fillMinimal] Class done`);
 
-    console.log(`[fillMinimal] Filling postcode...`);
     await this.postcodeInput().fill(postcode);
-    console.log(`[fillMinimal] Postcode done`);
-
     if (joinedOn) {
-      console.log(`[fillMinimal] Filling joinedOn...`);
       await this.joinedOnInput().fill(joinedOn);
-      console.log(`[fillMinimal] JoinedOn done. Waiting for next renewal date...`);
       // Wait for the auto-computed "Next renewal" date to be populated.
       // The frontend fetches year-config from the API and computes the
       // renewal date in a useEffect — this can lag behind the fill,
       // especially in CI where the API may be slow.
       await this.nextRenewalInput().waitFor({ state: 'visible' });
-      console.log(`[fillMinimal] Next renewal input visible. Waiting for value...`);
-
-      // Debug: check how many dd/mm/yyyy inputs exist
-      const dateInputCount = await this.page.locator('input[placeholder="dd/mm/yyyy"]').count();
-      console.log(`[fillMinimal] Number of dd/mm/yyyy inputs: ${dateInputCount}`);
-
       await this.page.waitForFunction(
         (sel) => { const el = document.querySelectorAll(sel)[1]; return el && el.value.length > 0; },
         'input[placeholder="dd/mm/yyyy"]',
         { timeout: 10_000 },
-      ).catch(async (err) => {
-        // Debug: check current values of all date inputs
-        const dateValues = await this.page.evaluate((sel) => {
-          return [...document.querySelectorAll(sel)].map((el, i) => ({ index: i, value: el.value, name: el.name }));
-        }, 'input[placeholder="dd/mm/yyyy"]');
-        console.log(`[fillMinimal] TIMEOUT waiting for renewal date. Date inputs: ${JSON.stringify(dateValues)}`);
-        throw err;
-      });
-      console.log(`[fillMinimal] Next renewal date populated`);
+      );
     }
-    console.log(`[fillMinimal] Complete`);
   }
 }

--- a/e2e/tests/02-members.spec.js
+++ b/e2e/tests/02-members.spec.js
@@ -47,25 +47,8 @@ test.describe('Add new member', () => {
 
   test('create a member with required fields', async ({ adminPage: page }) => {
     const editor = new MemberEditorPage(page);
-
-    // Listen for console messages from the browser
-    page.on('console', (msg) => {
-      if (msg.type() === 'error' || msg.text().includes('401') || msg.text().includes('auth'))
-        console.log(`[BROWSER ${msg.type()}] ${msg.text()}`);
-    });
-
-    // Listen for failed network requests
-    page.on('response', (response) => {
-      if (response.status() >= 400) {
-        console.log(`[HTTP ${response.status()}] ${response.url()}`);
-      }
-    });
-
-    console.log(`[TEST] Starting gotoNew...`);
     await editor.gotoNew();
-    console.log(`[TEST] gotoNew complete. URL: ${page.url()}`);
 
-    console.log(`[TEST] Filling minimal fields...`);
     await editor.fillMinimal({
       forenames:  TEST_FORENAMES,
       surname:    TEST_SURNAME,
@@ -74,32 +57,9 @@ test.describe('Add new member', () => {
       postcode:   'OX1 1AA',
       joinedOn:   '01/01/2024',
     });
-    console.log(`[TEST] fillMinimal complete`);
-
-    // Debug: check what the save button looks like
-    const btnText = await editor.saveButton().innerText().catch(() => '(not found)');
-    console.log(`[TEST] Save button text: "${btnText}"`);
 
     await editor.saveButton().click();
-    console.log(`[TEST] Save button clicked. Waiting for success banner...`);
-
-    // Confirm the save succeeded before checking the URL.
-    // If the success banner doesn't appear, the form probably has a
-    // validation error or the API call failed.
-    await expect(editor.successBanner()).toBeVisible({ timeout: 10_000 })
-      .catch(async (err) => {
-        const url = page.url();
-        const bodyText = await page.locator('body').innerText().catch(() => '(unreadable)');
-        console.log(`[TEST] SUCCESS BANNER NOT FOUND. URL: ${url}`);
-        console.log(`[TEST] Page body (first 1000 chars): ${bodyText.slice(0, 1000)}`);
-        // Check for any error banners
-        const errorVisible = await editor.errorBanner().isVisible().catch(() => false);
-        if (errorVisible) {
-          const errorText = await editor.errorBanner().innerText().catch(() => '(unreadable)');
-          console.log(`[TEST] Error banner found: ${errorText}`);
-        }
-        throw err;
-      });
+    await expect(editor.successBanner()).toBeVisible({ timeout: 10_000 });
 
     // After save, URL changes to the edit URL (/members/:id)
     await page.waitForURL(/\/members\/[^/]+$/, { timeout: 10_000 });


### PR DESCRIPTION
Root cause: The MemberEditor component hides the status <select> on the "Add New Member" form (guarded by `!isNew`). Status is auto-set to "Current" via useEffect. The test was trying to selectOption on a non-existent element, causing an infinite hang.

Fix:
- Skip status selection when the select isn't present (new member form)
- Wait for class options to load from the API before selecting
- Remove debug logging now that the issue is identified

https://claude.ai/code/session_012dTgg391UdKobXYeXVQWoE