### PR TITLE
Fix E2E suite timeout: increase globalTimeout and remove per-test dia…

### DIFF
--- a/e2e/fixtures/admin.js
+++ b/e2e/fixtures/admin.js
@@ -58,23 +58,6 @@ export const test = base.extend({
     await page.getByText('You are logged in as').waitFor({ timeout: 15_000 });
     console.log(`[adminPage] Home page rendered (${Date.now() - homeStart} ms)`);
 
-    // Diagnostic: check whether the members link actually exists as an <a>.
-    // This helps debug the long-standing waitForSelector mystery.
-    const memberLinkDiag = await page.evaluate(() => {
-      const exact = document.querySelectorAll('a[href="/members"]');
-      const partial = document.querySelectorAll('a[href*="member"]');
-      const allLinks = [...document.querySelectorAll('a')];
-      const memberishLinks = allLinks
-        .filter(a => a.textContent.trim().toLowerCase().includes('member'))
-        .map(a => ({ text: a.textContent.trim().slice(0, 40), href: a.href, tag: a.tagName }));
-      return {
-        exactCount: exact.length,
-        partialCount: partial.length,
-        memberishLinks,
-      };
-    }).catch(() => ({ error: 'evaluate failed' }));
-    console.log(`[adminPage] Members link diagnostic:`, JSON.stringify(memberLinkDiag));
-
     // Override page.goto to prefer SPA navigation.
     // Full-page reloads destroy the in-memory auth token; clicking an <a>
     // in the DOM triggers React Router without a reload.

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -57,8 +57,9 @@ export default defineConfig({
   },
 
   // Global setup creates (or resets) the test tenant before any tests run.
-  // Allow up to 3 minutes for global setup (cold-start warm-up + tenant creation).
-  globalTimeout: 180_000,
+  // globalTimeout covers the ENTIRE test run (setup + all tests + teardown).
+  // 10 minutes for CI (83+ tests × ~3 s login overhead each).
+  globalTimeout: process.env.CI ? 600_000 : 300_000,
   globalSetup: './global-setup.js',
   // globalTeardown: './global-teardown.js',
 


### PR DESCRIPTION
…gnostic

- globalTimeout was 180s which covers the ENTIRE run, not just global setup. Increased to 10min (CI) / 5min (local) to accommodate 83+ tests.
- Removed the per-test Members link diagnostic evaluate() call from the admin fixture — it was debug instrumentation adding overhead to every test.

https://claude.ai/code/session_01GdPoHRPgHV6E6APfqWN8V9