### PR TITLE
Fix remaining E2E test failures across finance, users, settings, offi…

### DIFF
--- a/e2e/pages/FinancePage.js
+++ b/e2e/pages/FinancePage.js
@@ -84,36 +84,29 @@ export class FinanceLedgerPage {
     this.page = page;
   }
 
-  async gotoByAccount() {
-    // SPA navigation — see CLAUDE-E2E.md
-    // Link on home page is /finance/ledger (no query); click it then append the view
+  /** @private SPA-navigate to /finance/ledger, preserving auth token */
+  async _gotoLedger() {
+    // Wait for the SPA link to exist in the DOM before clicking
+    await this.page.waitForSelector('a[href="/finance/ledger"]', { timeout: 5_000 }).catch(() => null);
     const clicked = await this.page.evaluate(() => {
       const link = document.querySelector('a[href="/finance/ledger"]');
       if (link) { link.click(); return true; }
       return false;
     });
-    if (!clicked) await this.page.goto('/finance/ledger?view=account');
+    if (!clicked) await this.page.goto('/finance/ledger');
     await this.page.getByRole('heading', { name: /ledger/i }).waitFor();
+  }
+
+  async gotoByAccount() {
+    await this._gotoLedger();
   }
 
   async gotoByCategory() {
-    const clicked = await this.page.evaluate(() => {
-      const link = document.querySelector('a[href="/finance/ledger"]');
-      if (link) { link.click(); return true; }
-      return false;
-    });
-    if (!clicked) await this.page.goto('/finance/ledger?view=category');
-    await this.page.getByRole('heading', { name: /ledger/i }).waitFor();
+    await this._gotoLedger();
   }
 
   async gotoByGroup() {
-    const clicked = await this.page.evaluate(() => {
-      const link = document.querySelector('a[href="/finance/ledger"]');
-      if (link) { link.click(); return true; }
-      return false;
-    });
-    if (!clicked) await this.page.goto('/finance/ledger?view=group');
-    await this.page.getByRole('heading', { name: /ledger/i }).waitFor();
+    await this._gotoLedger();
   }
 
   transactionRow(payee) {

--- a/e2e/tests/06-finance.spec.js
+++ b/e2e/tests/06-finance.spec.js
@@ -109,9 +109,13 @@ test.describe('Finance transactions', () => {
     await editor.fromToInput().fill(PAYEE);
     await editor.amountInput().fill('50.00');
 
+    // Category allocation — required by form validation
+    // Fill the first category amount input to match the transaction amount
+    await page.locator('input[name="categoryAmount"]').first().fill('50.00');
+
     await editor.saveButton().click();
 
-    // After save, should show success banner or redirect
+    // After save, should show success banner (then auto-redirects)
     await expect(editor.successBanner()).toBeVisible({ timeout: 10_000 });
   });
 

--- a/e2e/tests/07-roles-users.spec.js
+++ b/e2e/tests/07-roles-users.spec.js
@@ -15,11 +15,13 @@
 
 import { test, expect } from '../fixtures/admin.js';
 import { RoleListPage, UserListPage, UserEditorPage } from '../pages/SettingsPage.js';
+import { MemberEditorPage } from '../pages/MemberEditorPage.js';
 
 const SUFFIX    = Date.now();
 const ROLE_NAME = `E2ERole${SUFFIX}`;
-const USER_NAME = `E2E User ${SUFFIX}`;
 const USER_UNAME = `e2euser${SUFFIX % 100000}`;  // keep to <=12 lowercase chars
+const MEMBER_SURNAME   = `E2EUserMbr${SUFFIX}`;
+const MEMBER_FORENAMES = 'Test';
 
 // ── Roles ─────────────────────────────────────────────────────────────────
 
@@ -87,44 +89,56 @@ test.describe('System users', () => {
   });
 
   test('add a new user', async ({ adminPage: page }) => {
+    // Step 1: Create a member to link to the new user
+    const memberEditor = new MemberEditorPage(page);
+    await memberEditor.gotoNew();
+    await memberEditor.surnameInput().fill(MEMBER_SURNAME);
+    await memberEditor.forenamesInput().fill(MEMBER_FORENAMES);
+    await memberEditor.saveButton().click();
+    await page.waitForURL(/\/members\/(?!new\b)[^/]+$/, { timeout: 10_000 });
+
+    // Step 2: Navigate to the users list
     const userList = new UserListPage(page);
     await userList.goto();
 
-    // Navigate to /users/new via the nav bar "Add" link
+    // Step 3: Click "Add New User" link
     await userList.addNewLink().click();
     await page.getByRole('heading', { name: 'Add New User' }).waitFor({ timeout: 10_000 });
 
-    const userEditor = new UserEditorPage(page);
-    await userEditor.nameInput().fill(USER_NAME);
-    await userEditor.emailInput().fill(`${USER_UNAME}@beacon2-e2e.invalid`);
-    await userEditor.usernameInput().fill(USER_UNAME);
-    await userEditor.passwordInput().fill('TestUser99!');
+    // Step 4: Select the member from the dropdown
+    const memberSelect = page.locator('select[name="memberId"]');
+    await memberSelect.selectOption({ label: new RegExp(MEMBER_SURNAME) });
 
-    await userEditor.saveButton().click();
+    // Step 5: Fill required fields
+    await page.locator('input[name="username"]').fill(USER_UNAME);
+    await page.locator('input[name="email"]').fill(`${USER_UNAME}@beacon2-e2e.invalid`);
 
-    // After save, should show success or redirect to the user editor
-    await expect(userEditor.successBanner()).toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: /save user/i }).click();
+
+    // After save, should show temp password notice or success
+    await expect(page.getByText(/temporary password|saved/i).first()).toBeVisible({ timeout: 10_000 });
   });
 
   test('new user appears in the users list', async ({ adminPage: page }) => {
     const userList = new UserListPage(page);
     await userList.goto();
-    await expect(page.getByText(USER_NAME)).toBeVisible();
+    // The user's display name comes from the linked member
+    await expect(page.getByText(MEMBER_SURNAME)).toBeVisible();
   });
 
