### PR TITLE
Fix fourth strict mode violation: EVENT_TOPIC matches heading and par…

### DIFF
--- a/e2e/tests/19-event-members.spec.js
+++ b/e2e/tests/19-event-members.spec.js
@@ -197,7 +197,7 @@ test.describe('EventRecord navigation and details', () => {
     // Group name as a link
     await expect(page.getByRole('link', { name: GROUP_NAME }).first()).toBeVisible();
     // Topic
-    await expect(page.getByText(EVENT_TOPIC)).toBeVisible();
+    await expect(page.getByRole('paragraph').filter({ hasText: EVENT_TOPIC })).toBeVisible();
   });
 
   test('all three tabs are visible and clickable', async ({ adminPage: page }) => {


### PR DESCRIPTION
…agraph

Target the paragraph specifically since the test checks details tab content, not the page heading.

https://claude.ai/code/session_015DazpkYfRfA4fyJMxqZj7H