### PR TITLE
0.6.8 Allow flexible account selection on Financial Statement

### DIFF
--- a/backend/src/routes/finance.js
+++ b/backend/src/routes/finance.js
@@ -1225,10 +1225,16 @@ async function getStatementData(tenantSlug, accountId, yearNum) {
     yearNum, settings.year_start_month, settings.year_start_day,
   );
 
+  // accountId can be 'all' or a comma-separated list of IDs
   const isAll = accountId === 'all';
-  const accounts = isAll
-    ? await tenantQuery(tenantSlug, `SELECT id, name, balance_brought_forward::float FROM finance_accounts WHERE active = true ORDER BY sort_order, name`)
-    : await tenantQuery(tenantSlug, `SELECT id, name, balance_brought_forward::float FROM finance_accounts WHERE id = $1`, [accountId]);
+  let accounts;
+  if (isAll) {
+    accounts = await tenantQuery(tenantSlug, `SELECT id, name, balance_brought_forward::float FROM finance_accounts WHERE active = true ORDER BY sort_order, name`);
+  } else {
+    const requestedIds = accountId.split(',').map((s) => s.trim()).filter(Boolean);
+    if (requestedIds.length === 0) throw AppError('At least one account must be selected.', 400);
+    accounts = await tenantQuery(tenantSlug, `SELECT id, name, balance_brought_forward::float FROM finance_accounts WHERE id = ANY($1::text[]) ORDER BY sort_order, name`, [requestedIds]);
+  }
 
   if (!isAll && accounts.length === 0) throw AppError('Account not found.', 404);
 
