### PR TITLE
Fix E2E: category-with-transactions test and user list strict mode

### DIFF
--- a/e2e/tests/06-finance.spec.js
+++ b/e2e/tests/06-finance.spec.js
@@ -126,15 +126,26 @@ test.describe('Finance transactions', () => {
 // ── Category cleanup (after transaction tests used it) ──────────────────
 
 test.describe('Finance category cleanup', () => {
-  test('delete the new category', async ({ adminPage: page }) => {
+  test('category with transactions cannot be deleted', async ({ adminPage: page }) => {
     const catPage = new FinanceCategoriesPage(page);
     await catPage.goto();
 
     const row = catPage.categoryRow(CAT_NAME);
-    page.once('dialog', (d) => d.accept());
+
+    // Two dialogs fire: (1) confirm prompt, (2) error alert from backend
+    let alertMsg = '';
+    page.on('dialog', async (d) => {
+      if (d.type() === 'confirm') await d.accept();
+      else { alertMsg = d.message(); await d.dismiss(); }
+    });
+
     await row.getByRole('button', { name: /delete/i }).click();
 
-    await expect(page.getByText(CAT_NAME)).toBeHidden({ timeout: 6_000 });
+    // Wait briefly for the API round-trip and alert
+    await page.waitForTimeout(2_000);
+    expect(alertMsg).toMatch(/cannot delete/i);
+    // Category should still be visible
+    await expect(page.getByText(CAT_NAME)).toBeVisible();
   });
 });
 

--- a/e2e/tests/07-roles-users.spec.js
+++ b/e2e/tests/07-roles-users.spec.js
@@ -147,8 +147,9 @@ test.describe('System users', () => {
   test('new user appears in the users list', async ({ adminPage: page }) => {
     const userList = new UserListPage(page);
     await userList.goto();
-    // The user's display name comes from the linked member
-    await expect(page.getByText(MEMBER_SURNAME)).toBeVisible();
+    // The user's display name comes from the linked member.
+    // Name appears in both "Full Name" and "Member" columns, so use .first()
+    await expect(page.getByText(MEMBER_SURNAME).first()).toBeVisible();
   });
 
   test('edit user username', async ({ adminPage: page }) => {


### PR DESCRIPTION
1. Category cleanup: backend refuses to delete categories with transactions (returns 400). Changed test to verify the error alert message instead of expecting deletion.

2. User list: member name appears in both "Full Name" and "Member" columns as buttons. Added .first() to disambiguate the locator.

https://claude.ai/code/session_01GdPoHRPgHV6E6APfqWN8V9