### PR TITLE
Fix third strict mode violation: group name link in Details tab test

### DIFF
--- a/e2e/tests/19-event-members.spec.js
+++ b/e2e/tests/19-event-members.spec.js
@@ -195,7 +195,7 @@ test.describe('EventRecord navigation and details', () => {
     // Time
     await expect(page.getByText('10:00', { exact: true })).toBeVisible();
     // Group name as a link
-    await expect(page.getByRole('link', { name: GROUP_NAME })).toBeVisible();
+    await expect(page.getByRole('link', { name: GROUP_NAME }).first()).toBeVisible();
     // Topic
     await expect(page.getByText(EVENT_TOPIC)).toBeVisible();
   });


### PR DESCRIPTION
The group name link appears 3 times on the EventRecord page. Using .first() to resolve the strict mode violation since we only need to verify the link exists.

https://claude.ai/code/session_015DazpkYfRfA4fyJMxqZj7H