### PR TITLE
Fix E2E strict mode violation in event-members Details tab test

### DIFF
--- a/e2e/tests/19-event-members.spec.js
+++ b/e2e/tests/19-event-members.spec.js
@@ -191,7 +191,7 @@ test.describe('EventRecord navigation and details', () => {
     await gotoEventViaCalendar(page);
 
     // Date in DD/MM/YYYY format
-    await expect(page.getByText('15/06/2026')).toBeVisible();
+    await expect(page.getByText('15/06/2026', { exact: true })).toBeVisible();
     // Time
     await expect(page.getByText('10:00')).toBeVisible();
     // Group name as a link


### PR DESCRIPTION
getByText('15/06/2026') matched two elements: the combined "15/06/2026 10:00" paragraph and the standalone "15/06/2026" date. Adding { exact: true } ensures only the exact date text is matched.

https://claude.ai/code/session_015DazpkYfRfA4fyJMxqZj7H