### PR TITLE
Fix remaining E2E failures: calendar option visibility + event type i…

### DIFF
--- a/e2e/tests/12-calendar.spec.js
+++ b/e2e/tests/12-calendar.spec.js
@@ -97,8 +97,9 @@ test.describe('Calendar', () => {
     const groupSelect = page.locator('select[name="groupId"]');
     await expect(groupSelect).toBeVisible({ timeout: 5_000 });
 
-    // Should have at least the placeholder option
-    await expect(groupSelect.locator('option').first()).toBeVisible();
+    // Should have at least the placeholder option (options inside a closed
+    // <select> are not "visible" per Playwright, so check count instead)
+    await expect(groupSelect.locator('option')).not.toHaveCount(0);
   });
 });
 

--- a/e2e/tests/17-setup-extended.spec.js
+++ b/e2e/tests/17-setup-extended.spec.js
@@ -151,12 +151,12 @@ test.describe('Event Types', () => {
   test('add a new event type', async ({ adminPage: page }) => {
     await gotoHomeLink(page, '/event-types', 'Event Types');
 
-    // Fill the add-new form
-    const nameInput = page.locator('input[name="name"]').first();
+    // Fill the add-new form (input names are "newName" / "newDesc")
+    const nameInput = page.locator('input[name="newName"]').first();
     await nameInput.waitFor({ timeout: 5_000 });
     await nameInput.fill(`E2EEventType${SUFFIX}`);
 
-    const descInput = page.locator('input[name="description"]').first();
+    const descInput = page.locator('input[name="newDesc"]').first();
     if (await descInput.isVisible()) await descInput.fill('Test event type');
 
     await page.getByRole('button', { name: /save/i }).first().click();


### PR DESCRIPTION
…nput name

- Calendar group filter: use toHaveCount instead of toBeVisible for <option> elements (Playwright considers options inside a closed <select> as hidden)
- Event Types: input name is "newName"/"newDesc", not "name"/"description"

https://claude.ai/code/session_01M6rvb3GaFyiqmvTH3cXEUM