### PR TITLE
Polish Event Record page: nav, eyebrow label, record timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 - **Calendar menu entry renamed to Events** — better reflects the page's broader
   scope (group meetings + non-group events + new tabular view). The route
   `/calendar` is unchanged to preserve bookmarks and portal links.
+- **Event Record page nav bar updated** — the top nav link now reads
+  "Home – Events – {Group}" (previously "Calendar – {Group}"), matching the
+  pattern used on Group and Team records.
+- **Event Record page clearly labelled as an Event** — a small uppercase
+  "EVENT" eyebrow label now appears above the title so the page can no longer
+  be mistaken for a Group or Team record, which share a similar layout.
 
 ### Added
 - **Ledger "by Event" view** (`frontend/src/pages/finance/FinanceLedger.jsx`) —
@@ -37,6 +43,11 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
   via a new `upcomingEventsExpanded` preference key (collapsed by default).
 
 ### Fixed
+- **Event Record timestamp now displays** — the "Event record created … ; last
+  changed …" footer on the Event Record page was silently hidden because
+  `RecordTimestamp` was being passed `created`/`updated` props instead of
+  `createdAt`/`updatedAt`, and no `label` prop. The footer now renders beneath
+  the tab content on every tab, mirroring the Group Record footer.
 - **`splitSQL()` hardened to ignore semicolons in comments and strings** —
   the SQL splitter in `backend/src/utils/migrate.js` previously only tracked
   `$$` dollar quoting, which is why a stray `;` in a `--` line comment in

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -1350,6 +1350,13 @@ to the default event type.
 - **event_members is independent of group_members** — "Copy from group" is a one-time snapshot, not a live link
 - **Transaction event_id** — mirrors existing `group_id` FK pattern; search-as-you-type in TransactionEditor
 - **Feature toggle** — `eventAttendance` sub-feature under Events section; controls Members tab visibility
+- **Event Record visual distinction** — the page carries a small uppercase
+  "EVENT" eyebrow label above the title so it is not confused with a Group
+  or Team record (which share the same centred-title / tab layout). NavBar
+  uses the standard "Home – Events – {Group}" pattern. The
+  `RecordTimestamp` footer sits under the tab panel and renders on every
+  tab (must be passed `label`, `createdAt`, `updatedAt` — not `created` /
+  `updated`).
 
 ### Deferred items (in KNOWN-ISSUES.md)
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-backend",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-backend",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-frontend",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-frontend",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.20.4",
         "@tiptap/extension-text-style": "^3.20.4",

--- a/frontend/src/pages/calendar/EventRecord.jsx
+++ b/frontend/src/pages/calendar/EventRecord.jsx
@@ -52,7 +52,8 @@ export default function EventRecord() {
   }
 
   const navLinks = [
-    { label: 'Calendar', to: '/calendar' },
+    { label: 'Home', to: '/' },
+    { label: 'Events', to: '/calendar' },
     ...(event?.group_id ? [{ label: event.group_name || 'Group', to: `/groups/${event.group_id}` }] : []),
   ];
 
@@ -66,7 +67,7 @@ export default function EventRecord() {
     return (
       <div className="min-h-screen pb-10">
         <PageHeader tenant={tenant} />
-        <NavBar links={[{ label: 'Calendar', to: '/calendar' }]} />
+        <NavBar links={[{ label: 'Home', to: '/' }, { label: 'Events', to: '/calendar' }]} />
         <div className="max-w-4xl mx-auto px-4 py-4">
           <p className="text-slate-500 text-sm">Loading event...</p>
         </div>
@@ -78,7 +79,7 @@ export default function EventRecord() {
     return (
       <div className="min-h-screen pb-10">
         <PageHeader tenant={tenant} />
-        <NavBar links={[{ label: 'Calendar', to: '/calendar' }]} />
+        <NavBar links={[{ label: 'Home', to: '/' }, { label: 'Events', to: '/calendar' }]} />
         <div className="max-w-4xl mx-auto px-4 py-4">
           <p className="text-red-600 text-sm">{error || 'Event not found.'}</p>
         </div>
@@ -94,6 +95,7 @@ export default function EventRecord() {
       <NavBar links={navLinks} />
 
       <div className="max-w-4xl mx-auto px-4 py-4">
+        <p className="text-xs font-semibold tracking-widest text-slate-500 uppercase text-center mb-1">Event</p>
         <h1 className="text-xl font-bold text-center mb-1">{title}</h1>
         <p className="text-sm text-slate-500 text-center mb-3">
           {fmtDate(event.event_date)}
@@ -133,6 +135,8 @@ export default function EventRecord() {
             <EventFinancials eventId={eventId} />
           )}
         </div>
+
+        <RecordTimestamp label="Event record" createdAt={event.created_at} updatedAt={event.updated_at} className="pt-3" />
       </div>
 
       <NavBar links={navLinks} />
@@ -207,7 +211,6 @@ function EventDetails({ event }) {
           <p className={`${fieldCls} whitespace-pre-wrap`}>{e.details}</p>
         </div>
       )}
-      <RecordTimestamp created={e.created_at} updated={e.updated_at} />
     </div>
   );
 }


### PR DESCRIPTION
- NavBar now reads "Home – Events – {Group}" (matches Group/Team records; replaces the single "Calendar" link).
- Added a small uppercase "EVENT" eyebrow label above the title so the page is clearly distinguished from Group and Team records, which share the same centred-title / tab layout.
- Fixed the "Event record created …" footer: RecordTimestamp was being passed the wrong prop names (`created` / `updated`) and no `label`, so nothing rendered. Now uses `createdAt` / `updatedAt` / `label="Event record"` and sits at page level so it shows on every tab.

https://claude.ai/code/session_011PRpcgvyv9Gs2Z4GD5qpRn