### PR TITLE
feat: SQL reports — saved library + site-admin ad-hoc editor

### DIFF
--- a/Beacon2 Project Definition.md
+++ b/Beacon2 Project Definition.md
@@ -211,6 +211,15 @@ Beacon2 is a ground-up rebuild with these goals:
 - **Event financials** — per-event income/costs summary with transaction links;
   "Add transaction" pre-fills event_id; transactions linkable to events via search-as-you-type
 
+### Reports module (Beacon2 extra)
+- **SQL reports** — hybrid of (a) a library of saved parameterised reports
+  that any user with `reports:run` can execute, and (b) an ad-hoc SQL editor
+  for site administrators. All queries run in a read-only Postgres transaction
+  (`SET LOCAL transaction_read_only = on`) with a 15-second statement timeout,
+  a single-statement guard (only `SELECT` / `WITH`), and a 5,000-row result cap.
+  Named `:param` placeholders are substituted with positional `$N` server-side.
+  Results render as a table; Excel download via ExcelJS. Every run is audited.
+
 ### Admin / Misc module
 - **Audit log** — date-filtered view + delete-before-date; clickable When → Audit Record detail; clickable Record → entity view
 - **Gift Aid log** — date-filtered view of Gift Aid consent given/withdrawn; member filter dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 
 ---
 
+## [0.10.5] — 2026-04-18
+
+### Added
+- **SQL reports** — new `/reports` page for running saved parameterised SELECT/WITH
+  queries against the tenant schema. Library of saved reports (site admin creates +
+  edits; anyone with `reports:run` can execute) plus an ad-hoc SQL editor gated to
+  site administrators. Safety: queries run in a read-only transaction with
+  `SET LOCAL transaction_read_only = on`, `SET LOCAL statement_timeout = 15000`, a
+  single-statement guard that rejects anything starting with anything other than
+  `SELECT`/`WITH`, and a 5,000-row result cap. Named `:param` placeholders are
+  substituted with positional `$N` parameters server-side so parameter values can
+  never alter the query structure. Results render as a table with row count +
+  duration metadata; Excel download via ExcelJS. Every run is written to the audit
+  log. New `reports` privilege resource with `view` + `run` actions; added to
+  Administration role by default. Home page menu gains a "SQL reports" link under
+  Misc
+
 ## [0.9.7] — 2026-04-18
 
 ### Added

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-backend",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-backend",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",

--- a/backend/prisma/tenant_schema.sql
+++ b/backend/prisma/tenant_schema.sql
@@ -809,4 +809,18 @@ ALTER TABLE :schema.tenant_settings ADD COLUMN IF NOT EXISTS calendar_config  JS
 -- ─── Feature configuration ────────────────────────────────────────────
 -- Per-tenant feature toggles. Missing keys default to true (opt-out model).
 -- See FeatureConfig.jsx for the full toggle inventory.
