### PR TITLE
Split E2E teams tests into dedicated spec and page object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
   and `OpenMeetings.jsx` from `pages/groups/` to new `pages/calendar/` directory;
   moved `TeamList.jsx` and `TeamRecord.jsx` to new `pages/teams/` directory, so
   each page directory mirrors a single backend domain
+- **Split E2E teams tests** — extracted team tests from `04-groups.spec.js` into new
+  `04b-teams.spec.js` with a dedicated `TeamsPage.js` page object, matching R8's
+  `pages/teams/` directory split
 - **Extract shared Zod schemas** (R9) — created `backend/src/schemas/` directory with
   `common.js`, `groups.js`, and `teams.js`. Extracted 9 duplicated Zod schemas from
   `routes/groups.js` and `routes/teams.js` into shared modules, using `.extend()` for

--- a/e2e/pages/TeamsPage.js
+++ b/e2e/pages/TeamsPage.js
@@ -1,0 +1,56 @@
+// beacon2/e2e/pages/TeamsPage.js
+// Page Object Models for Teams list and record.
+// Beacon UG §5 — "Teams"
+
+export class TeamListPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto() {
+    const clicked = await this.page.evaluate(() => {
+      const link = document.querySelector('a[href="/teams"]');
+      if (link) { link.click(); return true; }
+      return false;
+    });
+    if (!clicked) await this.page.goto('/teams');
+    await this.page.getByRole('heading', { name: 'Teams' }).waitFor({ timeout: 10_000 });
+  }
+
+  addNewButton() {
+    return this.page.getByRole('link', { name: /add new team/i }).first();
+  }
+
+  teamLink(name) {
+    return this.page.getByRole('link', { name }).first();
+  }
+}
+
+export class TeamRecordPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async gotoNew() {
+    const clicked = await this.page.evaluate(() => {
+      const link = document.querySelector('a[href="/teams/new"]');
+      if (link) { link.click(); return true; }
+      return false;
+    });
+    if (!clicked) {
+      const listClicked = await this.page.evaluate(() => {
+        const link = document.querySelector('a[href="/teams"]');
+        if (link) { link.click(); return true; }
+        return false;
+      });
+      if (!listClicked) await this.page.goto('/teams');
+      await this.page.getByRole('heading', { name: 'Teams' }).waitFor();
+      await this.page.getByRole('link', { name: /add new team/i }).first().click();
+    }
+    await this.page.getByRole('heading', { name: /add new team/i }).waitFor({ timeout: 10_000 });
+  }
+
+  nameInput()     { return this.page.locator('input[name="name"]').first(); }
+  saveButton()    { return this.page.getByRole('button', { name: /save|add team/i }).first(); }
+  deleteButton()  { return this.page.getByRole('button', { name: /delete/i }).first(); }
+}

--- a/e2e/tests/04-groups.spec.js
+++ b/e2e/tests/04-groups.spec.js
@@ -1,5 +1,5 @@
 // beacon2/e2e/tests/04-groups.spec.js
-// Group and Team management tests.
+// Group management tests. Team tests are in 04b-teams.spec.js.
 // Beacon UG §5   — "Groups"
 // Beacon UG §5.1 — "The Group List"
 // Beacon UG §5.2 — "Group Details"
@@ -15,12 +15,7 @@
 //  ✓ Group ledger tab is accessible
 //  ✓ Delete a group
 //  ✓ Switch to Teams link on group list
-//  ✓ Team list page loads
 //  ✓ Switch to Groups link on team list
-//  ✓ Add a new team → appears in list
-//  ✓ Team tabs: Schedule and Ledger are accessible
-//  ✓ Add a schedule event to a team
-//  ✓ Delete a team
 
 import { test, expect } from '../fixtures/admin.js';
 import { GroupListPage, GroupRecordPage } from '../pages/GroupsPage.js';
