### PR TITLE
Fix transaction, user creation, and backup E2E tests

### DIFF
--- a/e2e/pages/FinancePage.js
+++ b/e2e/pages/FinancePage.js
@@ -58,6 +58,8 @@ export class TransactionEditorPage {
 
   async gotoNew() {
     // SPA navigation — see CLAUDE-E2E.md
+    // Wait for the SPA link to exist in the DOM before clicking
+    await this.page.waitForSelector('a[href="/finance/transactions/new"]', { timeout: 5_000 }).catch(() => null);
     const clicked = await this.page.evaluate(() => {
       const link = document.querySelector('a[href="/finance/transactions/new"]');
       if (link) { link.click(); return true; }

--- a/e2e/pages/SettingsPage.js
+++ b/e2e/pages/SettingsPage.js
@@ -65,6 +65,12 @@ export class UserListPage {
 
   async goto() {
     // SPA navigation — see CLAUDE-E2E.md
+    // First navigate Home (link is always in NavBar), then click the Users link
+    await this.page.evaluate(() => {
+      const homeLink = document.querySelector('a[href="/"]');
+      if (homeLink) homeLink.click();
+    });
+    await this.page.waitForSelector('a[href="/users"]', { timeout: 5_000 }).catch(() => null);
     const clicked = await this.page.evaluate(() => {
       const link = document.querySelector('a[href="/users"]');
       if (link) { link.click(); return true; }

--- a/e2e/tests/07-roles-users.spec.js
+++ b/e2e/tests/07-roles-users.spec.js
@@ -95,7 +95,8 @@ test.describe('System users', () => {
     await memberEditor.surnameInput().fill(MEMBER_SURNAME);
     await memberEditor.forenamesInput().fill(MEMBER_FORENAMES);
     await memberEditor.saveButton().click();
-    await page.waitForURL(/\/members\/(?!new\b)[^/]+$/, { timeout: 10_000 });
+    // Wait for save success (banner appears, then SPA redirects after 1200ms)
+    await expect(page.getByText(/saved/i).first()).toBeVisible({ timeout: 10_000 });
 
     // Step 2: Navigate to the users list
     const userList = new UserListPage(page);

--- a/e2e/tests/11-backup.spec.js
+++ b/e2e/tests/11-backup.spec.js
@@ -3,14 +3,14 @@
 // Beacon UG §9.5 — "Data Export and Backup"
 //
 // Tests:
-//  ✓ Backup page loads with all 8 export options
+//  ✓ Backup page loads with all export options
 //  ✓ Clicking a download button triggers an .xlsx file download
 //  ✓ Member data validator page loads
 
 import { test, expect } from '../fixtures/admin.js';
 
-// All eight export types listed in the backup UI (labels as shown in the UI)
-const EXPORT_TYPES = [
+// Export option labels as shown in the UI (in the <div> text, not button text)
+const EXPORT_LABELS = [
   /members/i,
   /finance/i,
   /groups/i,
@@ -18,37 +18,63 @@ const EXPORT_TYPES = [
   /system/i,
   /officers/i,
   /settings/i,
-  /backup all/i,
 ];
+
+/** SPA-navigate to /backup, preserving auth token */
+async function gotoBackup(page) {
+  await page.waitForSelector('a[href="/backup"]', { timeout: 5_000 }).catch(() => null);
+  const clicked = await page.evaluate(() => {
+    const link = document.querySelector('a[href="/backup"]');
+    if (link) { link.click(); return true; }
+    return false;
+  });
+  if (!clicked) await page.goto('/backup');
+  await page.getByRole('heading', { name: /backup|export/i }).waitFor();
+}
+
+/** SPA-navigate to /admin/validate-members, preserving auth token */
+async function gotoValidator(page) {
+  await page.waitForSelector('a[href="/admin/validate-members"]', { timeout: 5_000 }).catch(() => null);
+  const clicked = await page.evaluate(() => {
+    const link = document.querySelector('a[href="/admin/validate-members"]');
+    if (link) { link.click(); return true; }
+    return false;
+  });
+  if (!clicked) await page.goto('/admin/validate-members');
+  await page.getByRole('heading', { name: /validate|member data/i }).waitFor();
+}
 
 test.describe('Data export & backup', () => {
   test('backup page loads', async ({ adminPage: page }) => {
-    await page.goto('/backup');
+    await gotoBackup(page);
     await expect(page.getByRole('heading', { name: /backup|export/i })).toBeVisible();
   });
 
-  test('all export-type buttons are present', async ({ adminPage: page }) => {
-    await page.goto('/backup');
+  test('all export-type labels are present', async ({ adminPage: page }) => {
+    await gotoBackup(page);
 
-    for (const label of EXPORT_TYPES) {
-      await expect(page.getByRole('button', { name: label }).first()).toBeVisible();
+    // Each export option has a label <div> with the type name and a "Download" button
+    for (const label of EXPORT_LABELS) {
+      await expect(page.getByText(label).first()).toBeVisible();
     }
+    // The "Backup all data" button
+    await expect(page.getByRole('button', { name: /backup all/i })).toBeVisible();
   });
 
-  test('clicking "Members" export triggers an xlsx download', async ({ adminPage: page }) => {
-    await page.goto('/backup');
+  test('clicking first "Download" triggers an xlsx download', async ({ adminPage: page }) => {
+    await gotoBackup(page);
 
-    // Listen for the download event
+    // All individual export buttons say "Download"; click the first one
     const [download] = await Promise.all([
       page.waitForEvent('download', { timeout: 15_000 }),
-      page.getByRole('button', { name: /members/i }).first().click(),
+      page.getByRole('button', { name: /download/i }).first().click(),
     ]);
 
     expect(download.suggestedFilename()).toMatch(/\.xlsx$/i);
   });
 
   test('clicking "Backup all data" export triggers an xlsx download', async ({ adminPage: page }) => {
-    await page.goto('/backup');
+    await gotoBackup(page);
 
     const [download] = await Promise.all([
       page.waitForEvent('download', { timeout: 30_000 }),
@@ -61,13 +87,12 @@ test.describe('Data export & backup', () => {
 
 test.describe('Member data validator', () => {
   test('validator page loads', async ({ adminPage: page }) => {
-    await page.goto('/admin/validate-members');
+    await gotoValidator(page);
     await expect(page.getByRole('heading', { name: /validate|member data/i })).toBeVisible();
   });
 
   test('validator shows result (valid or issues)', async ({ adminPage: page }) => {
-    await page.goto('/admin/validate-members');
-    await page.waitForLoadState('networkidle');
+    await gotoValidator(page);
 
     // Either a "All member data is valid!" banner or a list of issues
     const valid   = page.getByText(/all member data is valid/i);


### PR DESCRIPTION
Transaction test:
- Add waitForSelector before SPA-clicking /finance/transactions/new to prevent auth-losing fallback to page.goto

User creation test:
- Wait for "saved" banner after member creation instead of waitForURL (SPA navigation doesn't fire "load" event for waitForURL)
- UserListPage.goto() now navigates Home first then clicks /users link (member detail page has no /users link in its NavBar)

Backup tests:
- Use SPA navigation via Home page link for /backup and /admin/validate-members
- Fix button assertions: individual export buttons say "Download" not type names; verify section labels (Members, Finance, etc.) as text
- Click first "Download" button for download test instead of non-existent "Members" button

https://claude.ai/code/session_01GdPoHRPgHV6E6APfqWN8V9