### PR TITLE
Fix user test class name and transaction test category ordering

### DIFF
--- a/e2e/tests/06-finance.spec.js
+++ b/e2e/tests/06-finance.spec.js
@@ -11,9 +11,9 @@
 //  ✓ Delete a non-locked account → removed
 //  ✓ Finance categories page loads
 //  ✓ Add a finance category → appears in list
-//  ✓ Delete a category → removed
 //  ✓ Add a money-in transaction → appears in ledger
 //  ✓ Finance ledger loads by account, category, and group
+//  ✓ Delete a category → removed (after transaction tests use it)
 
 import { test, expect } from '../fixtures/admin.js';
 import {
@@ -58,7 +58,7 @@ test.describe('Finance accounts', () => {
   });
 });
 
-// ── Finance Categories ────────────────────────────────────────────────────
+// ── Finance Categories (add) ────────────────────────────────────────────
 
 test.describe('Finance categories', () => {
   test('categories page loads', async ({ adminPage: page }) => {
@@ -76,20 +76,9 @@ test.describe('Finance categories', () => {
 
     await expect(page.getByText(CAT_NAME)).toBeVisible({ timeout: 6_000 });
   });
-
-  test('delete the new category', async ({ adminPage: page }) => {
-    const catPage = new FinanceCategoriesPage(page);
-    await catPage.goto();
-
-    const row = catPage.categoryRow(CAT_NAME);
-    page.once('dialog', (d) => d.accept());
-    await row.getByRole('button', { name: /delete/i }).click();
-
-    await expect(page.getByText(CAT_NAME)).toBeHidden({ timeout: 6_000 });
-  });
 });
 
-// ── Transactions ──────────────────────────────────────────────────────────
+// ── Transactions (depend on the category created above) ─────────────────
 
 test.describe('Finance transactions', () => {
   test('add a money-in transaction', async ({ adminPage: page }) => {
@@ -126,6 +115,21 @@ test.describe('Finance transactions', () => {
 
     // The payee should appear somewhere in the ledger
     await expect(page.getByText(PAYEE)).toBeVisible({ timeout: 6_000 });
+  });
+});
+
+// ── Category cleanup (after transaction tests used it) ──────────────────
+
+test.describe('Finance category cleanup', () => {
+  test('delete the new category', async ({ adminPage: page }) => {
+    const catPage = new FinanceCategoriesPage(page);
+    await catPage.goto();
+
+    const row = catPage.categoryRow(CAT_NAME);
+    page.once('dialog', (d) => d.accept());
+    await row.getByRole('button', { name: /delete/i }).click();
+
+    await expect(page.getByText(CAT_NAME)).toBeHidden({ timeout: 6_000 });
   });
 });
 

--- a/e2e/tests/07-roles-users.spec.js
+++ b/e2e/tests/07-roles-users.spec.js
@@ -96,7 +96,7 @@ test.describe('System users', () => {
       forenames: MEMBER_FORENAMES,
       surname:   MEMBER_SURNAME,
       statusName: 'Current',
-      className:  'Ordinary',
+      className:  'Individual',
       postcode:   'SW1A 1AA',
       joinedOn:   '01/01/2025',
     });


### PR DESCRIPTION
1. User test: Change className from 'Ordinary' to 'Individual' — the only seeded member class is "Individual" (locked), not "Ordinary".

2. Transaction test: Move category delete to AFTER transaction tests. No finance categories are seeded, so the transaction test depends on the category created by the "add a new category" test. Previously the category was deleted before the transaction test ran, leaving no categoryAmount inputs to fill.

https://claude.ai/code/session_01GdPoHRPgHV6E6APfqWN8V9