### PR TITLE
Fix SPA navigation in transaction/member/validator E2E tests

### DIFF
--- a/e2e/pages/FinancePage.js
+++ b/e2e/pages/FinancePage.js
@@ -58,7 +58,11 @@ export class TransactionEditorPage {
 
   async gotoNew() {
     // SPA navigation — see CLAUDE-E2E.md
-    // Wait for the SPA link to exist in the DOM before clicking
+    // Navigate Home first (Home has the link; finance sub-pages don't)
+    await this.page.evaluate(() => {
+      const h = document.querySelector('a[href="/"]');
+      if (h) h.click();
+    });
     await this.page.waitForSelector('a[href="/finance/transactions/new"]', { timeout: 5_000 }).catch(() => null);
     const clicked = await this.page.evaluate(() => {
       const link = document.querySelector('a[href="/finance/transactions/new"]');

--- a/e2e/pages/MemberEditorPage.js
+++ b/e2e/pages/MemberEditorPage.js
@@ -9,11 +9,13 @@ export class MemberEditorPage {
   }
 
   async gotoNew() {
-    // Use page.evaluate() to fire a DOM click — this triggers React Router's
-    // onClick handler regardless of CSS visibility.  The Home page renders both
-    // a mobile layout (md:hidden) and a desktop grid; Playwright's locator.click()
-    // would fail if it resolved the hidden mobile element first.
-    // See CLAUDE-E2E.md § "The SPA-navigation pattern".
+    // SPA navigation — see CLAUDE-E2E.md § "The SPA-navigation pattern".
+    // Navigate Home first (only Home has the /members/new link).
+    await this.page.evaluate(() => {
+      const h = document.querySelector('a[href="/"]');
+      if (h) h.click();
+    });
+    await this.page.waitForSelector('a[href="/members/new"]', { timeout: 5_000 }).catch(() => null);
     const clicked = await this.page.evaluate(() => {
       const link = document.querySelector('a[href="/members/new"]');
       if (link) { link.click(); return true; }

--- a/e2e/tests/11-backup.spec.js
+++ b/e2e/tests/11-backup.spec.js
@@ -94,16 +94,14 @@ test.describe('Member data validator', () => {
   test('validator shows result (valid or issues)', async ({ adminPage: page }) => {
     await gotoValidator(page);
 
-    // Either a "All member data is valid!" banner or a list of issues
-    const valid   = page.getByText(/all member data is valid/i);
-    const issues  = page.getByRole('heading', { name: /issues?/i });
-    const recheck = page.getByRole('button', { name: /re-check/i });
+    // Wait for the "Re-check now" button (always present once loaded)
+    await expect(page.getByRole('button', { name: /re-check/i })).toBeVisible({ timeout: 15_000 });
 
-    const anyVisible = await Promise.any([
-      valid.isVisible(),
-      issues.isVisible(),
-      recheck.isVisible(),
-    ]);
-    expect(anyVisible).toBe(true);
+    // After loading, either the "All valid" banner or flagged members appear
+    const valid  = page.getByText(/all member data is valid/i);
+    const flagged = page.getByText(/issues? found/i);
+
+    // At least one of these should be visible
+    await expect(valid.or(flagged)).toBeVisible({ timeout: 10_000 });
   });
 });


### PR DESCRIPTION
Root cause: SPA-navigate helpers assumed the target link existed on the current page, but tests land on sub-pages (e.g. finance categories, users list) that don't have links to /finance/transactions/new or /members/new. The fallback page.goto() loses the in-memory auth token.

Fix: TransactionEditorPage.gotoNew() and MemberEditorPage.gotoNew() now click the Home link first (always in NavBar) before looking for the target link.

Also fix validator test: Promise.any with isVisible() always resolves (never rejects), so false values weren't caught. Use Playwright's locator.or() pattern instead.

https://claude.ai/code/session_01GdPoHRPgHV6E6APfqWN8V9