### PR TITLE
Fix gotoNew() to use page.evaluate() for SPA navigation

### DIFF
--- a/e2e/fixtures/admin.js
+++ b/e2e/fixtures/admin.js
@@ -49,11 +49,21 @@ export const test = base.extend({
     await page.getByRole('button', { name: 'Enter' }).click();
     await page.waitForURL('/', { timeout: 10_000 });
     console.log(`[adminPage] Logged in. URL: ${page.url()}`);
-    // Wait for the Home page to actually render (links visible)
-    await page.waitForSelector('a[href="/members"]', { timeout: 5_000 }).catch(() => {
-      console.log(`[adminPage] WARNING: /members link not found after login — Home page may not have rendered`);
+
+    // Wait for the Home page to actually render.  The Home component fetches
+    // privileges via AuthContext before it can render links — in CI the backend
+    // may be slow (cold start / shared runner), so allow a generous timeout.
+    const homeStart = Date.now();
+    await page.waitForSelector('a[href="/members"]', { timeout: 15_000 }).catch(async () => {
+      // Dump diagnostic info so we can debug if the home page never renders
+      const bodyText = await page.evaluate(() => document.body?.innerText?.slice(0, 500)).catch(() => '<eval failed>');
+      const linkCount = await page.evaluate(() => document.querySelectorAll('a').length).catch(() => -1);
+      console.log(`[adminPage] WARNING: /members link not found after 15 s`);
+      console.log(`[adminPage]   URL: ${page.url()}`);
+      console.log(`[adminPage]   Total <a> tags: ${linkCount}`);
+      console.log(`[adminPage]   Body text (first 500 chars): ${bodyText}`);
     });
-    console.log(`[adminPage] Home page rendered`);
+    console.log(`[adminPage] Home page rendered (${Date.now() - homeStart} ms)`);
 
     // Override page.goto to prefer SPA navigation.
     // Full-page reloads destroy the in-memory auth token; clicking an <a>

--- a/e2e/pages/MemberEditorPage.js
+++ b/e2e/pages/MemberEditorPage.js
@@ -9,15 +9,30 @@ export class MemberEditorPage {
   }
 
   async gotoNew() {
-    // Prefer SPA link-click navigation to preserve the in-memory auth token.
-    // page.goto() causes a full page reload which loses auth state.
-    const link = this.page.locator('a[href="/members/new"]').first();
-    if (await link.count() > 0) {
-      await link.click();
-    } else {
+    // Use page.evaluate() to fire a DOM click — this triggers React Router's
+    // onClick handler regardless of CSS visibility.  The Home page renders both
+    // a mobile layout (md:hidden) and a desktop grid; Playwright's locator.click()
+    // would fail if it resolved the hidden mobile element first.
+    // See CLAUDE-E2E.md § "The SPA-navigation pattern".
+    const url = this.page.url();
+    console.log(`[MemberEditorPage.gotoNew] Current URL before navigation: ${url}`);
+
+    const clicked = await this.page.evaluate(() => {
+      const link = document.querySelector('a[href="/members/new"]');
+      console.log('[gotoNew] link found in DOM:', !!link, link?.offsetParent, link?.getBoundingClientRect());
+      if (link) { link.click(); return true; }
+      return false;
+    });
+    console.log(`[MemberEditorPage.gotoNew] SPA link clicked: ${clicked}`);
+
+    if (!clicked) {
+      console.log('[MemberEditorPage.gotoNew] Falling back to page.goto("/members/new")');
       await this.page.goto('/members/new');
     }
-    await this.page.getByRole('heading', { name: 'Add New Member' }).waitFor({ timeout: 10_000 });
+
+    console.log(`[MemberEditorPage.gotoNew] Waiting for "Add New Member" heading...`);
+    await this.page.getByRole('heading', { name: 'Add New Member' }).waitFor({ timeout: 15_000 });
+    console.log(`[MemberEditorPage.gotoNew] Heading found. URL: ${this.page.url()}`);
   }
 
   heading() {


### PR DESCRIPTION
The Home page renders both mobile (md:hidden) and desktop layouts in the DOM. Using locator.click() with .first() picks the hidden mobile link, causing "element is not visible" timeout. Switch to page.evaluate() which fires the DOM click directly regardless of CSS visibility — matching the pattern already used by MemberListPage.goto() and documented in CLAUDE-E2E.md.

Also:
- Add detailed debug logging to gotoNew() and the adminPage fixture
- Increase admin fixture home-page wait from 5s to 15s with diagnostics
- Dump body text and link count when home page fails to render

https://claude.ai/code/session_012dTgg391UdKobXYeXVQWoE