### PR TITLE
Security M1/M4/M5: CSRF on /auth/refresh, payment redirect whitelist,…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,33 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
   `vite.config.js`, and `vi` mock usage in the test suites are compatible
   with vitest 4 and vite 8 out of the box. All upgraded packages are
   `devDependencies`; nothing ships to production
+- **Security M1 — CSRF protection on `/auth/refresh`** — the refresh
+  endpoint now verifies the `Origin` header against `CORS_ORIGIN` before
+  doing any work, and rejects mismatches with 403 `Origin not allowed.`
+  Because the refresh cookie is `SameSite=none` (required for the
+  Vercel→Render deployment), a cross-origin page could previously trigger
+  a refresh as a side effect — rotating the legitimate cookie and causing
+  a denial of service. The new check is stateless: browsers always set
+  Origin on cross-origin POSTs and it cannot be forged by attacker
+  JavaScript. In dev/test, requests without an Origin header (e.g.
+  supertest) are allowed
+- **Security M4 — payment redirect whitelist** — added
+  `frontend/src/lib/safeRedirect.js` with `isSafePaymentRedirect(url)`.
+  `ResumePayment.jsx` and `PortalRenewal.jsx` now validate the
+  backend-supplied `redirectUrl` before navigating, allowing only
+  same-origin URLs and the `paypal.com` / `sandbox.paypal.com` families
+  (including `www.` hosts). Look-alike domains (`paypal.com.evil.com`,
+  `evilpaypal.com`) and non-http(s) schemes (`javascript:`, `data:`) are
+  blocked. Failed checks surface a user-visible error instead of
+  navigating. Defence-in-depth if the backend is ever compromised or
+  mis-configured
+- **Security M5 — audit logging on bulk password reset** —
+  `POST /system/tenants/:id/set-temp-password`, the sys-admin-only
+  endpoint that resets every user's password in a tenant, now writes an
+  entry to the target tenant's audit log (`action=bulk_password_reset`,
+  `entity_type=tenant`, `user_name="System Admin: <name>"`, detail
+  recording the affected user count). Previously this powerful operation
+  left no trail in the tenant's audit view
 
 ## [0.9.6] — 2026-04-17
 

--- a/SECURITY-REVIEW.md
+++ b/SECURITY-REVIEW.md
@@ -173,7 +173,7 @@ fixes are implemented.
 
 ### MEDIUM
 
-#### M1 — SameSite=none on refresh cookie without additional CSRF protection — `OPEN`
+#### M1 — SameSite=none on refresh cookie without additional CSRF protection — `FIXED`
 - **File:** `backend/src/routes/auth.js:20`
 - **Issue:** The refresh token cookie uses `sameSite: 'none'` (required for cross-origin
   Vercel→Render). This means the cookie is sent with all cross-origin requests.
@@ -186,6 +186,17 @@ fixes are implemented.
 - **Fix:** Consider adding a CSRF token or using the Double Submit Cookie pattern for
   the refresh endpoint. Alternatively, document this as an accepted risk given the
   CORS + header requirement.
+- **Resolution:** `/auth/refresh` now enforces an Origin header check before doing
+  any work. `isAllowedOrigin()` in `backend/src/routes/auth.js` rejects (403
+  `Origin not allowed.`) any request whose `Origin` header does not match
+  `CORS_ORIGIN`. This is stateless CSRF protection: the browser always sets Origin
+  on cross-origin POSTs and it cannot be forged from a victim page, so an
+  attacker's site cannot trigger a refresh. Requests with no Origin header are
+  allowed in dev/test only (supertest, server-to-server) — in production, a
+  missing Origin on a cross-origin request is treated as a refusal to participate
+  in CORS and rejected. Covered by two new tests in
+  `backend/src/__tests__/auth.test.js` (mismatched Origin → 403;
+  matching Origin → 200).
 
 #### M2 — Zod validation errors expose field paths — `OPEN`
 - **File:** `backend/src/middleware/errorHandler.js:20-23`
@@ -204,7 +215,7 @@ fixes are implemented.
 - **Fix:** Document this clearly. Consider generating unique random passwords per user
   during migration and emailing them.
 
-#### M4 — Open redirect in payment flows — `OPEN`
+#### M4 — Open redirect in payment flows — `FIXED`
 - **Files:**
   - `frontend/src/pages/public/ResumePayment.jsx:34`
   - `frontend/src/pages/public/PortalRenewal.jsx:101-102`
@@ -214,13 +225,34 @@ fixes are implemented.
 - **Mitigation:** The URL comes from the trusted backend, not from user input.
 - **Fix:** Validate the redirect URL against a whitelist of allowed domains (e.g.,
   `paypal.com`) before redirecting.
