### PR TITLE
Fix finance page objects: addButton matches actual 'Save' label

### DIFF
--- a/e2e/pages/FinancePage.js
+++ b/e2e/pages/FinancePage.js
@@ -19,7 +19,7 @@ export class FinanceAccountsPage {
   }
 
   addNameInput()  { return this.page.getByPlaceholder(/account name/i); }
-  addButton()     { return this.page.getByRole('button', { name: /add/i }).first(); }
+  addButton()     { return this.page.getByRole('button', { name: /save/i }).first(); }
   accountRow(name) {
     return this.page.getByRole('row').filter({ hasText: name });
   }
@@ -45,7 +45,7 @@ export class FinanceCategoriesPage {
   }
 
   addNameInput()  { return this.page.getByPlaceholder(/category name/i); }
-  addButton()     { return this.page.getByRole('button', { name: /add/i }).first(); }
+  addButton()     { return this.page.getByRole('button', { name: /save/i }).first(); }
   categoryRow(name) {
     return this.page.getByRole('row').filter({ hasText: name });
   }


### PR DESCRIPTION
The FinanceAccounts and FinanceCategories components use "Save" as the submit button label, not "Add". Updated both page objects to match with /save/i.

https://claude.ai/code/session_01GdPoHRPgHV6E6APfqWN8V9