### PR TITLE
Fix groups E2E: saveButton regex to match 'Add Group' on new form

### DIFF
--- a/e2e/pages/GroupsPage.js
+++ b/e2e/pages/GroupsPage.js
@@ -61,7 +61,7 @@ export class GroupRecordPage {
 
   nameInput()        { return this.page.locator('input[name="name"]').first(); }
   descriptionInput() { return this.page.locator('textarea[name="description"], input[name="description"]').first(); }
-  saveButton()       { return this.page.getByRole('button', { name: /save/i }).first(); }
+  saveButton()       { return this.page.getByRole('button', { name: /save|add group/i }).first(); }
   deleteButton()     { return this.page.getByRole('button', { name: /delete/i }).first(); }
   successBanner()    { return this.page.getByText('✓ Saved successfully.'); }
 

--- a/e2e/tests/04-groups.spec.js
+++ b/e2e/tests/04-groups.spec.js
@@ -37,9 +37,9 @@ test.describe('Add and edit a group', () => {
     await recordPage.gotoNew();
 
     // Fill name (required)
-    await page.locator('input[name="name"]').first().fill(GROUP_NAME);
+    await recordPage.nameInput().fill(GROUP_NAME);
 
-    await page.getByRole('button', { name: /save/i }).first().click();
+    await recordPage.saveButton().click();
 
     // After save, URL should become /groups/:id
     await page.waitForURL(/\/groups\/[^/]+$/, { timeout: 10_000 });
@@ -60,9 +60,9 @@ test.describe('Add and edit a group', () => {
     await page.waitForURL(/\/groups\/[^/]+$/);
 
     // Edit the name (append suffix)
-    const nameInput = page.locator('input[name="name"]').first();
-    await nameInput.fill(GROUP_NAME);  // ensure no stale value
-    await page.getByRole('button', { name: /save/i }).first().click();
+    const recordPage = new GroupRecordPage(page);
+    await recordPage.nameInput().fill(GROUP_NAME);  // ensure no stale value
+    await recordPage.saveButton().click();
 
     await expect(page.getByText(/saved/i).first()).toBeVisible({ timeout: 6_000 });
   });


### PR DESCRIPTION
The new-group form button says "Add Group" not "Save", so the /save/i regex never matched and the test timed out. Updated POM saveButton() to /save|add group/i and refactored tests to use POM methods.

https://claude.ai/code/session_012dTgg391UdKobXYeXVQWoE