### PR TITLE
Fix E2E: ledger account selection and user member-select label

### DIFF
--- a/e2e/tests/06-finance.spec.js
+++ b/e2e/tests/06-finance.spec.js
@@ -113,8 +113,13 @@ test.describe('Finance transactions', () => {
     const ledger = new FinanceLedgerPage(page);
     await ledger.gotoByAccount();
 
+    // Must select an account before transactions are shown (selId controls fetch)
+    const acctSelect = page.locator('select[name="selId"]');
+    await acctSelect.waitFor({ timeout: 6_000 });
+    await acctSelect.selectOption({ index: 1 }); // first real account after "— select —"
+
     // The payee should appear somewhere in the ledger
-    await expect(page.getByText(PAYEE)).toBeVisible({ timeout: 6_000 });
+    await expect(page.getByText(PAYEE)).toBeVisible({ timeout: 10_000 });
   });
 });
 

--- a/e2e/tests/07-roles-users.spec.js
+++ b/e2e/tests/07-roles-users.spec.js
@@ -113,8 +113,26 @@ test.describe('System users', () => {
     await page.getByRole('heading', { name: 'Add New User' }).waitFor({ timeout: 10_000 });
 
     // Step 4: Select the member from the dropdown
+    // Label format: "Surname, Forenames" (see UserEditor.jsx)
     const memberSelect = page.locator('select[name="memberId"]');
-    await memberSelect.selectOption({ label: new RegExp(MEMBER_SURNAME) });
+    await memberSelect.waitFor({ timeout: 10_000 });
+    // Wait for options to load from API, then pick by partial text match
+    await page.waitForFunction(
+      (surname) => {
+        const sel = document.querySelector('select[name="memberId"]');
+        return sel && [...sel.options].some((o) => o.text.includes(surname));
+      },
+      MEMBER_SURNAME,
+      { timeout: 10_000 },
+    );
+    const optionLabel = await memberSelect.evaluate(
+      (sel, surname) => {
+        const opt = [...sel.options].find((o) => o.text.includes(surname));
+        return opt ? opt.text : null;
+      },
+      MEMBER_SURNAME,
+    );
+    await memberSelect.selectOption({ label: optionLabel });
 
     // Step 5: Fill required fields
     await page.locator('input[name="username"]').fill(USER_UNAME);


### PR DESCRIPTION
1. Ledger test: select an account from the selId dropdown before checking for the payee — the ledger shows no transactions until an account/category/group is selected.

2. User test: Playwright selectOption requires a string label, not RegExp. Wait for member options to load, find the option containing MEMBER_SURNAME, then select by exact label text.

3. Category cleanup: was failing because the worker restarted after the ledger test failure, giving a new Date.now() SUFFIX. Fixing the ledger test prevents the worker restart, so the SUFFIX stays consistent.

https://claude.ai/code/session_01GdPoHRPgHV6E6APfqWN8V9