### PR TITLE
Fix E2E tenant cleanup and delete-member test flakiness

### DIFF
--- a/e2e/global-teardown.js
+++ b/e2e/global-teardown.js
@@ -21,8 +21,8 @@ function readSlug() {
 
 const API       = process.env.BEACON2_API_URL || 'http://localhost:3001';
 const SLUG      = readSlug();
-const SADM_USER = process.env.BEACON2_SYSADMIN_USERNAME || 'sysadmin';
-const SADM_PASS = process.env.BEACON2_SYSADMIN_PASSWORD || 'changeme';
+const SADM_EMAIL = process.env.BEACON2_SYSADMIN_EMAIL    || 'admin@beacon2.example';
+const SADM_PASS  = process.env.BEACON2_SYSADMIN_PASSWORD || 'changeme';
 
 async function apiCall(path, { method = 'GET', body, token } = {}) {
   const headers = { 'Content-Type': 'application/json' };
@@ -39,7 +39,7 @@ export default async function globalTeardown() {
   console.log('\n[teardown] Deleting test tenant…');
   const { body: loginBody } = await apiCall('/auth/system/login', {
     method: 'POST',
-    body: { username: SADM_USER, password: SADM_PASS },
+    body: { email: SADM_EMAIL, password: SADM_PASS },
   });
   const sysToken = loginBody?.accessToken;
   if (!sysToken) { console.warn('[teardown] Could not log in — skipping delete.'); return; }

--- a/e2e/tests/02-members.spec.js
+++ b/e2e/tests/02-members.spec.js
@@ -237,8 +237,6 @@ test.describe('Delete a member', () => {
 
     // Confirm member no longer appears
     await listPage.search(TEST_SURNAME);
-    await page.getByText('No members found.').waitFor({ timeout: 10_000 });
-    const count = await listPage.memberRowCount();
-    expect(count).toBe(0);
+    await expect(page.getByText('No members found.')).toBeVisible({ timeout: 10_000 });
   });
 });


### PR DESCRIPTION
- Teardown used `username` field for system login but the endpoint expects `email` — switched to SADM_EMAIL so tenant deletion works
- Delete-member assertion had a race between waitFor and memberRowCount re-checking visibility — simplified to a single toBeVisible expect

https://claude.ai/code/session_019izseLJawyirhCYfw62C3X