@@ -179,137 +174,5 @@ test.describe('Groups / Teams switching', () => {
     await groupsLink.click();
 
     await expect(page.getByRole('heading', { name: 'Groups' })).toBeVisible({ timeout: 10_000 });
-  });
-});
-
-// ── Teams ───────────────────────────────────────────────────────────────
-
-const TEAM_NAME = `E2ETeam${SUFFIX}`;
-
-test.describe('Team list', () => {
-  test('page loads with heading', async ({ adminPage: page }) => {
-    const clicked = await page.evaluate(() => {
-      const link = document.querySelector('a[href="/teams"]');
-      if (link) { link.click(); return true; }
-      return false;
-    });
-    if (!clicked) await page.goto('/teams');
-    await expect(page.getByRole('heading', { name: 'Teams' })).toBeVisible({ timeout: 10_000 });
-  });
-});
-
-test.describe('Add and edit a team', () => {
-  async function gotoTeamNew(page) {
-    // Navigate to /teams first, then click "Add new team"
-    const clicked = await page.evaluate(() => {
-      const link = document.querySelector('a[href="/teams/new"]');
-      if (link) { link.click(); return true; }
-      return false;
-    });
-    if (!clicked) {
-      const listClicked = await page.evaluate(() => {
-        const link = document.querySelector('a[href="/teams"]');
-        if (link) { link.click(); return true; }
-        return false;
-      });
-      if (!listClicked) await page.goto('/teams');
-      await page.getByRole('heading', { name: 'Teams' }).waitFor();
-      await page.getByRole('link', { name: /add new team/i }).first().click();
-    }
-    await page.getByRole('heading', { name: /add new team/i }).waitFor({ timeout: 10_000 });
-  }
-
-  test('create a new team', async ({ adminPage: page }) => {
-    await gotoTeamNew(page);
-
-    await page.locator('input[name="name"]').first().fill(TEAM_NAME);
-    await page.getByRole('button', { name: /add team/i }).first().click();
-
-    // After save, URL should become /teams/:id
-    await page.waitForURL(/\/teams\/(?!new\b)[^/]+$/, { timeout: 10_000 });
-    await expect(page.getByRole('heading', { name: TEAM_NAME })).toBeVisible({ timeout: 10_000 });
-  });
-
-  test('new team appears in the team list', async ({ adminPage: page }) => {
-    const clicked = await page.evaluate(() => {
-      const link = document.querySelector('a[href="/teams"]');
-      if (link) { link.click(); return true; }
-      return false;
-    });
-    if (!clicked) await page.goto('/teams');
-    await page.getByRole('heading', { name: 'Teams' }).waitFor({ timeout: 10_000 });
-
-    await expect(page.getByRole('link', { name: TEAM_NAME }).first()).toBeVisible({ timeout: 6_000 });
-  });
-});
-
-test.describe('Team tabs', () => {
-  async function openTeam(page) {
-    const clicked = await page.evaluate(() => {
-      const link = document.querySelector('a[href="/teams"]');
-      if (link) { link.click(); return true; }
-      return false;
-    });
-    if (!clicked) await page.goto('/teams');
-    await page.getByRole('heading', { name: 'Teams' }).waitFor({ timeout: 10_000 });
-
-    await page.getByRole('link', { name: TEAM_NAME }).first().click();
-    await expect(page.getByRole('heading', { name: TEAM_NAME })).toBeVisible({ timeout: 10_000 });
-  }
-
-  test('Schedule tab is visible and clickable', async ({ adminPage: page }) => {
-    await openTeam(page);
-    const scheduleTab = page.getByRole('tab', { name: /schedule/i }).first();
-    await expect(scheduleTab).toBeVisible();
-    await scheduleTab.click();
-    await expect(page.getByText(/schedule/i).first()).toBeVisible();
-  });
-
-  test('Ledger tab is visible and clickable', async ({ adminPage: page }) => {
-    await openTeam(page);
-    const ledgerTab = page.getByRole('tab', { name: /ledger/i }).first();
-    await expect(ledgerTab).toBeVisible();
-    await ledgerTab.click();
-    await expect(page.getByText(/brought forward/i).first()).toBeVisible({ timeout: 6_000 });
-  });
-
-  test('add a schedule event to a team', async ({ adminPage: page }) => {
-    await openTeam(page);
-    await page.getByRole('tab', { name: /schedule/i }).first().click();
-
-    const dateInput = page.locator('input[name="eventDate"]').first();
-    await expect(dateInput).toBeVisible({ timeout: 5_000 });
-    await dateInput.fill('2026-07-15');
-
-    const timeInput = page.locator('input[name="startTime"]').first();
-    if (await timeInput.isVisible()) await timeInput.fill('14:00');
-
-    const topicInput = page.locator('input[name="topic"]').first();
-    if (await topicInput.isVisible()) await topicInput.fill('E2E Team Meeting');
-
-    await page.getByRole('button', { name: /add event/i }).first().click();
-
-    await expect(page.getByText('E2E Team Meeting')).toBeVisible({ timeout: 6_000 });
-  });
-});
-
-test.describe('Delete a team', () => {
-  test('delete the test team', async ({ adminPage: page }) => {
-    const clicked = await page.evaluate(() => {
-      const link = document.querySelector('a[href="/teams"]');
-      if (link) { link.click(); return true; }
-      return false;
-    });
-    if (!clicked) await page.goto('/teams');
-    await page.getByRole('heading', { name: 'Teams' }).waitFor({ timeout: 10_000 });
-
-    await page.getByRole('link', { name: TEAM_NAME }).first().click();
-    await expect(page.getByRole('heading', { name: TEAM_NAME })).toBeVisible({ timeout: 10_000 });
-
-    page.once('dialog', (d) => d.accept());
-    await page.getByRole('button', { name: /delete/i }).first().click();
-
-    await page.waitForURL('/teams', { timeout: 10_000 });
-    await expect(page.getByText(TEAM_NAME)).toBeHidden({ timeout: 5_000 });
   });
 });