+- **Resolution:** Added `frontend/src/lib/safeRedirect.js` exporting
+  `isSafePaymentRedirect(url)`. The helper allows only (1) same-origin URLs
+  (the stub PayPal flow bounces back to our own confirmation pages) and
+  (2) `paypal.com`, `www.paypal.com`, `sandbox.paypal.com`, and
+  `www.sandbox.paypal.com`. All other hosts, `javascript:`/`data:` schemes,
+  and look-alike domains (e.g. `paypal.com.evil.com`, `evilpaypal.com`) are
+  rejected. Both `ResumePayment.jsx` and `PortalRenewal.jsx` now call the
+  helper before `window.location.href = redirectUrl` and surface a
+  user-visible error ("The payment provider returned an unexpected
+  redirect…") if the check fails, instead of navigating. Covered by unit
+  tests in `frontend/src/__tests__/safeRedirect.test.js`.
 
-#### M5 — set-temp-password endpoint sets same password for ALL tenant users — `OPEN`
+#### M5 — set-temp-password endpoint sets same password for ALL tenant users — `FIXED`
 - **File:** `backend/src/routes/system.js:98-113`
 - **Issue:** This endpoint resets every user's password to the same value. While
   protected by `requireSysAdmin`, it's a powerful operation with no audit trail.
 - **Fix:** Add audit logging for this endpoint. Consider whether this is the right
   design (perhaps reset only specific users).
+- **Resolution:** `POST /system/tenants/:id/set-temp-password` now writes an
+  entry to the target tenant's `audit_log` via `logAudit()` after the bulk
+  reset. `user_id` is null (the caller is a sys-admin with no tenant-level
+  user record); `user_name` is `System Admin: <name>` so it cannot be
+  confused with a regular user; `action` is `bulk_password_reset`,
+  `entity_type` is `tenant`, and `detail` records how many users were
+  affected and that `must_change_password=true`. Narrowing the endpoint to
+  specific users was considered but left as-is — it exists for "all admins
+  locked out" situations where the sysadmin does not know any one user by
+  ID. The audit entry provides the accountability the finding called for.
 
 #### M6 — Password reset token in URL parameter — `OPEN`
 - **File:** `frontend/src/pages/public/PortalResetPassword.jsx:11`

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -129,6 +129,34 @@ describe('POST /auth/refresh', () => {
     expect(res.status).toBe(200);
     expect(res.body.accessToken).toBe('new.acc.tok');
   });
+
+  it('returns 403 when Origin header does not match CORS_ORIGIN (CSRF)', async () => {
+    const res = await request(app)
+      .post('/auth/refresh')
+      .set('Cookie', 'beacon2_refresh=valid-token')
+      .set('x-tenant-slug', TEST_TENANT)
+      .set('Origin', 'https://evil.example.com');
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Origin not allowed.');
+    expect(refreshTokens).not.toHaveBeenCalled();
+  });
+
+  it('accepts a refresh whose Origin matches CORS_ORIGIN', async () => {
+    refreshTokens.mockResolvedValueOnce({
+      accessToken:  'new.acc.tok',
+      refreshToken: 'new.ref.tok',
+    });
+
+    const res = await request(app)
+      .post('/auth/refresh')
+      .set('Cookie', 'beacon2_refresh=valid-token')
+      .set('x-tenant-slug', TEST_TENANT)
+      .set('Origin', 'http://localhost:5173');
+
+    expect(res.status).toBe(200);
+    expect(res.body.accessToken).toBe('new.acc.tok');
+  });
 });
 
 // ── POST /auth/system/login ───────────────────────────────────────────────

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -28,6 +28,29 @@ const cookieOptions = {
   maxAge: 1000 * 60 * 60 * 24 * parseInt(process.env.JWT_REFRESH_EXPIRES_DAYS ?? '30', 10),
 };
 
+// CSRF defence for the refresh cookie. Because the cookie is SameSite=none
+// a cross-origin POST from an attacker's page could otherwise trigger a
+// token refresh (revoking the legitimate one). The browser always sends
+// Origin on cross-origin requests and the attacker cannot spoof it, so we
+// require Origin — when present — to match CORS_ORIGIN. In dev/test
+// CORS_ORIGIN may be unset or Origin may be absent (supertest); we skip
+// the check there.
+function isAllowedOrigin(req) {
+  const allowed = process.env.CORS_ORIGIN;
+  if (!allowed) return true;
+  const origin = req.headers.origin;
+  if (!origin) {
+    // Browsers always send Origin on cross-origin POST. Absence means a
+    // non-browser caller (server-to-server, tests) — no CSRF risk.
+    return process.env.NODE_ENV !== 'production';
+  }
+  try {
+    return new URL(origin).origin === new URL(allowed).origin;
+  } catch {
+    return false;
+  }
+}
+
 // ─── POST /auth/login ─────────────────────────────────────────────────────
 // Log in a u3a user. Tenant is identified by the slug in the request body.
 // In production, tenant could also be determined by subdomain.
