### PR TITLE
Fix E2E strict mode violation: "Add new member" link resolves to 2 el…

### DIFF
--- a/e2e/pages/MemberEditorPage.js
+++ b/e2e/pages/MemberEditorPage.js
@@ -11,7 +11,7 @@ export class MemberEditorPage {
   async gotoNew() {
     // Prefer SPA link-click navigation to preserve the in-memory auth token.
     // page.goto() causes a full page reload which loses auth state.
-    const link = this.page.locator('a[href="/members/new"]');
+    const link = this.page.locator('a[href="/members/new"]').first();
     if (await link.count() > 0) {
       await link.click();
     } else {
@@ -62,6 +62,18 @@ export class MemberEditorPage {
     return this.page.locator(`[name="${name}"] ~ *`).filter({ hasText: /required|invalid|valid/i }).first();
   }
 
+  /** Wait for class select options to load from the API. */
+  async waitForClassOptions() {
+    await this.page.waitForFunction(
+      (sel) => {
+        const select = document.querySelector(sel);
+        return select && select.options.length > 1;
+      },
+      'select[name="classId"]',
+      { timeout: 10_000 },
+    );
+  }
+
   // ── Helpers ──────────────────────────────────────────────────────────────
 
   /**
@@ -84,16 +96,8 @@ export class MemberEditorPage {
       await this.statusSelect().selectOption({ label: statusName });
     }
 
-    // Class options load async from the API — wait for at least one
-    // real option (beyond the "— select —" placeholder) before selecting.
-    await this.page.waitForFunction(
-      (sel) => {
-        const select = document.querySelector(sel);
-        return select && select.options.length > 1;
-      },
-      'select[name="classId"]',
-      { timeout: 10_000 },
-    );
+    // Class options load async from the API — wait before selecting.
+    await this.waitForClassOptions();
     await this.classSelect().selectOption({ label: className });
 
     await this.postcodeInput().fill(postcode);

--- a/e2e/tests/02-members.spec.js
+++ b/e2e/tests/02-members.spec.js
@@ -127,7 +127,8 @@ test.describe('Member validation', () => {
 
     // Fill forenames only — no surname
     await editor.forenamesInput().fill('Noname');
-    await editor.statusSelect().selectOption({ label: 'Current' });
+    // Status is auto-set to "Current" on the new-member form (hidden select)
+    await editor.waitForClassOptions();
     await editor.classSelect().selectOption({ label: 'Individual' });
     await editor.postcodeInput().fill('OX1 1AA');
 
@@ -147,7 +148,8 @@ test.describe('Member validation', () => {
 
     await editor.forenamesInput().fill('Test');
     await editor.surnameInput().fill('Postcode');
-    await editor.statusSelect().selectOption({ label: 'Current' });
+    // Status is auto-set to "Current" on the new-member form (hidden select)
+    await editor.waitForClassOptions();
     await editor.classSelect().selectOption({ label: 'Individual' });
     await editor.postcodeInput().fill('NOT-A-POSTCODE');
 


### PR DESCRIPTION
…ements

The Home page renders both mobile and desktop layouts in the DOM (CSS hides one), so locator('a[href="/members/new"]') matches 2 elements. Add .first() to resolve. Also fix validation tests that called statusSelect() on the new-member form where it's hidden, and extract waitForClassOptions() helper.

https://claude.ai/code/session_012dTgg391UdKobXYeXVQWoE