### PR TITLE
Fix groups E2E tests: strict mode, SPA navigation, and role selectors

### DIFF
--- a/e2e/pages/GroupsPage.js
+++ b/e2e/pages/GroupsPage.js
@@ -19,7 +19,7 @@ export class GroupListPage {
   }
 
   addNewButton() {
-    return this.page.getByRole('link', { name: 'Add new group' });
+    return this.page.getByRole('link', { name: 'Add new group' }).first();
   }
 
   groupLink(name) {
@@ -38,13 +38,25 @@ export class GroupRecordPage {
   }
 
   async gotoNew() {
-    // SPA navigation — see CLAUDE-E2E.md
+    // Navigate to /groups first (SPA), then click "Add New Group"
     const clicked = await this.page.evaluate(() => {
       const link = document.querySelector('a[href="/groups/new"]');
       if (link) { link.click(); return true; }
       return false;
     });
-    if (!clicked) await this.page.goto('/groups/new');
+    if (!clicked) {
+      // No /groups/new link on current page — go to groups list first
+      const listClicked = await this.page.evaluate(() => {
+        const link = document.querySelector('a[href="/groups"]');
+        if (link) { link.click(); return true; }
+        return false;
+      });
+      if (!listClicked) await this.page.goto('/groups');
+      await this.page.getByRole('heading', { name: 'Groups' }).waitFor();
+      // Now click "Add New Group" from the list page NavBar
+      await this.page.getByRole('link', { name: /add new group/i }).first().click();
+    }
+    await this.page.getByRole('heading', { name: /add new group/i }).waitFor();
   }
 
   nameInput()        { return this.page.locator('input[name="name"]').first(); }

--- a/e2e/tests/04-groups.spec.js
+++ b/e2e/tests/04-groups.spec.js
@@ -33,7 +33,8 @@ test.describe('Group list', () => {
 
 test.describe('Add and edit a group', () => {
   test('create a new group', async ({ adminPage: page }) => {
-    await page.goto('/groups/new');
+    const recordPage = new GroupRecordPage(page);
+    await recordPage.gotoNew();
 
     // Fill name (required)
     await page.locator('input[name="name"]').first().fill(GROUP_NAME);


### PR DESCRIPTION
- GroupListPage.addNewButton(): add .first() to avoid strict mode violation from duplicate NavBar links (top + bottom)
- GroupRecordPage.gotoNew(): navigate via groups list SPA click then "Add New Group" link, since /groups/new isn't on the Home page
- Test "create a new group": use GroupRecordPage.gotoNew() instead of direct page.goto('/groups/new') which loses auth on full reload

https://claude.ai/code/session_012dTgg391UdKobXYeXVQWoE