--- a/e2e/tests/04b-teams.spec.js
+++ b/e2e/tests/04b-teams.spec.js
@@ -1,0 +1,103 @@
+// beacon2/e2e/tests/04b-teams.spec.js
+// Team management tests — split from 04-groups.spec.js to match
+// the pages/teams/ directory created by R8.
+//
+// Tests:
+//  ✓ Team list page loads
+//  ✓ Add a new team → appears in list
+//  ✓ Team tabs: Schedule and Ledger are accessible
+//  ✓ Add a schedule event to a team
+//  ✓ Delete a team
+
+import { test, expect } from '../fixtures/admin.js';
+import { TeamListPage, TeamRecordPage } from '../pages/TeamsPage.js';
+
+const SUFFIX    = Date.now();
+const TEAM_NAME = `E2ETeam${SUFFIX}`;
+
+test.describe('Team list', () => {
+  test('page loads with heading', async ({ adminPage: page }) => {
+    const listPage = new TeamListPage(page);
+    await listPage.goto();
+    await expect(page.getByRole('heading', { name: 'Teams' })).toBeVisible();
+  });
+});
+
+test.describe('Add and edit a team', () => {
+  test('create a new team', async ({ adminPage: page }) => {
+    const recordPage = new TeamRecordPage(page);
+    await recordPage.gotoNew();
+
+    await recordPage.nameInput().fill(TEAM_NAME);
+    await recordPage.saveButton().click();
+
+    // After save, URL should become /teams/:id
+    await page.waitForURL(/\/teams\/(?!new\b)[^/]+$/, { timeout: 10_000 });
+    await expect(page.getByRole('heading', { name: TEAM_NAME })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('new team appears in the team list', async ({ adminPage: page }) => {
+    const listPage = new TeamListPage(page);
+    await listPage.goto();
+    await expect(listPage.teamLink(TEAM_NAME)).toBeVisible({ timeout: 6_000 });
+  });
+});
+
+test.describe('Team tabs', () => {
+  async function openTeam(page) {
+    const listPage = new TeamListPage(page);
+    await listPage.goto();
+    await listPage.teamLink(TEAM_NAME).click();
+    await expect(page.getByRole('heading', { name: TEAM_NAME })).toBeVisible({ timeout: 10_000 });
+  }
+
+  test('Schedule tab is visible and clickable', async ({ adminPage: page }) => {
+    await openTeam(page);
+    const scheduleTab = page.getByRole('tab', { name: /schedule/i }).first();
+    await expect(scheduleTab).toBeVisible();
+    await scheduleTab.click();
+    await expect(page.getByText(/schedule/i).first()).toBeVisible();
+  });
+
+  test('Ledger tab is visible and clickable', async ({ adminPage: page }) => {
+    await openTeam(page);
+    const ledgerTab = page.getByRole('tab', { name: /ledger/i }).first();
+    await expect(ledgerTab).toBeVisible();
+    await ledgerTab.click();
+    await expect(page.getByText(/brought forward/i).first()).toBeVisible({ timeout: 6_000 });
+  });
+
+  test('add a schedule event to a team', async ({ adminPage: page }) => {
+    await openTeam(page);
+    await page.getByRole('tab', { name: /schedule/i }).first().click();
+
+    const dateInput = page.locator('input[name="eventDate"]').first();
+    await expect(dateInput).toBeVisible({ timeout: 5_000 });
+    await dateInput.fill('2026-07-15');
+
+    const timeInput = page.locator('input[name="startTime"]').first();
+    if (await timeInput.isVisible()) await timeInput.fill('14:00');
+
+    const topicInput = page.locator('input[name="topic"]').first();
+    if (await topicInput.isVisible()) await topicInput.fill('E2E Team Meeting');
+
+    await page.getByRole('button', { name: /add event/i }).first().click();
+
+    await expect(page.getByText('E2E Team Meeting')).toBeVisible({ timeout: 6_000 });
+  });
+});
+
+test.describe('Delete a team', () => {
+  test('delete the test team', async ({ adminPage: page }) => {
+    const listPage = new TeamListPage(page);
+    await listPage.goto();
+    await listPage.teamLink(TEAM_NAME).click();
+    await expect(page.getByRole('heading', { name: TEAM_NAME })).toBeVisible({ timeout: 10_000 });
+
+    page.once('dialog', (d) => d.accept());
+    await page.getByRole('button', { name: /delete/i }).first().click();
+
+    await page.waitForURL('/teams', { timeout: 10_000 });
+    await expect(page.getByText(TEAM_NAME)).toBeHidden({ timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
Extracted team CRUD tests from 04-groups.spec.js into 04b-teams.spec.js with a new TeamsPage.js page object model, matching the R8 pages/teams/ directory reorganization. Groups/Teams switching tests remain in 04-groups.spec.js since they span both domains.

https://claude.ai/code/session_01ABMDiCvCuA8cbVoAmioQS5