### PR TITLE
Fix remaining E2E test failures: strict mode, required fields, naviga…

### DIFF
--- a/e2e/tests/06-finance.spec.js
+++ b/e2e/tests/06-finance.spec.js
@@ -44,7 +44,7 @@ test.describe('Finance accounts', () => {
     await acctPage.addNameInput().fill(ACCT_NAME);
     await acctPage.addButton().click();
 
-    await expect(page.getByText(ACCT_NAME)).toBeVisible({ timeout: 6_000 });
+    await expect(page.getByText(ACCT_NAME).first()).toBeVisible({ timeout: 6_000 });
   });
 
   test('delete the new finance account', async ({ adminPage: page }) => {
@@ -110,7 +110,8 @@ test.describe('Finance transactions', () => {
     await editor.amountInput().fill('50.00');
 
     // Category allocation — required by form validation
-    // Fill the first category amount input to match the transaction amount
+    // Categories load async from the API; wait for at least one input to appear
+    await page.locator('input[name="categoryAmount"]').first().waitFor({ timeout: 10_000 });
     await page.locator('input[name="categoryAmount"]').first().fill('50.00');
 
     await editor.saveButton().click();

--- a/e2e/tests/07-roles-users.spec.js
+++ b/e2e/tests/07-roles-users.spec.js
@@ -92,8 +92,14 @@ test.describe('System users', () => {
     // Step 1: Create a member to link to the new user
     const memberEditor = new MemberEditorPage(page);
     await memberEditor.gotoNew();
-    await memberEditor.surnameInput().fill(MEMBER_SURNAME);
-    await memberEditor.forenamesInput().fill(MEMBER_FORENAMES);
+    await memberEditor.fillMinimal({
+      forenames: MEMBER_FORENAMES,
+      surname:   MEMBER_SURNAME,
+      statusName: 'Current',
+      className:  'Ordinary',
+      postcode:   'SW1A 1AA',
+      joinedOn:   '01/01/2025',
+    });
     await memberEditor.saveButton().click();
     // Wait for save success (banner appears, then SPA redirects after 1200ms)
     await expect(page.getByText(/saved/i).first()).toBeVisible({ timeout: 10_000 });

--- a/e2e/tests/11-backup.spec.js
+++ b/e2e/tests/11-backup.spec.js
@@ -34,6 +34,11 @@ async function gotoBackup(page) {
 
 /** SPA-navigate to /admin/validate-members, preserving auth token */
 async function gotoValidator(page) {
+  // Navigate Home first (backup page doesn't have the validator link)
+  await page.evaluate(() => {
+    const h = document.querySelector('a[href="/"]');
+    if (h) h.click();
+  });
   await page.waitForSelector('a[href="/admin/validate-members"]', { timeout: 5_000 }).catch(() => null);
   const clicked = await page.evaluate(() => {
     const link = document.querySelector('a[href="/admin/validate-members"]');
@@ -97,11 +102,11 @@ test.describe('Member data validator', () => {
     // Wait for the "Re-check now" button (always present once loaded)
     await expect(page.getByRole('button', { name: /re-check/i })).toBeVisible({ timeout: 15_000 });
 
-    // After loading, either the "All valid" banner or flagged members appear
-    const valid  = page.getByText(/all member data is valid/i);
-    const flagged = page.getByText(/issues? found/i);
+    // After loading, either the "All valid" banner or flagged member rows appear
+    const valid  = page.getByText('All member data is valid!');
+    const flagged = page.locator('text=/\\d+ member/');
 
-    // At least one of these should be visible
-    await expect(valid.or(flagged)).toBeVisible({ timeout: 10_000 });
+    // At least one of these should be visible (use .first() to avoid strict mode)
+    await expect(valid.or(flagged).first()).toBeVisible({ timeout: 10_000 });
   });
 });


### PR DESCRIPTION
…tion

1. Finance account (test 45): getByText(ACCT_NAME) matched twice (input + list) — add .first() to avoid strict mode violation.

2. Transaction (test 51): categoryAmount inputs only appear after async category fetch — add explicit waitFor() before fill().

3. User creation (test 63): Member form requires statusId, classId, joinedOn, nextRenewal, and postcode — switch from manual fill to fillMinimal() helper which handles all required fields.

4. Validator (test 90): locator.or() resolved to 2 elements because both "All member data is valid!" and "no issues found" matched — use exact text match and .first(). Also navigate Home first since backup page lacks the validator link.

https://claude.ai/code/session_01GdPoHRPgHV6E6APfqWN8V9