### PR TITLE
Move Groups/Teams switch links into NavBar

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-backend",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-backend",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-frontend",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-frontend",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.20.4",
         "@tiptap/extension-text-style": "^3.20.4",

--- a/frontend/src/pages/groups/GroupList.jsx
+++ b/frontend/src/pages/groups/GroupList.jsx
@@ -163,6 +163,7 @@ export default function GroupList() {
   const navLinks = [
     { label: 'Home', to: '/' },
     ...(can('group_records_all', 'create') ? [{ label: 'Add New Group', to: '/groups/new' }] : []),
+    { label: 'Teams', to: '/teams' },
   ];
 
   return (
@@ -172,9 +173,6 @@ export default function GroupList() {
 
       <div className="max-w-6xl mx-auto px-4 py-4">
         <h1 className="text-xl font-bold text-center mb-3">Groups</h1>
-        <div className="text-center mb-3">
-          <Link to="/teams" className="text-sm text-blue-700 hover:underline">Switch to Teams</Link>
-        </div>
 
         {/* ── Filters ──────────────────────────────────────────────── */}
         <div className="bg-white/90 rounded-lg shadow-sm p-3 mb-3 flex flex-wrap gap-4 items-end">

--- a/frontend/src/pages/groups/TeamList.jsx
+++ b/frontend/src/pages/groups/TeamList.jsx
@@ -154,6 +154,7 @@ export default function TeamList() {
   const navLinks = [
     { label: 'Home', to: '/' },
     ...(can('group_records_all', 'create') ? [{ label: 'Add New Team', to: '/teams/new' }] : []),
+    { label: 'Groups', to: '/groups' },
   ];
 
   return (
@@ -163,9 +164,6 @@ export default function TeamList() {
 
       <div className="max-w-6xl mx-auto px-4 py-4">
         <h1 className="text-xl font-bold text-center mb-3">Teams</h1>
-        <div className="text-center mb-3">
-          <Link to="/groups" className="text-sm text-blue-700 hover:underline">Switch to Groups</Link>
-        </div>
 
         {/* ── Filters ──────────────────────────────────────────────── */}
         <div className="bg-white/90 rounded-lg shadow-sm p-3 mb-3 flex flex-wrap gap-4 items-end">


### PR DESCRIPTION
Instead of a separate "Switch to Teams/Groups" link below the page heading, add the cross-link directly to the NavBar for consistency.

https://claude.ai/code/session_011FjnLmgrE9zTHFkmpfShV9