### PR TITLE
Fix GROUP BY clause in transaction detail endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 - **Finance ledger GROUP BY error** — adding short_name and type to the SELECT
   without adding them to GROUP BY caused all transaction queries to fail with a
   PostgreSQL error. Fixed by including `g.short_name, g.type` in commonGroupBy.
+- **Transaction redisplay after save** — the GET /transactions/:id endpoint had
+  the same GROUP BY omission (`g.short_name, g.type`), causing "Transaction #null"
+  and an error message after saving a new transaction despite the save succeeding.
 
 ## [0.8.3] — 2026-04-02
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-backend",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-backend",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",

--- a/backend/src/routes/finance.js
+++ b/backend/src/routes/finance.js
@@ -527,7 +527,7 @@ router.get('/transactions/:id', requirePrivilege('finance_transactions', 'view')
        LEFT JOIN transaction_categories tc ON tc.transaction_id = t.id
        LEFT JOIN finance_categories fc ON fc.id = tc.category_id
        WHERE t.id = $1
-       GROUP BY t.id, m1.forenames, m1.surname, m2.forenames, m2.surname, g.name, fa.name, cb.batch_ref,
+       GROUP BY t.id, m1.forenames, m1.surname, m2.forenames, m2.surname, g.name, g.short_name, g.type, fa.name, cb.batch_ref,
                 ref_orig.transaction_number, ref_by.transaction_number, ref_by.amount, fa.enable_refunds`,
       [req.params.id],
     );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-frontend",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-frontend",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.20.4",
         "@tiptap/extension-text-style": "^3.20.4",


### PR DESCRIPTION
## Summary
Fixed a GROUP BY omission in the GET /transactions/:id endpoint that was causing transaction redisplay failures after saving a new transaction.

## Changes
- Added `g.short_name` and `g.type` to the GROUP BY clause in the transaction detail query
- This mirrors the fix previously applied to the transaction list endpoint
- Resolves the "Transaction #null" display error and associated error message that occurred after successfully saving a new transaction

## Details
The SELECT statement was retrieving `g.short_name` and `g.type` from the finance_groups table but wasn't including them in the GROUP BY clause. This caused PostgreSQL to raise an error when executing the query. By adding these columns to the GROUP BY clause, the query now executes successfully and allows the transaction detail to be properly displayed after a save operation.

https://claude.ai/code/session_01HJXu4rv57pyYon9gehLudc