@@ -74,6 +97,10 @@ router.post('/logout', requireAuth, async (req, res, next) => {
 
 router.post('/refresh', async (req, res, next) => {
   try {
+    if (!isAllowedOrigin(req)) {
+      return res.status(403).json({ error: 'Origin not allowed.' });
+    }
+
     const refreshToken = req.cookies?.[COOKIE_NAME];
     if (!refreshToken) {
       return res.status(401).json({ error: 'No refresh token.' });

--- a/backend/src/routes/system.js
+++ b/backend/src/routes/system.js
@@ -13,6 +13,7 @@ import { AppError } from '../middleware/errorHandler.js';
 import { createTenantSchema } from '../seed/createTenant.js';
 import { clearTenantData, resetSequences, restoreBeacon2, restoreBeacon, BEACON_DEFAULT_PASSWORD } from './backup.js';
 import { syncDefaultRolePrivileges } from '../utils/migrate.js';
+import { logAudit } from '../utils/audit.js';
 import ExcelJS from 'exceljs';
 
 const router = Router();
@@ -107,6 +108,21 @@ router.post('/tenants/:id/set-temp-password', async (req, res, next) => {
       `UPDATE users SET password_hash = $1, must_change_password = true RETURNING username, name`,
       [hash],
     );
+
+    // Record the bulk reset in the tenant audit log. user_id is null because
+    // the caller is a sys-admin (no tenant-level user record). user_name is
+    // the sys-admin's display name, prefixed so it can't be confused with a
+    // regular tenant user.
+    await logAudit(tenant.slug, {
+      userId:     null,
+      userName:   `System Admin: ${req.sysAdmin?.name ?? 'unknown'}`,
+      action:     'bulk_password_reset',
+      entityType: 'tenant',
+      entityId:   tenant.id,
+      entityName: tenant.name,
+      detail:     `Set temporary password for ${result.length} user(s); must_change_password=true.`,
+    });
+
     res.json({ ok: true, updated: result.length, users: result.map((u) => u.username || u.name) });
   } catch (err) {
     next(err);

--- a/frontend/src/__tests__/safeRedirect.test.js
+++ b/frontend/src/__tests__/safeRedirect.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isSafePaymentRedirect } from '../lib/safeRedirect.js';
+
+describe('isSafePaymentRedirect', () => {
+  it('allows same-origin absolute URLs', () => {
+    expect(isSafePaymentRedirect(`${window.location.origin}/portal/paid?ok=1`)).toBe(true);
+  });
+
+  it('allows same-origin relative paths', () => {
+    expect(isSafePaymentRedirect('/portal/paid?ok=1')).toBe(true);
+  });
+
+  it('allows paypal.com and its sandbox', () => {
+    expect(isSafePaymentRedirect('https://www.paypal.com/checkoutnow?token=X')).toBe(true);
+    expect(isSafePaymentRedirect('https://sandbox.paypal.com/checkoutnow?token=X')).toBe(true);
+    expect(isSafePaymentRedirect('https://www.sandbox.paypal.com/checkoutnow?token=X')).toBe(true);
+  });
+
+  it('blocks look-alike domains', () => {
+    expect(isSafePaymentRedirect('https://paypal.com.evil.com/x')).toBe(false);
+    expect(isSafePaymentRedirect('https://evilpaypal.com/x')).toBe(false);
+    expect(isSafePaymentRedirect('https://paypal.co/x')).toBe(false);
+  });
+
+  it('blocks arbitrary third-party origins', () => {
+    expect(isSafePaymentRedirect('https://evil.example.com/go')).toBe(false);
+  });
+
+  it('blocks non-http(s) schemes', () => {
+    expect(isSafePaymentRedirect('javascript:alert(1)')).toBe(false);
+    expect(isSafePaymentRedirect('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('rejects empty or non-string input', () => {
+    expect(isSafePaymentRedirect('')).toBe(false);
+    expect(isSafePaymentRedirect(null)).toBe(false);
+    expect(isSafePaymentRedirect(undefined)).toBe(false);
+    expect(isSafePaymentRedirect(42)).toBe(false);
+  });
+});

--- a/frontend/src/lib/safeRedirect.js
+++ b/frontend/src/lib/safeRedirect.js
@@ -1,0 +1,31 @@
+// Guards against open redirects in flows where the backend returns a URL for
+// the browser to navigate to (currently the PayPal payment flow). The backend
+// is trusted under normal operation, but if it were compromised or
+// mis-configured a user could be sent to a phishing site.
+//
+// Allowed destinations:
+//   • Same origin as the frontend (the stub PayPal flow redirects back to our
+//     own confirmation pages).
+//   • PayPal live and sandbox domains.
+//
+// Anything else is blocked.
+
+const ALLOWED_HOSTS = new Set([
+  'paypal.com',
+  'www.paypal.com',
+  'sandbox.paypal.com',
+  'www.sandbox.paypal.com',
+]);
+
+export function isSafePaymentRedirect(url) {
+  if (typeof url !== 'string' || !url) return false;
+  let u;
+  try {
+    u = new URL(url, window.location.origin);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return false;
+  if (u.origin === window.location.origin) return true;
+  return ALLOWED_HOSTS.has(u.hostname);
+}

--- a/frontend/src/pages/public/PortalRenewal.jsx
+++ b/frontend/src/pages/public/PortalRenewal.jsx
@@ -5,6 +5,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { portalApi, hasPortalToken, clearPortalToken } from '../../lib/api.js';
+import { isSafePaymentRedirect } from '../../lib/safeRedirect.js';
 import PortalVersion from '../../components/PortalVersion.jsx';
 
 function fmtDate(d) {
@@ -98,6 +99,11 @@ export default function PortalRenewal() {
         partnerGiftAid,
       });
       if (result.redirectUrl) {
+        if (!isSafePaymentRedirect(result.redirectUrl)) {
+          setError('The payment provider returned an unexpected redirect. Please contact your u3a.');
+          setSubmitting(false);
+          return;
+        }
         window.location.href = result.redirectUrl;
       }
     } catch (err) {

--- a/frontend/src/pages/public/ResumePayment.jsx
+++ b/frontend/src/pages/public/ResumePayment.jsx
@@ -5,6 +5,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { publicApi } from '../../lib/api.js';
+import { isSafePaymentRedirect } from '../../lib/safeRedirect.js';
 import PortalVersion from '../../components/PortalVersion.jsx';
 
 export default function ResumePayment() {
@@ -26,13 +27,16 @@ export default function ResumePayment() {
   }, [slug, token]);
 
   function handlePayNow() {
-    if (data?.redirectUrl) {
-      // Store result for the completion page (same as JoinForm flow)
-      sessionStorage.setItem('joinResult', JSON.stringify({
-        memberId: data.memberId,
-      }));
-      window.location.href = data.redirectUrl;
+    if (!data?.redirectUrl) return;
+    if (!isSafePaymentRedirect(data.redirectUrl)) {
+      setError('The payment provider returned an unexpected redirect. Please contact your u3a.');
+      return;
     }
+    // Store result for the completion page (same as JoinForm flow)
+    sessionStorage.setItem('joinResult', JSON.stringify({
+      memberId: data.memberId,
+    }));
+    window.location.href = data.redirectUrl;
   }
 
   if (loading) {


### PR DESCRIPTION
… audit log on bulk password reset

M1 — CSRF protection on /auth/refresh
  The refresh cookie is SameSite=none (required cross-origin Vercel→Render),
  so a cross-origin POST could previously trigger a token refresh as a side
  effect. /auth/refresh now validates the Origin header against CORS_ORIGIN
  before any work and rejects mismatches with 403. Requests with no Origin
  header are allowed only outside production (for supertest etc). New tests
  in backend/src/__tests__/auth.test.js cover matching and mismatched Origin.

M4 — Payment redirect whitelist
  Added frontend/src/lib/safeRedirect.js exporting isSafePaymentRedirect(url).
  ResumePayment.jsx and PortalRenewal.jsx now validate the backend-supplied
  redirectUrl before navigating, allowing only same-origin URLs and the
  paypal.com / sandbox.paypal.com families. Look-alike domains and
  javascript:/data: schemes are blocked. Covered by unit tests in
  frontend/src/__tests__/safeRedirect.test.js.

M5 — Audit log on bulk password reset
  POST /system/tenants/:id/set-temp-password now writes an audit entry
  (action=bulk_password_reset, user_name="System Admin: <name>", detail
  naming the affected user count) to the target tenant's audit_log.

Tests green: backend 388/388, frontend 140/140.