-ALTER TABLE :schema.tenant_settings ADD COLUMN IF NOT EXISTS feature_config JSONB NOT NULL DEFAULT '{}'
+ALTER TABLE :schema.tenant_settings ADD COLUMN IF NOT EXISTS feature_config JSONB NOT NULL DEFAULT '{}';
+
+-- ─── Saved reports ───────────────────────────────────────────────────
+-- Saved parameterised SQL reports. SQL is SELECT/WITH only; parameters
+-- is a JSONB array of { name, label, type, required, default } objects.
+CREATE TABLE IF NOT EXISTS :schema.saved_reports (
+  id          SERIAL PRIMARY KEY,
+  name        TEXT NOT NULL,
+  description TEXT,
+  sql_text    TEXT NOT NULL,
+  parameters  JSONB NOT NULL DEFAULT '[]',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS :schema_idx_saved_reports_name ON :schema.saved_reports (name)

--- a/backend/src/__tests__/helpers.js
+++ b/backend/src/__tests__/helpers.js
@@ -59,6 +59,7 @@ export const ALL_PRIVS = [
   'letters:view', 'letters:download',
   'letters_standard_messages:view', 'letters_standard_messages:create', 'letters_standard_messages:change', 'letters_standard_messages:delete',
   'utilities:view',
+  'reports:view', 'reports:run',
 ];
 
 export const TEST_TENANT = 'test-u3a';

--- a/backend/src/__tests__/reports.test.js
+++ b/backend/src/__tests__/reports.test.js
@@ -1,0 +1,263 @@
+// beacon2/backend/src/__tests__/reports.test.js
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { makeAuthHeader } from './helpers.js';
+
+vi.mock('../utils/redis.js', () => ({
+  isSessionInvalidated:   vi.fn().mockResolvedValue(false),
+  invalidateUserSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/db.js', () => ({
+  prisma:      { $disconnect: vi.fn(), $transaction: vi.fn() },
+  tenantQuery: vi.fn(),
+  withTenant:  vi.fn(),
+}));
+
+const { default: app } = await import('../app.js');
+const { tenantQuery, prisma } = await import('../utils/db.js');
+
+// Note: the shared TEST_TENANT slug has a hyphen (`test-u3a`) which would be
+// rejected by our own slug regex in sqlSafety.js (`^[a-z0-9_]+$` — matches
+// db.js). We override it here with a valid production-style slug. Other test
+// files bypass this because they mock tenantQuery fully, but sqlSafety.js runs
+// its own check before calling prisma.$transaction.
+const AUTH       = makeAuthHeader({ tenantSlug: 'test_u3a' });
+const AUTH_ADMIN = makeAuthHeader({ tenantSlug: 'test_u3a', isSiteAdmin: true });
+
+const SAMPLE_REPORT = {
+  id: 1,
+  name: 'Member count by class',
+  description: 'Counts',
+  sql_text: 'SELECT class_id, count(*) AS n FROM members GROUP BY class_id',
+  parameters: [],
+  created_at: new Date('2026-01-01T00:00:00Z'),
+  updated_at: new Date('2026-01-01T00:00:00Z'),
+};
+
+// Runs the callback the same way prisma.$transaction does for our reports
+// code: we pass a fake tx stub that supports the SET LOCAL statements and
+// returns `txResult` from $queryRawUnsafe.
+function mockTransaction(txResult) {
+  prisma.$transaction.mockImplementationOnce(async (cb) => {
+    const tx = {
+      $executeRawUnsafe: vi.fn().mockResolvedValue(undefined),
+      $queryRawUnsafe:   vi.fn().mockResolvedValue(txResult),
+    };
+    return cb(tx);
+  });
+}
+
+// ── GET /reports ─────────────────────────────────────────────────────────
+
+describe('GET /reports', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with list', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 1, name: 'r', description: null, parameters: [], updated_at: new Date() }]);
+    const res = await request(app).get('/reports').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/reports');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 without reports:view', async () => {
+    const res = await request(app)
+      .get('/reports')
+      .set('Authorization', makeAuthHeader({ privileges: [] }));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── GET /reports/:id ─────────────────────────────────────────────────────
+
+describe('GET /reports/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with the saved report', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_REPORT]);
+    const res = await request(app).get('/reports/1').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Member count by class');
+  });
+
+  it('returns 404 when missing', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const res = await request(app).get('/reports/999').set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /reports — create (site admin) ─────────────────────────────────
+
+describe('POST /reports', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a saved report (site admin)', async () => {
+    tenantQuery.mockResolvedValueOnce([{ ...SAMPLE_REPORT, id: 2 }]);  // INSERT ... RETURNING
+    tenantQuery.mockResolvedValueOnce([]);  // audit
+    const res = await request(app)
+      .post('/reports').set('Authorization', AUTH_ADMIN)
+      .send({ name: 'r', sqlText: 'SELECT 1', parameters: [] });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe(2);
+  });
+
+  it('rejects when not site admin', async () => {
+    const res = await request(app)
+      .post('/reports').set('Authorization', AUTH)
+      .send({ name: 'r', sqlText: 'SELECT 1' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects non-SELECT SQL', async () => {
+    const res = await request(app)
+      .post('/reports').set('Authorization', AUTH_ADMIN)
+      .send({ name: 'r', sqlText: 'DROP TABLE members' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/SELECT or WITH/);
+  });
+
+  it('rejects multi-statement SQL', async () => {
+    const res = await request(app)
+      .post('/reports').set('Authorization', AUTH_ADMIN)
+      .send({ name: 'r', sqlText: 'SELECT 1; DELETE FROM members' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Multiple statements/);
+  });
+});
+
+// ── POST /reports/:id/run ───────────────────────────────────────────────
+
+describe('POST /reports/:id/run', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('runs a saved report and returns columns + rows', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_REPORT]);        // fetchReport
+    mockTransaction([{ class_id: 'c1', n: 3n }]);              // BigInt handled
+    tenantQuery.mockResolvedValueOnce([]);                     // audit
+    const res = await request(app)
+      .post('/reports/1/run').set('Authorization', AUTH)
+      .send({ params: {} });
+    expect(res.status).toBe(200);
+    expect(res.body.columns).toEqual(['class_id', 'n']);
+    expect(res.body.rows[0].n).toBe('3');  // BigInt → string
+    expect(res.body.truncated).toBe(false);
+  });
+
+  it('substitutes named parameters positionally', async () => {
+    const paramReport = {
+      ...SAMPLE_REPORT,
+      sql_text: 'SELECT * FROM members WHERE class_id = :cls AND created_at > :since',
+      parameters: [
+        { name: 'cls', label: 'Class', type: 'text', required: true },
+        { name: 'since', label: 'Since', type: 'date', required: false },
+      ],
+    };
+    tenantQuery.mockResolvedValueOnce([paramReport]);
+
+    // Capture the exact SQL + values passed to $queryRawUnsafe
+    let seenSql, seenValues;
+    prisma.$transaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        $executeRawUnsafe: vi.fn().mockResolvedValue(undefined),
+        $queryRawUnsafe:   vi.fn().mockImplementation((sql, ...values) => {
+          seenSql = sql;
+          seenValues = values;
+          return Promise.resolve([]);
+        }),
+      };
+      return cb(tx);
+    });
+
+    tenantQuery.mockResolvedValueOnce([]);  // audit
+
+    const res = await request(app)
+      .post('/reports/1/run').set('Authorization', AUTH)
+      .send({ params: { cls: 'c1', since: '2026-01-01' } });
+
+    expect(res.status).toBe(200);
+    expect(seenSql).toBe('SELECT * FROM members WHERE class_id = $1 AND created_at > $2');
+    expect(seenValues).toEqual(['c1', '2026-01-01']);
+  });
+
+  it('returns 404 for unknown report', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const res = await request(app)
+      .post('/reports/999/run').set('Authorization', AUTH)
+      .send({ params: {} });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /reports/sql/run — ad-hoc (site admin) ─────────────────────────
+
+describe('POST /reports/sql/run', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('runs ad-hoc SQL as site admin', async () => {
+    mockTransaction([{ one: 1 }]);
+    tenantQuery.mockResolvedValueOnce([]);  // audit
+    const res = await request(app)
+      .post('/reports/sql/run').set('Authorization', AUTH_ADMIN)
+      .send({ sql: 'SELECT 1 AS one' });
+    expect(res.status).toBe(200);
+    expect(res.body.rows).toEqual([{ one: 1 }]);
+  });
+
+  it('rejects non-admin user', async () => {
+    const res = await request(app)
+      .post('/reports/sql/run').set('Authorization', AUTH)
+      .send({ sql: 'SELECT 1' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects UPDATE statements', async () => {
+    const res = await request(app)
+      .post('/reports/sql/run').set('Authorization', AUTH_ADMIN)
+      .send({ sql: 'UPDATE members SET name = 1' });
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts WITH (CTE) queries', async () => {
+    mockTransaction([{ total: 5 }]);
+    tenantQuery.mockResolvedValueOnce([]);  // audit
+    const res = await request(app)
+      .post('/reports/sql/run').set('Authorization', AUTH_ADMIN)
+      .send({ sql: 'WITH t AS (SELECT 5 AS total) SELECT * FROM t' });
+    expect(res.status).toBe(200);
+    expect(res.body.rows[0].total).toBe(5);
+  });
+
+  it('accepts SQL with leading comments before SELECT', async () => {
+    mockTransaction([{ one: 1 }]);
+    tenantQuery.mockResolvedValueOnce([]);  // audit
+    const res = await request(app)
+      .post('/reports/sql/run').set('Authorization', AUTH_ADMIN)
+      .send({ sql: '-- count rows\nSELECT 1 AS one' });
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── POST /reports/:id/download ──────────────────────────────────────────
+
+describe('POST /reports/:id/download', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns xlsx content-type', async () => {
+    tenantQuery.mockResolvedValueOnce([SAMPLE_REPORT]);
+    mockTransaction([{ class_id: 'c1', n: 3 }]);
+    tenantQuery.mockResolvedValueOnce([]);  // audit
+    const res = await request(app)
+      .post('/reports/1/download').set('Authorization', AUTH)
+      .send({ params: {} });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/spreadsheetml/);
+    expect(res.headers['content-disposition']).toMatch(/attachment/);
+  });
+});

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -40,6 +40,7 @@ import eventTypeRoutes     from './routes/eventTypes.js';
 import membershipCardRoutes from './routes/membershipCards.js';
 import letterRoutes         from './routes/letters.js';
 import customFieldRoutes    from './routes/customFields.js';
+import reportRoutes         from './routes/reports.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 // Refuse to start in production without CORS_ORIGIN — otherwise the cors
@@ -98,6 +99,7 @@ app.use('/event-types',     eventTypeRoutes);
 app.use('/membership-cards', membershipCardRoutes);
 app.use('/letters',          letterRoutes);
 app.use('/custom-fields',   customFieldRoutes);
+app.use('/reports',         reportRoutes);
 
 app.get('/health', (_req, res) => res.json({
   status:  'ok',

--- a/backend/src/routes/reports.js
+++ b/backend/src/routes/reports.js
@@ -1,0 +1,273 @@
+// beacon2/backend/src/routes/reports.js
+// SQL reports — library of saved parameterised queries plus an ad-hoc raw SQL
+// editor for site administrators.
+//
+// Privilege model:
+//   - reports:view  — list and view saved reports
+//   - reports:run   — run saved reports + download results as Excel
+//   - Creating, editing, deleting saved reports AND running ad-hoc SQL
+//     require `is_site_admin` (not a privilege) because it is the user who
+//     writes the SQL.  A single mistake could expose the whole tenant, so we
+//     gate at the admin level rather than via a delegable privilege.
+
+import { Router } from 'express';
+import { z } from 'zod';
+import ExcelJS from 'exceljs';
+import { requireAuth } from '../middleware/auth.js';
+import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { tenantQuery } from '../utils/db.js';
+import { logAudit } from '../utils/audit.js';
+import { AppError } from '../middleware/errorHandler.js';
+import {
+  validateReadOnlySql,
+  substituteParameters,
+  runReadOnly,
+  sanitizeRow,
+} from '../utils/sqlSafety.js';
+
+const router = Router();
+router.use(requireAuth);
+
+function requireSiteAdmin(req, _res, next) {
+  if (!req.user?.isSiteAdmin) {
+    return next(AppError('Site administrator privilege required.', 403));
+  }
+  next();
+}
+
+// ─── Zod schemas ──────────────────────────────────────────────────────────
+
+const parameterSchema = z.object({
+  name:     z.string().regex(/^[a-z_][a-z0-9_]*$/i).min(1).max(60),
+  label:    z.string().min(1).max(120),
+  type:     z.enum(['text', 'number', 'date', 'boolean']),
+  required: z.boolean().optional().default(false),
+  default:  z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+});
+
+const createSchema = z.object({
+  name:        z.string().min(1).max(120),
+  description: z.string().max(500).nullable().optional(),
+  sqlText:     z.string().min(1).max(10000),
+  parameters:  z.array(parameterSchema).max(20).default([]),
+});
+
+const updateSchema = createSchema.partial();
+
+const runSchema = z.object({
+  params: z.record(z.string(), z.unknown()).optional().default({}),
+});
+
+const adhocSqlSchema = z.object({
+  sql: z.string().min(1).max(20000),
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+async function fetchReport(slug, id) {
+  const numId = Number(id);
+  if (!Number.isInteger(numId) || numId <= 0) {
+    throw AppError('Report not found.', 404);
+  }
+  const [row] = await tenantQuery(
+    slug,
+    `SELECT id, name, description, sql_text, parameters, created_at, updated_at
+     FROM saved_reports WHERE id = $1`,
+    [numId],
+  );
+  if (!row) throw AppError('Report not found.', 404);
+  return row;
+}
+
+async function buildExcelBuffer(name, result) {
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet('Report');
+  const cols = result.columns.length ? result.columns : ['(no rows)'];
+  ws.columns = cols.map((c) => ({ header: c, key: c, width: 18 }));
+  ws.getRow(1).font = { bold: true };
+  for (const row of result.rows) ws.addRow(sanitizeRow(row));
+  return wb.xlsx.writeBuffer();
+}
+
+function safeFilename(name) {
+  const base = String(name ?? 'report').replace(/[^A-Za-z0-9._-]+/g, '_').slice(0, 60);
+  return base || 'report';
+}
+
+// ─── GET /reports — list ─────────────────────────────────────────────────
+
+router.get('/', requirePrivilege('reports', 'view'), async (req, res, next) => {
+  try {
+    const rows = await tenantQuery(
+      req.user.tenantSlug,
+      `SELECT id, name, description, parameters, updated_at
+       FROM saved_reports ORDER BY name`,
+    );
+    res.json(rows);
+  } catch (err) { next(err); }
+});
+
+// ─── POST /reports/sql/run — raw SQL (site admin) ──────────────────────
+// Declared BEFORE /:id/run so that `/sql/run` isn't caught as `id=sql`.
+
+router.post('/sql/run', requireSiteAdmin, async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const { sql: rawSql } = adhocSqlSchema.parse(req.body ?? {});
+    const cleaned = validateReadOnlySql(rawSql);
+    const result = await runReadOnly(slug, cleaned, []);
+    logAudit(slug, {
+      userId: req.user.userId, userName: req.user.name,
+      action: 'run', entityType: 'adhoc_sql',
+      detail: rawSql.slice(0, 500),
+    });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+// ─── POST /reports/sql/download — Excel of raw SQL (site admin) ────────
+
+router.post('/sql/download', requireSiteAdmin, async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const { sql: rawSql } = adhocSqlSchema.parse(req.body ?? {});
+    const cleaned = validateReadOnlySql(rawSql);
+    const result = await runReadOnly(slug, cleaned, []);
+    const buffer = await buildExcelBuffer('adhoc-sql', result);
+    logAudit(slug, {
+      userId: req.user.userId, userName: req.user.name,
+      action: 'download', entityType: 'adhoc_sql',
+      detail: rawSql.slice(0, 500),
+    });
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="adhoc-sql.xlsx"`);
+    res.send(Buffer.from(buffer));
+  } catch (err) { next(err); }
+});
+
+// ─── GET /reports/:id ────────────────────────────────────────────────────
+
+router.get('/:id', requirePrivilege('reports', 'view'), async (req, res, next) => {
+  try {
+    const row = await fetchReport(req.user.tenantSlug, req.params.id);
+    res.json(row);
+  } catch (err) { next(err); }
+});
+
+// ─── POST /reports — create (site admin) ────────────────────────────────
+
+router.post('/', requireSiteAdmin, async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const data = createSchema.parse(req.body);
+    validateReadOnlySql(data.sqlText);
+    const [created] = await tenantQuery(
+      slug,
+      `INSERT INTO saved_reports (name, description, sql_text, parameters)
+       VALUES ($1, $2, $3, $4::jsonb)
+       RETURNING id, name, description, sql_text, parameters, created_at, updated_at`,
+      [data.name, data.description ?? null, data.sqlText, JSON.stringify(data.parameters)],
+    );
+    logAudit(slug, {
+      userId: req.user.userId, userName: req.user.name,
+      action: 'create', entityType: 'saved_report',
+      entityId: String(created.id), entityName: created.name,
+    });
+    res.status(201).json(created);
+  } catch (err) { next(err); }
+});
+
+// ─── PATCH /reports/:id — update (site admin) ───────────────────────────
+
+router.patch('/:id', requireSiteAdmin, async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const data = updateSchema.parse(req.body);
+    if (data.sqlText !== undefined) validateReadOnlySql(data.sqlText);
+
+    await fetchReport(slug, req.params.id);  // 404 if missing
+
+    const sets = [];
+    const values = [];
+    let i = 1;
+    if (data.name !== undefined)        { sets.push(`name = $${i++}`);             values.push(data.name); }
+    if (data.description !== undefined) { sets.push(`description = $${i++}`);      values.push(data.description); }
+    if (data.sqlText !== undefined)     { sets.push(`sql_text = $${i++}`);         values.push(data.sqlText); }
+    if (data.parameters !== undefined)  { sets.push(`parameters = $${i++}::jsonb`); values.push(JSON.stringify(data.parameters)); }
+    if (!sets.length) throw AppError('Nothing to update.', 400);
+    sets.push('updated_at = now()');
+    values.push(Number(req.params.id));
+
+    const [updated] = await tenantQuery(
+      slug,
+      `UPDATE saved_reports SET ${sets.join(', ')} WHERE id = $${i}
+       RETURNING id, name, description, sql_text, parameters, created_at, updated_at`,
+      values,
+    );
+    logAudit(slug, {
+      userId: req.user.userId, userName: req.user.name,
+      action: 'update', entityType: 'saved_report',
+      entityId: String(updated.id), entityName: updated.name,
+    });
+    res.json(updated);
+  } catch (err) { next(err); }
+});
+
+// ─── DELETE /reports/:id (site admin) ───────────────────────────────────
+
+router.delete('/:id', requireSiteAdmin, async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const existing = await fetchReport(slug, req.params.id);
+    await tenantQuery(slug, `DELETE FROM saved_reports WHERE id = $1`, [existing.id]);
+    logAudit(slug, {
+      userId: req.user.userId, userName: req.user.name,
+      action: 'delete', entityType: 'saved_report',
+      entityId: String(existing.id), entityName: existing.name,
+    });
+    res.json({ deleted: true });
+  } catch (err) { next(err); }
+});
+
+// ─── POST /reports/:id/run — execute saved report ───────────────────────
+
+router.post('/:id/run', requirePrivilege('reports', 'run'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const { params } = runSchema.parse(req.body ?? {});
+    const report = await fetchReport(slug, req.params.id);
+    const cleaned = validateReadOnlySql(report.sql_text);
+    const { sql, values } = substituteParameters(cleaned, report.parameters ?? [], params);
+    const result = await runReadOnly(slug, sql, values);
+    logAudit(slug, {
+      userId: req.user.userId, userName: req.user.name,
+      action: 'run', entityType: 'saved_report',
+      entityId: String(report.id), entityName: report.name,
+    });
+    res.json(result);
+  } catch (err) { next(err); }
+});
+
+// ─── POST /reports/:id/download — Excel of saved report result ─────────
+
+router.post('/:id/download', requirePrivilege('reports', 'run'), async (req, res, next) => {
+  try {
+    const slug = req.user.tenantSlug;
+    const { params } = runSchema.parse(req.body ?? {});
+    const report = await fetchReport(slug, req.params.id);
+    const cleaned = validateReadOnlySql(report.sql_text);
+    const { sql, values } = substituteParameters(cleaned, report.parameters ?? [], params);
+    const result = await runReadOnly(slug, sql, values);
+    const buffer = await buildExcelBuffer(report.name, result);
+    logAudit(slug, {
+      userId: req.user.userId, userName: req.user.name,
+      action: 'download', entityType: 'saved_report',
+      entityId: String(report.id), entityName: report.name,
+    });
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="${safeFilename(report.name)}.xlsx"`);
+    res.send(Buffer.from(buffer));
+  } catch (err) { next(err); }
+});
+
+export default router;

--- a/backend/src/seed/defaultRoles.js
+++ b/backend/src/seed/defaultRoles.js
@@ -188,6 +188,10 @@ export const DEFAULT_ROLES = [
       { code: 'public_links',             action: 'view' },
       { code: 'public_links',             action: 'change' },            // ve
 
+      // Reports
+      { code: 'reports',                  action: 'view' },
+      { code: 'reports',                  action: 'run' },               // vo
+
       // Roles
       { code: 'role_record',              action: 'view' },
       { code: 'role_record',              action: 'create' },

--- a/backend/src/seed/privilegeResources.js
+++ b/backend/src/seed/privilegeResources.js
@@ -64,6 +64,7 @@ export const PRIVILEGE_RESOURCES = [
   r('offices',                   'Offices',                         ['view', 'create', 'change', 'delete']),
   r('poll_set_up',               'Poll set up',                     ['view', 'create', 'change', 'delete']),
   r('public_links',              'Public links',                    ['view', 'change']),
+  r('reports',                   'SQL reports',                     ['view', 'run']),
   r('role_record',               'Role record',                     ['view', 'create', 'change', 'delete']),
   r('roles_list',                'Roles list',                      ['view']),
   r('settings',                  'Settings',                        ['view', 'change']),

--- a/backend/src/utils/sqlSafety.js
+++ b/backend/src/utils/sqlSafety.js
@@ -1,0 +1,155 @@
+// beacon2/backend/src/utils/sqlSafety.js
+// Safety helpers for the SQL reports feature.
+//
+// The reports tool lets users run raw SELECT/WITH queries against their tenant
+// schema. These helpers enforce the read-only contract:
+//   1. Validate the SQL starts with SELECT or WITH and contains a single statement
+//   2. Substitute named `:param` placeholders with positional `$N` placeholders
+//   3. Execute the query inside a transaction with search_path set to the tenant
+//      schema, statement_timeout, and transaction_read_only on.
+
+import { prisma } from './db.js';
+import { AppError } from '../middleware/errorHandler.js';
+
+export const MAX_ROWS            = 5000;   // results truncated beyond this
+export const STATEMENT_TIMEOUT_MS = 15000;  // PG statement_timeout
+
+/**
+ * Validate that a SQL string is a single SELECT/WITH query with no embedded
+ * statement separators. Returns the cleaned SQL (trimmed, trailing `;` removed).
+ * Throws AppError with a user-facing message if anything looks wrong.
+ *
+ * We cannot fully parse SQL here, but combined with runReadOnly()'s read-only
+ * transaction and statement_timeout, the guard is strong enough: Postgres
+ * rejects any write at the engine level, and we reject multi-statements.
+ */
+export function validateReadOnlySql(rawSql) {
+  if (typeof rawSql !== 'string') {
+    throw AppError('SQL must be a string.', 400);
+  }
+  let sql = rawSql.trim();
+  if (!sql) throw AppError('SQL is empty.', 400);
+  // Allow a single trailing semicolon but no other statement separators
+  sql = sql.replace(/;+\s*$/, '');
+  if (sql.includes(';')) {
+    throw AppError('Multiple statements are not allowed (remove semicolons).', 400);
+  }
+  const leading = stripLeadingComments(sql);
+  if (!/^(select|with)\b/i.test(leading)) {
+    throw AppError('Only SELECT or WITH queries are allowed.', 400);
+  }
+  return sql;
+}
+
+function stripLeadingComments(s) {
+  let i = 0;
+  while (i < s.length) {
+    const ch = s[i];
+    if (ch === ' ' || ch === '\n' || ch === '\r' || ch === '\t') { i++; continue; }
+    if (ch === '-' && s[i + 1] === '-') {
+      const nl = s.indexOf('\n', i);
+      if (nl === -1) return '';
+      i = nl + 1;
+      continue;
+    }
+    if (ch === '/' && s[i + 1] === '*') {
+      const end = s.indexOf('*/', i + 2);
+      if (end === -1) return '';
+      i = end + 2;
+      continue;
+    }
+    break;
+  }
+  return s.slice(i);
+}
+
+/**
+ * Replace `:name` placeholders in the SQL with `$1`, `$2`, ... in the order
+ * parameters were defined. Only parameters whose `name` matches a declared
+ * parameter are substituted; any other `:word` is left alone and Postgres
+ * will raise a normal syntax error.
+ *
+ * @param {string} sql
+ * @param {Array<{name:string,type:string}>} parameters
+ * @param {Record<string,unknown>} valuesByName
+ * @returns {{ sql: string, values: unknown[] }}
+ */
+export function substituteParameters(sql, parameters = [], valuesByName = {}) {
+  const values = [];
+  let out = sql;
+  parameters.forEach((p, idx) => {
+    const re = new RegExp(`:${escapeRegExp(p.name)}\\b`, 'g');
+    out = out.replace(re, `$${idx + 1}`);
+    values.push(coerceValue(valuesByName[p.name], p.type, p.required));
+  });
+  return { sql: out, values };
+}
+
+function escapeRegExp(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function coerceValue(raw, type, required) {
+  if (raw === undefined || raw === null || raw === '') {
+    if (required) throw AppError(`Parameter is required.`, 400);
+    return null;
+  }
+  switch (type) {
+    case 'number': {
+      const n = Number(raw);
+      if (!Number.isFinite(n)) throw AppError('Expected a number.', 400);
+      return n;
+    }
+    case 'boolean':
+      return raw === true || raw === 'true' || raw === 1 || raw === '1';
+    case 'date':
+      return String(raw);   // YYYY-MM-DD — pg casts to date as needed
+    default:
+      return String(raw);
+  }
+}
+
+/**
+ * Run a pre-validated SELECT/WITH query in a read-only transaction scoped to
+ * the given tenant schema. Caps results at MAX_ROWS.
+ *
+ * Returns { columns, rows, rowCount, truncated, durationMs }.
+ */
+export async function runReadOnly(tenantSlug, sql, values = []) {
+  if (!/^[a-z0-9_]+$/.test(tenantSlug)) {
+    throw AppError('Invalid tenant.', 400);
+  }
+  const schema = `u3a_${tenantSlug}`;
+  const start  = Date.now();
+
+  const rawRows = await prisma.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe(`SET LOCAL search_path TO ${schema}, public`);
+    await tx.$executeRawUnsafe(`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`);
+    await tx.$executeRawUnsafe(`SET LOCAL transaction_read_only = on`);
+    return tx.$queryRawUnsafe(sql, ...values);
+  });
+
+  const durationMs = Date.now() - start;
+  const truncated  = rawRows.length > MAX_ROWS;
+  const kept       = truncated ? rawRows.slice(0, MAX_ROWS) : rawRows;
+  const rows       = kept.map(sanitizeRow);
+  const columns    = rows.length ? Object.keys(rows[0]) : [];
+
+  return { columns, rows, rowCount: rows.length, truncated, durationMs };
+}
+
+/**
+ * Make one row safe for JSON serialisation:
+ *  - BigInt values become strings (JSON.stringify cannot handle BigInt)
+ *  - Date instances become ISO strings
+ *  - everything else is left as-is (JSONB is already a plain object)
+ */
+export function sanitizeRow(row) {
+  const out = {};
+  for (const [k, v] of Object.entries(row)) {
+    if (typeof v === 'bigint')      out[k] = v.toString();
+    else if (v instanceof Date)     out[k] = v.toISOString();
+    else                            out[k] = v;
+  }
+  return out;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-frontend",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-frontend",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.20.4",
         "@tiptap/extension-text-style": "^3.20.4",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -89,6 +89,10 @@ const ChangePassword     = lazy(() => import('./pages/ChangePassword.jsx'));
 const CustomFields       = lazy(() => import('./pages/settings/CustomFields.jsx'));
 const EventTypeList      = lazy(() => import('./pages/settings/EventTypeList.jsx'));
 const FeatureConfig      = lazy(() => import('./pages/settings/FeatureConfig.jsx'));
+const ReportList         = lazy(() => import('./pages/reports/ReportList.jsx'));
+const ReportRun          = lazy(() => import('./pages/reports/ReportRun.jsx'));
+const ReportEditor       = lazy(() => import('./pages/reports/ReportEditor.jsx'));
+const ReportSql          = lazy(() => import('./pages/reports/ReportSql.jsx'));
 
 function ProtectedRoute({ skipPasswordCheck, children }) {
   const { isLoggedIn, mustChangePassword } = useAuth();
@@ -151,6 +155,13 @@ const router = createBrowserRouter([
       { path: '/backup',              element: <ProtectedRoute><DataBackup /></ProtectedRoute> },
       { path: '/preferences',         element: <ProtectedRoute><PersonalPreferences /></ProtectedRoute> },
       { path: '/public-links',        element: <ProtectedRoute><PublicLinks /></ProtectedRoute> },
+
+      // Reports — gated by reports:view/run privileges; editor and sql pages self-check isSiteAdmin
+      { path: '/reports',             element: <ProtectedRoute><ReportList /></ProtectedRoute> },
+      { path: '/reports/new',         element: <ProtectedRoute><ReportEditor /></ProtectedRoute> },
+      { path: '/reports/sql',         element: <ProtectedRoute><ReportSql /></ProtectedRoute> },
+      { path: '/reports/:id',         element: <ProtectedRoute><ReportRun /></ProtectedRoute> },
+      { path: '/reports/:id/edit',    element: <ProtectedRoute><ReportEditor /></ProtectedRoute> },
 
       // Membership — always available (core), sub-features gated
       { path: '/members',             element: <ProtectedRoute><MemberList /></ProtectedRoute> },

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -543,6 +543,32 @@ export const eventTypes = {
   remove: (id)       => request(`/event-types/${id}`, { method: 'DELETE' }),
 };
 
+// ─── Reports ──────────────────────────────────────────────────────────────
+
+export const reports = {
+  list:   ()         => request('/reports'),
+  get:    (id)       => request(`/reports/${id}`),
+  create: (data)     => request('/reports', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id, data) => request(`/reports/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  remove: (id)       => request(`/reports/${id}`, { method: 'DELETE' }),
+  run:    (id, params = {}) =>
+    request(`/reports/${id}/run`, { method: 'POST', body: JSON.stringify({ params }) }),
+  download: (id, params = {}) =>
+    requestBlob(`/reports/${id}/download`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ params }),
+    }),
+  runSql: (sql) =>
+    request('/reports/sql/run', { method: 'POST', body: JSON.stringify({ sql }) }),
+  downloadSql: (sql) =>
+    requestBlob('/reports/sql/download', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sql }),
+    }),
+};
+
 // ─── Membership Cards ────────────────────────────────────────────────────
 
 export const membershipCards = {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -78,6 +78,7 @@ export default function Home() {
         { label: 'E-mail unblocker',      tip: 'Remove members from the email block list',     to: can('email_delivery', 'all')  ? '/email/unblocker' : null, f: 'email' },
         { label: 'Personal preferences',  tip: 'Change your password, name display and timeout settings', to: '/preferences' },
         { label: 'Utilities',              tip: 'Administrative utilities',                                to: can('utilities', 'view') ? '/utilities' : null },
+        { label: 'SQL reports',            tip: 'Run saved SQL reports and ad-hoc queries',                to: can('reports', 'view') ? '/reports' : null },
       ],
     },
     {

--- a/frontend/src/pages/reports/ReportEditor.jsx
+++ b/frontend/src/pages/reports/ReportEditor.jsx
@@ -1,0 +1,188 @@
+// beacon2/frontend/src/pages/reports/ReportEditor.jsx
+// Create / edit a saved SQL report (site admin only).
+// Users write parameterised SELECT/WITH queries using `:paramName` placeholders,
+// then declare each placeholder here as name/label/type.
+
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { reports as reportsApi } from '../../lib/api.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import NavBar from '../../components/NavBar.jsx';
+import PageHeader from '../../components/PageHeader.jsx';
+
+export default function ReportEditor() {
+  const { id } = useParams();
+  const isNew = !id;
+  const navigate = useNavigate();
+  const { isSiteAdmin, tenant } = useAuth();
+
+  const [name, setName]               = useState('');
+  const [description, setDescription] = useState('');
+  const [sqlText, setSqlText]         = useState('SELECT * FROM members LIMIT 10');
+  const [parameters, setParameters]   = useState([]);
+  const [loading, setLoading]         = useState(!isNew);
+  const [saving, setSaving]           = useState(false);
+  const [error, setError]             = useState(null);
+
+  useEffect(() => {
+    if (isNew) return;
+    (async () => {
+      try {
+        const r = await reportsApi.get(id);
+        setName(r.name);
+        setDescription(r.description ?? '');
+        setSqlText(r.sql_text);
+        setParameters(r.parameters ?? []);
+      } catch (err) {
+        setError(err.body?.error || err.message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [id, isNew]);
+
+  async function handleSave(e) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        name: name.trim(),
+        description: description.trim() || null,
+        sqlText,
+        parameters,
+      };
+      const saved = isNew
+        ? await reportsApi.create(payload)
+        : await reportsApi.update(id, payload);
+      navigate(`/reports/${saved.id}`);
+    } catch (err) {
+      setError(err.body?.error || err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function addParam() {
+    setParameters((prev) => [...prev, { name: '', label: '', type: 'text', required: false }]);
+  }
+
+  function updateParam(i, patch) {
+    setParameters((prev) => prev.map((p, j) => j === i ? { ...p, ...patch } : p));
+  }
+
+  function removeParam(i) {
+    setParameters((prev) => prev.filter((_, j) => j !== i));
+  }
+
+  const navLinks = [
+    { label: 'Home',    to: '/' },
+    { label: 'Reports', to: '/reports' },
+  ];
+
+  const inputCls = 'border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
+
+  if (!isSiteAdmin) {
+    return (
+      <div className="min-h-screen pb-10">
+        <PageHeader tenant={tenant} />
+        <NavBar links={navLinks} />
+        <p className="text-center text-red-600 py-8 text-sm">
+          Only site administrators can create or edit reports.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen pb-10">
+      <PageHeader tenant={tenant} />
+      <NavBar links={navLinks} />
+
+      <div className="max-w-4xl mx-auto px-4 py-4">
+        <h1 className="text-xl font-bold text-center mb-4">
+          {isNew ? 'New report' : 'Edit report'}
+        </h1>
+
+        {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
+
+        {loading ? (
+          <p className="text-center text-slate-500 py-8">Loading…</p>
+        ) : (
+          <form onSubmit={handleSave} className="space-y-4">
+            <div className="bg-white/90 rounded-lg shadow-sm p-4 space-y-3">
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">Name</label>
+                <input className={`${inputCls} w-full`} value={name}
+                  onChange={(e) => setName(e.target.value)} required maxLength={120} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">Description</label>
+                <input className={`${inputCls} w-full`} value={description}
+                  onChange={(e) => setDescription(e.target.value)} maxLength={500} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">
+                  SQL (SELECT / WITH only — use <code>:paramName</code> placeholders)
+                </label>
+                <textarea className={`${inputCls} w-full font-mono text-xs`}
+                  value={sqlText} onChange={(e) => setSqlText(e.target.value)}
+                  rows={12} required maxLength={10000} />
+              </div>
+            </div>
+
+            <div className="bg-white/90 rounded-lg shadow-sm p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-sm font-semibold text-slate-700">Parameters</h2>
+                <button type="button" onClick={addParam}
+                  className="text-blue-600 hover:underline text-xs">+ Add parameter</button>
+              </div>
+              {parameters.length === 0 ? (
+                <p className="text-xs text-slate-500">No parameters defined.</p>
+              ) : (
+                <div className="space-y-2">
+                  {parameters.map((p, i) => (
+                    <div key={i} className="grid grid-cols-1 sm:grid-cols-12 gap-2 items-center">
+                      <input className={`${inputCls} sm:col-span-3`} placeholder="name (in SQL)"
+                        value={p.name} onChange={(e) => updateParam(i, { name: e.target.value })}
+                        pattern="^[a-zA-Z_][a-zA-Z0-9_]*$" />
+                      <input className={`${inputCls} sm:col-span-4`} placeholder="label (shown to user)"
+                        value={p.label} onChange={(e) => updateParam(i, { label: e.target.value })} />
+                      <select className={`${inputCls} sm:col-span-2`}
+                        value={p.type} onChange={(e) => updateParam(i, { type: e.target.value })}>
+                        <option value="text">text</option>
+                        <option value="number">number</option>
+                        <option value="date">date</option>
+                        <option value="boolean">boolean</option>
+                      </select>
+                      <label className="sm:col-span-2 text-xs text-slate-700 inline-flex items-center gap-1">
+                        <input type="checkbox" checked={!!p.required}
+                          onChange={(e) => updateParam(i, { required: e.target.checked })} />
+                        required
+                      </label>
+                      <button type="button" onClick={() => removeParam(i)}
+                        className="sm:col-span-1 text-red-600 hover:underline text-xs text-left">Remove</button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="flex gap-2">
+              <button type="submit" disabled={saving || !name.trim() || !sqlText.trim()}
+                className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium">
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+              <button type="button" onClick={() => navigate('/reports')}
+                className="border border-slate-300 rounded px-5 py-2 text-sm hover:bg-slate-50">
+                Cancel
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+
+      <NavBar links={navLinks} />
+    </div>
+  );
+}

--- a/frontend/src/pages/reports/ReportList.jsx
+++ b/frontend/src/pages/reports/ReportList.jsx
@@ -1,0 +1,102 @@
+// beacon2/frontend/src/pages/reports/ReportList.jsx
+// List saved SQL reports. Admins see Edit/Delete/New/Ad-hoc SQL actions.
+
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { reports as reportsApi } from '../../lib/api.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import NavBar from '../../components/NavBar.jsx';
+import PageHeader from '../../components/PageHeader.jsx';
+
+export default function ReportList() {
+  const { can, isSiteAdmin, tenant } = useAuth();
+  const [list, setList]       = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState(null);
+
+  const canRun = can('reports', 'run');
+
+  useEffect(() => { load(); }, []);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try { setList(await reportsApi.list()); }
+    catch (err) { setError(err.message); }
+    finally    { setLoading(false); }
+  }
+
+  async function handleDelete(id, name) {
+    if (!window.confirm(`Delete report "${name}"? This cannot be undone.`)) return;
+    try {
+      await reportsApi.remove(id);
+      setList((prev) => prev.filter((r) => r.id !== id));
+    } catch (err) {
+      setError(err.body?.error || err.message);
+    }
+  }
+
+  const navLinks = [
+    { label: 'Home', to: '/' },
+    ...(isSiteAdmin ? [
+      { label: 'New report',   to: '/reports/new' },
+      { label: 'Ad-hoc SQL',   to: '/reports/sql' },
+    ] : []),
+  ];
+
+  return (
+    <div className="min-h-screen pb-10">
+      <PageHeader tenant={tenant} />
+      <NavBar links={navLinks} />
+
+      <div className="max-w-4xl mx-auto px-4 py-4">
+        <h1 className="text-xl font-bold text-center mb-4">SQL Reports</h1>
+
+        {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
+
+        {loading ? (
+          <p className="text-center text-slate-500 py-8">Loading…</p>
+        ) : list.length === 0 ? (
+          <p className="text-slate-600 text-sm text-center py-6">
+            No reports yet.{isSiteAdmin ? ' Add one from the menu above.' : ''}
+          </p>
+        ) : (
+          <div className="bg-white/90 rounded-lg shadow-sm overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-slate-50 border-b border-slate-200 text-left text-slate-600 italic font-normal">
+                  <th className="px-4 py-2 font-normal">Name</th>
+                  <th className="px-4 py-2 font-normal">Description</th>
+                  <th className="px-4 py-2 font-normal text-right"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {list.map((r, i) => (
+                  <tr key={r.id} className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}`}>
+                    <td className="px-4 py-2">
+                      {canRun
+                        ? <Link to={`/reports/${r.id}`} className="text-blue-700 hover:underline">{r.name}</Link>
+                        : r.name}
+                    </td>
+                    <td className="px-4 py-2 text-slate-600">{r.description ?? ''}</td>
+                    <td className="px-4 py-2 text-right whitespace-nowrap space-x-3">
+                      {isSiteAdmin && (
+                        <>
+                          <Link to={`/reports/${r.id}/edit`} className="text-blue-600 hover:underline text-xs">Edit</Link>
+                          <button onClick={() => handleDelete(r.id, r.name)}
+                            className="text-red-600 hover:underline text-xs">Delete</button>
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <NavBar links={navLinks} />
+    </div>
+  );
+}

--- a/frontend/src/pages/reports/ReportResults.jsx
+++ b/frontend/src/pages/reports/ReportResults.jsx
@@ -1,0 +1,52 @@
+// beacon2/frontend/src/pages/reports/ReportResults.jsx
+// Shared results table + metadata line for the reports feature.
+
+export default function ReportResults({ result }) {
+  if (!result) return null;
+  const { columns, rows, rowCount, truncated, durationMs } = result;
+
+  return (
+    <div className="bg-white/90 rounded-lg shadow-sm overflow-hidden">
+      <div className="px-4 py-2 text-xs text-slate-600 border-b border-slate-200 bg-slate-50 flex flex-wrap gap-3">
+        <span>{rowCount} row{rowCount === 1 ? '' : 's'}</span>
+        <span>{durationMs} ms</span>
+        {truncated && (
+          <span className="text-amber-700">Results truncated — export for the full set.</span>
+        )}
+      </div>
+      <div className="overflow-x-auto">
+        {columns.length === 0 ? (
+          <p className="text-sm text-slate-500 p-4">No rows returned.</p>
+        ) : (
+          <table className="w-full text-sm min-w-max">
+            <thead>
+              <tr className="bg-slate-50 border-b border-slate-200 text-left text-slate-600 italic font-normal">
+                {columns.map((c) => (
+                  <th key={c} className="px-4 py-2 font-normal whitespace-nowrap">{c}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr key={i} className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}`}>
+                  {columns.map((c) => (
+                    <td key={c} className="px-4 py-2 align-top whitespace-pre-wrap">
+                      {formatCell(row[c])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatCell(v) {
+  if (v === null || v === undefined) return '';
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  if (typeof v === 'object')  return JSON.stringify(v);
+  return String(v);
+}

--- a/frontend/src/pages/reports/ReportRun.jsx
+++ b/frontend/src/pages/reports/ReportRun.jsx
@@ -1,0 +1,173 @@
+// beacon2/frontend/src/pages/reports/ReportRun.jsx
+// Run a saved SQL report — parameter inputs, Run button, results table, Excel download.
+
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { reports as reportsApi } from '../../lib/api.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import NavBar from '../../components/NavBar.jsx';
+import PageHeader from '../../components/PageHeader.jsx';
+import ReportResults from './ReportResults.jsx';
+
+export default function ReportRun() {
+  const { id } = useParams();
+  const { can, isSiteAdmin, tenant } = useAuth();
+
+  const [report, setReport]     = useState(null);
+  const [loading, setLoading]   = useState(true);
+  const [error, setError]       = useState(null);
+  const [values, setValues]     = useState({});
+  const [running, setRunning]   = useState(false);
+  const [downloading, setDown]  = useState(false);
+  const [result, setResult]     = useState(null);
+  const [runError, setRunError] = useState(null);
+
+  const canRun = can('reports', 'run');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await reportsApi.get(id);
+        setReport(r);
+        const initial = {};
+        for (const p of r.parameters || []) {
+          initial[p.name] = p.default ?? '';
+        }
+        setValues(initial);
+      } catch (err) {
+        setError(err.body?.error || err.message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [id]);
+
+  async function handleRun() {
+    setRunning(true);
+    setRunError(null);
+    setResult(null);
+    try {
+      setResult(await reportsApi.run(id, values));
+    } catch (err) {
+      setRunError(err.body?.error || err.message);
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  async function handleDownload() {
+    setDown(true);
+    setRunError(null);
+    try {
+      await reportsApi.download(id, values);
+    } catch (err) {
+      setRunError(err.body?.error || err.message);
+    } finally {
+      setDown(false);
+    }
+  }
+
+  const navLinks = [
+    { label: 'Home',    to: '/' },
+    { label: 'Reports', to: '/reports' },
+    ...(isSiteAdmin ? [{ label: 'Edit', to: `/reports/${id}/edit` }] : []),
+  ];
+
+  const inputCls = 'border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
+
+  return (
+    <div className="min-h-screen pb-10">
+      <PageHeader tenant={tenant} />
+      <NavBar links={navLinks} />
+
+      <div className="max-w-5xl mx-auto px-4 py-4">
+        {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
+        {loading ? (
+          <p className="text-center text-slate-500 py-8">Loading…</p>
+        ) : report && (
+          <>
+            <h1 className="text-xl font-bold text-center mb-1">{report.name}</h1>
+            {report.description && (
+              <p className="text-sm text-slate-600 text-center mb-4">{report.description}</p>
+            )}
+
+            {(report.parameters || []).length > 0 && (
+              <div className="bg-white/90 rounded-lg shadow-sm p-4 mb-4">
+                <h2 className="text-sm font-semibold text-slate-700 mb-3">Parameters</h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {report.parameters.map((p) => (
+                    <div key={p.name}>
+                      <label className="block text-sm font-medium text-slate-700 mb-1">
+                        {p.label}{p.required ? <span className="text-red-600"> *</span> : null}
+                      </label>
+                      <ParamInput
+                        param={p}
+                        value={values[p.name] ?? ''}
+                        onChange={(v) => setValues((prev) => ({ ...prev, [p.name]: v }))}
+                        className={inputCls}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="flex gap-2 mb-4">
+              <button
+                onClick={handleRun}
+                disabled={!canRun || running}
+                className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium">
+                {running ? 'Running…' : 'Run'}
+              </button>
+              {result && result.rowCount > 0 && (
+                <button
+                  onClick={handleDownload}
+                  disabled={downloading}
+                  className="border border-slate-300 rounded px-5 py-2 text-sm hover:bg-slate-50 disabled:opacity-50">
+                  {downloading ? 'Preparing…' : 'Download Excel'}
+                </button>
+              )}
+              {!canRun && (
+                <p className="text-xs text-slate-500 self-center">You do not have permission to run reports.</p>
+              )}
+            </div>
+
+            {runError && <p className="text-red-600 text-sm mb-3">{runError}</p>}
+
+            <ReportResults result={result} />
+
+            {isSiteAdmin && (
+              <details className="mt-4 text-xs text-slate-600">
+                <summary className="cursor-pointer">Show SQL</summary>
+                <pre className="mt-2 p-3 bg-slate-50 border border-slate-200 rounded overflow-x-auto whitespace-pre-wrap">{report.sql_text}</pre>
+              </details>
+            )}
+          </>
+        )}
+      </div>
+
+      <NavBar links={navLinks} />
+    </div>
+  );
+}
+
+function ParamInput({ param, value, onChange, className }) {
+  if (param.type === 'boolean') {
+    return (
+      <select value={value === true || value === 'true' ? 'true' : 'false'}
+              onChange={(e) => onChange(e.target.value === 'true')}
+              className={className}>
+        <option value="false">No</option>
+        <option value="true">Yes</option>
+      </select>
+    );
+  }
+  const type = param.type === 'number' ? 'number'
+             : param.type === 'date'   ? 'date'
+             : 'text';
+  return (
+    <input type={type} className={className} value={value}
+           onChange={(e) => onChange(e.target.value)}
+           required={param.required} />
+  );
+}

--- a/frontend/src/pages/reports/ReportSql.jsx
+++ b/frontend/src/pages/reports/ReportSql.jsx
@@ -1,0 +1,103 @@
+// beacon2/frontend/src/pages/reports/ReportSql.jsx
+// Ad-hoc SQL editor (site admin only). Runs SELECT/WITH queries against the
+// tenant schema in a read-only transaction with a statement timeout.
+
+import { useState } from 'react';
+import { reports as reportsApi } from '../../lib/api.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import NavBar from '../../components/NavBar.jsx';
+import PageHeader from '../../components/PageHeader.jsx';
+import ReportResults from './ReportResults.jsx';
+
+export default function ReportSql() {
+  const { isSiteAdmin, tenant } = useAuth();
+
+  const [sql, setSql]         = useState('SELECT * FROM members LIMIT 10');
+  const [running, setRunning] = useState(false);
+  const [downloading, setDown] = useState(false);
+  const [result, setResult]   = useState(null);
+  const [error, setError]     = useState(null);
+
+  async function handleRun() {
+    setRunning(true);
+    setError(null);
+    setResult(null);
+    try {
+      setResult(await reportsApi.runSql(sql));
+    } catch (err) {
+      setError(err.body?.error || err.message);
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  async function handleDownload() {
+    setDown(true);
+    setError(null);
+    try {
+      await reportsApi.downloadSql(sql);
+    } catch (err) {
+      setError(err.body?.error || err.message);
+    } finally {
+      setDown(false);
+    }
+  }
+
+  const navLinks = [
+    { label: 'Home',    to: '/' },
+    { label: 'Reports', to: '/reports' },
+  ];
+
+  const inputCls = 'border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
+
+  if (!isSiteAdmin) {
+    return (
+      <div className="min-h-screen pb-10">
+        <PageHeader tenant={tenant} />
+        <NavBar links={navLinks} />
+        <p className="text-center text-red-600 py-8 text-sm">
+          Only site administrators can run ad-hoc SQL.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen pb-10">
+      <PageHeader tenant={tenant} />
+      <NavBar links={navLinks} />
+
+      <div className="max-w-5xl mx-auto px-4 py-4">
+        <h1 className="text-xl font-bold text-center mb-1">Ad-hoc SQL</h1>
+        <p className="text-sm text-slate-600 text-center mb-4">
+          Read-only queries only — SELECT or WITH, single statement. Runs against your tenant schema.
+        </p>
+
+        <div className="bg-white/90 rounded-lg shadow-sm p-4 mb-4">
+          <textarea className={`${inputCls} w-full font-mono text-xs`}
+            value={sql} onChange={(e) => setSql(e.target.value)}
+            rows={10} maxLength={20000}
+            placeholder="SELECT …" />
+          <div className="flex gap-2 mt-3">
+            <button onClick={handleRun} disabled={running || !sql.trim()}
+              className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium">
+              {running ? 'Running…' : 'Run'}
+            </button>
+            {result && result.rowCount > 0 && (
+              <button onClick={handleDownload} disabled={downloading}
+                className="border border-slate-300 rounded px-5 py-2 text-sm hover:bg-slate-50 disabled:opacity-50">
+                {downloading ? 'Preparing…' : 'Download Excel'}
+              </button>
+            )}
+          </div>
+        </div>
+
+        {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
+
+        <ReportResults result={result} />
+      </div>
+
+      <NavBar links={navLinks} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a SQL reports tool: library of saved parameterised reports (new `reports:view` / `reports:run` privileges) plus an ad-hoc SQL editor gated to site administrators
- Safety: every query runs in a transaction with `SET LOCAL transaction_read_only = on`, a 15 s `statement_timeout`, a single-statement guard (only `SELECT` / `WITH`), and a 5,000-row result cap. Named `:param` placeholders are substituted with positional `$N` parameters server-side
- Per-run audit entries; Excel download via ExcelJS; "SQL reports" link added to the Home menu under Misc

## Design choices
- **Hybrid model** — library of saved reports for everyday users; raw SQL for admins only (discussed up-front with the user)
- **Raw SQL gated to `is_site_admin`** rather than a delegable privilege, since one mistake can expose the whole tenant
- **In-code read-only enforcement** (no dedicated Postgres role) — adequate for the current deployment; can be upgraded to a read-only DB role on Render later

## Files
- Backend: `tenant_schema.sql` (new `saved_reports` table), `utils/sqlSafety.js`, `routes/reports.js`, privilege resource + default role grant, 18 new Vitest tests
- Frontend: `pages/reports/{ReportList,ReportRun,ReportEditor,ReportSql,ReportResults}.jsx`, API bindings, routes, Home nav link
- Docs: `CHANGELOG.md` under `[0.10.5]`, `Beacon2 Project Definition.md` new "Reports module" section

## Test plan
- [x] Backend `vitest --run` — 407/407 passing (18 new tests cover list / get / create / run / raw-SQL / download + injection and privilege-gate cases)
- [x] Frontend `vitest --run` — 140/140 passing
- [ ] Manual smoke on staging: create a saved report with one date parameter, run it, download Excel
- [ ] Manual smoke: raw SQL editor (as site admin) rejects `DROP`, `UPDATE`, multi-statement; accepts `WITH`
- [ ] Manual smoke: non-admin user cannot see "Ad-hoc SQL" nav item or hit `/reports/sql`

## Known caveat
`TEST_TENANT = 'test-u3a'` in `backend/src/__tests__/helpers.js` is actually invalid per the existing slug regex (`^[a-z0-9_]+$`). Other tests bypass this by mocking `tenantQuery` wholesale; the new tests call `prisma.$transaction` directly, so they override `tenantSlug` to `test_u3a`. Flagged but not fixed here.

https://claude.ai/code/session_01W5YP4qKiiGJvuxJzgXPXhz