### PR TITLE
Fix second strict mode violation in event-members Details tab test

### DIFF
--- a/e2e/tests/19-event-members.spec.js
+++ b/e2e/tests/19-event-members.spec.js
@@ -193,7 +193,7 @@ test.describe('EventRecord navigation and details', () => {
     // Date in DD/MM/YYYY format
     await expect(page.getByText('15/06/2026', { exact: true })).toBeVisible();
     // Time
-    await expect(page.getByText('10:00')).toBeVisible();
+    await expect(page.getByText('10:00', { exact: true })).toBeVisible();
     // Group name as a link
     await expect(page.getByRole('link', { name: GROUP_NAME })).toBeVisible();
     // Topic


### PR DESCRIPTION
getByText('10:00') also matched two elements: the combined "15/06/2026 10:00"
paragraph and the standalone "10:00" time. Adding { exact: true } as before.

https://claude.ai/code/session_015DazpkYfRfA4fyJMxqZj7H