### PR TITLE
Increase E2E globalTimeout from 10 to 15 minutes

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -59,8 +59,8 @@ export default defineConfig({
 
   // Global setup creates (or resets) the test tenant before any tests run.
   // globalTimeout covers the ENTIRE test run (setup + all tests + teardown).
-  // 10 minutes for CI (83+ tests × ~3 s login overhead each).
-  globalTimeout: process.env.CI ? 600_000 : 300_000,
+  // 15 minutes for CI (130 tests × ~5 s avg including login overhead).
+  globalTimeout: process.env.CI ? 900_000 : 300_000,
   globalSetup: './global-setup.js',
   globalTeardown: './global-teardown.js',
 


### PR DESCRIPTION
The suite now has 130 tests (up from 83 when the timeout was set). At ~5s average per test including login overhead, 10 minutes is too tight — 7 tests were consistently not running before timeout.

https://claude.ai/code/session_01KBz3SZWwrCtqcwvLfRaoR5