-  test('edit user name', async ({ adminPage: page }) => {
+  test('edit user username', async ({ adminPage: page }) => {
     const userList = new UserListPage(page);
     await userList.goto();
 
-    // Click the user name button to navigate to the editor
-    await userList.nameButton(USER_NAME).click();
+    // Click the user name (member surname) to navigate to the editor
+    await userList.nameButton(new RegExp(MEMBER_SURNAME)).click();
     await page.getByRole('heading', { name: 'System User Record' }).waitFor({ timeout: 10_000 });
 
-    const editor = new UserEditorPage(page);
-    await editor.nameInput().fill(USER_NAME);  // same — just save
-    await editor.saveButton().click();
+    // Change email and save
+    await page.locator('input[name="email"]').fill(`${USER_UNAME}2@beacon2-e2e.invalid`);
+    await page.getByRole('button', { name: /save user/i }).click();
 
-    await expect(editor.successBanner()).toBeVisible({ timeout: 6_000 });
+    await expect(page.getByText(/saved/i).first()).toBeVisible({ timeout: 6_000 });
   });
 
   test('delete the new user', async ({ adminPage: page }) => {
@@ -132,10 +146,10 @@ test.describe('System users', () => {
     await userList.goto();
 
     // Delete button is in the user list row (not on the editor page)
-    const row = userList.userRow(USER_NAME);
+    const row = userList.userRow(MEMBER_SURNAME);
     page.once('dialog', (d) => d.accept());
     await row.getByRole('button', { name: /delete/i }).click();
 
-    await expect(page.getByText(USER_NAME)).toBeHidden({ timeout: 6_000 });
+    await expect(row).toBeHidden({ timeout: 6_000 });
   });
 });

--- a/e2e/tests/08-settings.spec.js
+++ b/e2e/tests/08-settings.spec.js
@@ -69,16 +69,30 @@ test.describe('System settings', () => {
 
 test.describe('Personal preferences', () => {
   test('preferences page is accessible', async ({ adminPage: page }) => {
-    await page.goto('/preferences');
+    // SPA navigation to preserve auth token
+    const clicked = await page.evaluate(() => {
+      const link = document.querySelector('a[href="/preferences"]');
+      if (link) { link.click(); return true; }
+      return false;
+    });
+    if (!clicked) await page.goto('/preferences');
     await expect(page.getByRole('heading', { name: 'Personal Preferences' })).toBeVisible();
   });
 
-  test('preferences page has display and security sections', async ({ adminPage: page }) => {
-    await page.goto('/preferences');
+  test('preferences page has display and password sections', async ({ adminPage: page }) => {
+    // SPA navigation to preserve auth token
+    const clicked = await page.evaluate(() => {
+      const link = document.querySelector('a[href="/preferences"]');
+      if (link) { link.click(); return true; }
+      return false;
+    });
+    if (!clicked) await page.goto('/preferences');
+    await page.getByRole('heading', { name: 'Personal Preferences' }).waitFor();
 
-    // Beacon UG §9.1 — three sections
-    await expect(page.getByText(/display/i).first()).toBeVisible();
-    await expect(page.getByText(/password/i).first()).toBeVisible();
-    await expect(page.getByText(/security/i).first()).toBeVisible();
+    // Actual sections: Display Preferences, Drop-down Name Lists & Timeout,
+    // Change Password, Change Personal Q&A
+    await expect(page.getByText(/display preferences/i).first()).toBeVisible();
+    await expect(page.getByText(/change password/i).first()).toBeVisible();
+    await expect(page.getByText(/personal q&a/i).first()).toBeVisible();
   });
 });

--- a/e2e/tests/09-officers.spec.js
+++ b/e2e/tests/09-officers.spec.js
@@ -14,42 +14,45 @@ const SUFFIX       = Date.now();
 const OFFICER_NAME = `E2EOfficer${SUFFIX}`;
 const OFFICE_NAME  = `E2EOffice${SUFFIX}`;
 
+/** SPA-navigate to /officers, preserving auth token */
+async function gotoOfficers(page) {
+  const clicked = await page.evaluate(() => {
+    const link = document.querySelector('a[href="/officers"]');
+    if (link) { link.click(); return true; }
+    return false;
+  });
+  if (!clicked) await page.goto('/officers');
+  await page.getByRole('heading', { name: /offices/i }).waitFor();
+}
+
 test.describe('u3a Officers', () => {
   test('officers list page loads', async ({ adminPage: page }) => {
-    await page.goto('/officers');
-    await expect(page.getByRole('heading', { name: /officer/i })).toBeVisible();
+    await gotoOfficers(page);
+    await expect(page.getByRole('heading', { name: 'u3a Offices and Post Holders' })).toBeVisible();
   });
 
   test('add an officer record', async ({ adminPage: page }) => {
-    await page.goto('/officers');
+    await gotoOfficers(page);
 
-    // Fill the add-officer form (office title + post-holder name or member link)
-    const officeTitleInput = page.getByPlaceholder(/office|title|position/i).first();
-    if (await officeTitleInput.isVisible()) {
-      await officeTitleInput.fill(OFFICE_NAME);
-    } else {
-      // Some forms use labelled inputs
-      await page.getByLabel(/office/i).first().fill(OFFICE_NAME);
-    }
+    // Click "Add new office" to show the inline edit row
+    await page.getByRole('button', { name: /add new office/i }).click();
 
-    // The officer may link to a member; the name field is sometimes separate
-    const nameInput = page.locator('input[name="name"], input[placeholder*="name" i]').first();
-    if (await nameInput.isVisible()) {
-      await nameInput.fill(OFFICER_NAME);
-    }
+    // Fill the office name input in the edit row
+    await page.locator('input[name="name"]').fill(OFFICE_NAME);
 
-    await page.getByRole('button', { name: /add|save/i }).first().click();
+    // Save the record
+    await page.getByRole('button', { name: /save record/i }).click();
 
     await expect(page.getByText(OFFICE_NAME)).toBeVisible({ timeout: 6_000 });
   });
 
   test('officer appears in the list', async ({ adminPage: page }) => {
-    await page.goto('/officers');
+    await gotoOfficers(page);
     await expect(page.getByText(OFFICE_NAME)).toBeVisible();
   });
 
   test('delete the officer record', async ({ adminPage: page }) => {
-    await page.goto('/officers');
+    await gotoOfficers(page);
     const row = page.getByRole('row').filter({ hasText: OFFICE_NAME });
     page.once('dialog', (d) => d.accept());
     await row.getByRole('button', { name: /delete/i }).click();


### PR DESCRIPTION
…cers

Finance transactions:
- Fill category amount (required by form validation before save)
- Extract shared _gotoLedger() helper with waitForSelector before SPA click to prevent auth-losing fallback to page.goto

System users:
- Rewrite user creation test: create a member first, then select it from the member dropdown (UserEditor has no name field — user name comes from the linked member)
- Use nameButton(RegExp) to click user name in list (button, not link)
- Delete user via list row button (no delete button on editor page)

Settings / preferences:
- Use SPA navigation for /preferences (page.goto loses auth token)
- Fix section assertions: actual headings are "Display Preferences", "Change Password", "Change Personal Q&A" (no "security" section)

Officers:
- Use SPA navigation via Home page link instead of page.goto
- Fix heading: actual is "u3a Offices and Post Holders" not "officer"
- Fix add form: click "Add new office" button, fill input[name="name"], click "Save Record"

https://claude.ai/code/session_01GdPoHRPgHV6E6APfqWN8V9