@@ -1288,7 +1294,12 @@ async function getStatementData(tenantSlug, accountId, yearNum) {
   const totalOut      = yearTotals?.total_out ?? 0;
   const closingBalance = openingBalance + totalIn - totalOut;
 
-  const accountLabel = isAll ? 'All Accounts' : accounts[0]?.name ?? '';
+  // Build label: "All Accounts", single name, or comma-separated names
+  const allActive = await tenantQuery(tenantSlug, `SELECT COUNT(*)::int AS count FROM finance_accounts WHERE active = true`);
+  const isEffectivelyAll = isAll || accounts.length === (allActive[0]?.count ?? 0);
+  const accountLabel = isEffectivelyAll
+    ? 'All Accounts'
+    : accounts.map((a) => a.name).join(', ');
 
   return { yearNum, yearStart, yearEnd, accountLabel, openingBalance, totalIn, totalOut, closingBalance, categoryRows, pendingCount };
 }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -374,9 +374,10 @@ export const finance = {
   deleteBatch:      (id)       => request(`/finance/batches/${id}`, { method: 'DELETE' }),
 
   // Financial Statement
+  // accountId can be 'all' or an array of IDs (sent as comma-separated)
   getStatement: (accountId, year) => {
     const qs = new URLSearchParams();
-    qs.set('accountId', accountId);
+    qs.set('accountId', Array.isArray(accountId) ? accountId.join(',') : accountId);
     if (year) qs.set('year', String(year));
     return request(`/finance/statement?${qs.toString()}`);
   },

--- a/frontend/src/pages/finance/FinancialStatement.jsx
+++ b/frontend/src/pages/finance/FinancialStatement.jsx
@@ -20,7 +20,8 @@ function fmtAmt(n) {
 export default function FinancialStatement() {
   const { can, tenant } = useAuth();
   const [accounts,     setAccounts]     = useState([]);
-  const [accountId,    setAccountId]    = useState('all');
+  const [selectedIds,  setSelectedIds]  = useState(new Set());  // set of account id strings
+  const [allChecked,   setAllChecked]   = useState(true);
   const [year,         setYear]         = useState(CURRENT_YEAR);
   const [data,         setData]         = useState(null);
   const [loading,      setLoading]      = useState(false);
@@ -31,18 +32,54 @@ export default function FinancialStatement() {
   useEffect(() => { loadAccounts(); }, []);
 
   async function loadAccounts() {
-    try { setAccounts(await financeApi.listAccounts()); }
-    catch (err) { setError(err.message); }
+    try {
+      const accts = await financeApi.listAccounts();
+      setAccounts(accts);
+      // Default: all accounts selected
+      setSelectedIds(new Set(accts.map((a) => String(a.id))));
+      setAllChecked(true);
+    } catch (err) { setError(err.message); }
     finally { setLoadingAccts(false); }
+  }
+
+  function handleAllToggle() {
+    if (allChecked) {
+      // Uncheck all
+      setSelectedIds(new Set());
+      setAllChecked(false);
+    } else {
+      // Check all
+      setSelectedIds(new Set(accounts.map((a) => String(a.id))));
+      setAllChecked(true);
+    }
+  }
+
+  function handleAccountToggle(id) {
+    const idStr = String(id);
+    const next = new Set(selectedIds);
+    if (next.has(idStr)) {
+      next.delete(idStr);
+    } else {
+      next.add(idStr);
+    }
+    setSelectedIds(next);
+    setAllChecked(next.size === accounts.length);
+  }
+
+  // Derive the accountId parameter to send to the API
+  function getAccountParam() {
+    if (allChecked || selectedIds.size === accounts.length) return 'all';
+    return Array.from(selectedIds);
   }
 
   async function handleView(e) {
     e.preventDefault();
+    if (selectedIds.size === 0) { setError('Please select at least one account.'); return; }
     setLoading(true);
     setError(null);
     setData(null);
     try {
-      const d = await financeApi.getStatement(accountId, year);
+      const d = await financeApi.getStatement(getAccountParam(), year);
       setData(d);
     } catch (err) { setError(err.message); }
     finally { setLoading(false); }
@@ -51,6 +88,8 @@ export default function FinancialStatement() {
   async function handleDownload() {
     setDownloading(true);
     try {
+      const param = getAccountParam();
+      const accountId = Array.isArray(param) ? param.join(',') : param;
       await requestBlob(`/finance/statement/download?accountId=${encodeURIComponent(accountId)}&year=${year}&format=xlsx`);
     } catch (err) { alert(err.message); }
     finally { setDownloading(false); }
@@ -76,13 +115,34 @@ export default function FinancialStatement() {
 
         {/* Selector form */}
         <form onSubmit={handleView} className="bg-white/90 rounded-lg shadow-sm p-4 mb-5">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-end">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-start">
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">Account</label>
-              <select name="accountId" value={accountId} onChange={(e) => setAccountId(e.target.value)} className={`${inputCls} w-full`}>
-                <option value="all">All accounts combined</option>
-                {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
-              </select>
+              <label className="block text-sm font-medium text-slate-700 mb-1">Accounts</label>
+              <div className="border border-slate-300 rounded bg-white max-h-48 overflow-y-auto px-2 py-1.5">
+                {/* All accounts toggle */}
+                <label className="flex items-center gap-2 py-1 text-sm font-medium text-slate-700 border-b border-slate-200 mb-1 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={allChecked}
+                    onChange={handleAllToggle}
+                    className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  All accounts
+                </label>
+                {/* Individual accounts */}
+                {loadingAccts && <p className="text-xs text-slate-400 py-1">Loading…</p>}
+                {accounts.map((a) => (
+                  <label key={a.id} className="flex items-center gap-2 py-0.5 text-sm text-slate-700 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(String(a.id))}
+                      onChange={() => handleAccountToggle(a.id)}
+                      className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    {a.name}
+                  </label>
+                ))}
+              </div>
             </div>
             <div>
               <label className="block text-sm font-medium text-slate-700 mb-1">Financial year</label>
@@ -92,7 +152,7 @@ export default function FinancialStatement() {
             </div>
           </div>
           <div className="mt-3 flex gap-3 flex-wrap">
-            <button type="submit" disabled={loading} className={btnPrimary}>
+            <button type="submit" disabled={loading || selectedIds.size === 0} className={btnPrimary}>
               {loading ? 'Loading…' : 'View Statement'}
             </button>
             {data && canDownload && (


### PR DESCRIPTION
Replace the single account dropdown with a checkbox list so users can report on any combination of accounts. "All accounts" checkbox toggles the full set. Backend now accepts comma-separated account IDs.

https://claude.ai/code/session_0162VUjunWx2u4fMfWxATQD9