### PR TITLE
Restore Open Meetings event type and entries when restoring from Beacon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
   Implemented via a shared `PasswordInput` component
   (`frontend/src/components/PasswordInput.jsx`).
 
+### Fixed
+- **Restore from Beacon now imports Open Meetings** — the legacy Beacon backup's
+  `Calendar` sheet was previously ignored entirely, so any Open Meetings (Calendar
+  rows with no `gkey`) were silently dropped, and the seeded "Open Meetings"
+  event type — wiped by `clearTenantData` — was not re-created. `restoreBeacon()`
+  now re-creates the default "Open Meetings" event type and inserts each non-group
+  Calendar row as a `group_events` record (`group_id NULL`) linked to that event
+  type, with date/time, end time, venue, topic, details, contact and
+  exclude-from-public-calendar all preserved.
+
 ---
 
 ## [0.10.6] — 2026-04-20

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -720,6 +720,16 @@ group_info_config (JSON), calendar_config (JSON).
 shared `akey`. Month `0` → month_index 13 (Renewals). Positive amounts = in,
 negative = out.
 
+**Beacon restore — Open Meetings**: `clearTenantData()` deletes the
+`event_types` rows seeded by `tenant_schema.sql`, so `restoreBeacon()` re-creates
+the default `Open Meetings` event type (`is_default = true`) before processing
+the legacy `Calendar` sheet. Calendar rows with empty `gkey` become
+`group_events` records with `group_id = NULL` and `event_type_id =`
+the new Open Meetings id. The combined `date/time` cell is split via
+`parseBeaconDateTime()` (handles Excel Date objects, `YYYY-MM-DD HH:MM`, and
+`D/M/YYYY HH:MM`). Group-tied calendar rows (gkey set) are intentionally not
+restored — see KNOWN-ISSUES.md.
+
 Both use `prisma.$transaction` with 5-minute timeout. User accounts/roles included.
 
 ### Critical: restore helpers need transaction client

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -143,6 +143,12 @@ Items noted during development that need addressing in future sessions.
    Calendar export option entirely, or having it produce the same Group Events sheet
    independently.
 
+4. **Beacon restore — group-tied calendar events not migrated** — `restoreBeacon()`
+   now imports Open Meetings (Calendar rows with `gkey` empty) but skips group-tied
+   Calendar rows. Restoring those would require resolving the `gkey` to its
+   `groupMap` entry and confirming the per-group event semantics carry over. Defer
+   until needed; for now the group schedule has to be re-entered post-restore.
+
 ---
 
 ## Feature Toggles — deferred phases

--- a/backend/src/__tests__/restoreBeacon.test.js
+++ b/backend/src/__tests__/restoreBeacon.test.js
@@ -88,6 +88,87 @@ describe('restoreBeacon()', () => {
     const writtenJson = JSON.parse(featureCall[1]);
     expect(writtenJson).toEqual(STANDARD_IMPLEMENTATIONS[0].features);
   });
+
+  it('creates the default "Open Meetings" event type', async () => {
+    const wb = new ExcelJS.Workbook();
+    const calls = [];
+    const tx = {
+      $executeRawUnsafe: vi.fn(async (...args) => { calls.push(args); }),
+    };
+
+    await restoreBeacon(tx, wb);
+
+    const omCall = calls.find((c) =>
+      typeof c[0] === 'string' &&
+      c[0].includes('INSERT INTO event_types') &&
+      c[0].includes("'Open Meetings'") &&
+      c[0].includes('true'));
+    expect(omCall).toBeTruthy();
+    // Second arg should be the generated UUID for the event type
+    expect(typeof omCall[1]).toBe('string');
+    expect(omCall[1].length).toBeGreaterThan(0);
+  });
+
+  it('restores Calendar rows without a gkey as open meetings linked to the Open Meetings event type', async () => {
+    const wb = new ExcelJS.Workbook();
+    const cal = wb.addWorksheet('Calendar');
+    cal.addRow(['ckey', 'date/time', 'end_time', 'gkey', 'group', 'gvkey',
+                'venue', 'topic', 'detail', 'enquiries', 'exclude_public']);
+    // Open meeting (gkey empty)
+    cal.addRow(['c1', '2024-06-15 19:00', '21:00', '', '', '',
+                '', 'AGM', 'Annual General Meeting', 'chair@example.com', '']);
+    // Group event (gkey set) — should NOT be restored here
+    cal.addRow(['c2', '2024-06-20 10:00', '12:00', 'g1', 'Walking', '',
+                '', 'Walk', 'Weekly walk', 'leader@example.com', '']);
+    // Private open meeting
+    cal.addRow(['c3', '2024-07-01 14:00', '16:00', '', '', '',
+                '', 'Private planning', '', '', '1']);
+
+    const calls = [];
+    let omEventTypeId = null;
+    const tx = {
+      $executeRawUnsafe: vi.fn(async (sql, ...params) => {
+        calls.push([sql, ...params]);
+        if (typeof sql === 'string' &&
+            sql.includes('INSERT INTO event_types') &&
+            sql.includes("'Open Meetings'")) {
+          omEventTypeId = params[0];
+        }
+      }),
+    };
+
+    await restoreBeacon(tx, wb);
+
+    expect(omEventTypeId).toBeTruthy();
+
+    const openMeetingInserts = calls.filter((c) =>
+      typeof c[0] === 'string' &&
+      c[0].includes('INSERT INTO group_events') &&
+      c[0].includes('NULL'));
+    expect(openMeetingInserts).toHaveLength(2);
+
+    // Event type id parameter is the last one — confirm both link to Open Meetings
+    for (const call of openMeetingInserts) {
+      const params = call.slice(1);
+      expect(params[params.length - 1]).toBe(omEventTypeId);
+    }
+
+    // First open meeting: date, times, topic, details, contact, not private
+    const firstParams = openMeetingInserts[0].slice(1);
+    // params: [id, event_date, start_time, end_time, venue_id, contact, details, topic, is_private, event_type_id]
+    expect(firstParams[1]).toBe('2024-06-15');
+    expect(firstParams[2]).toBe('19:00');
+    expect(firstParams[3]).toBe('21:00');
+    expect(firstParams[5]).toBe('chair@example.com');
+    expect(firstParams[6]).toBe('Annual General Meeting');
+    expect(firstParams[7]).toBe('AGM');
+    expect(firstParams[8]).toBe(false);
+
+    // Third row: exclude_public = '1' → is_private = true
+    const thirdParams = openMeetingInserts[1].slice(1);
+    expect(thirdParams[7]).toBe('Private planning');
+    expect(thirdParams[8]).toBe(true);
+  });
 });
 
 // ── Sys-admin PATCH accepts eventAttendance (closes pre-existing drift) ───

--- a/backend/src/routes/backup.js
+++ b/backend/src/routes/backup.js
@@ -49,6 +49,27 @@ export function parseBool(val) {
   return val === true || val === 1 || val === '1' || val === 'true';
 }
 
+/** Parse a Beacon-format combined "date/time" cell into { date, time }.
+ *  Accepts Excel Date objects, strings like "2024-01-15 19:00" or "15/01/2024 19:00",
+ *  or date-only values.  Returns ISO date (YYYY-MM-DD) and time (HH:MM) or nulls. */
+export function parseBeaconDateTime(val) {
+  if (val == null || val === '') return { date: null, time: null };
+  if (val instanceof Date) {
+    if (isNaN(val.getTime())) return { date: null, time: null };
+    return {
+      date: val.toISOString().slice(0, 10),
+      time: val.toISOString().slice(11, 16),
+    };
+  }
+  const s = String(val).trim();
+  if (!s) return { date: null, time: null };
+  const parts = s.split(/[ T]+/);
+  return {
+    date: parseDate(parts[0]),
+    time: parts[1] ? parts[1].slice(0, 5) : null,
+  };
+}
+
 export function parseDec(val) {
   if (val == null || val === '') return null;
   const n = parseFloat(String(val));
@@ -1429,6 +1450,42 @@ export async function restoreBeacon(tx, wb) {
       `INSERT INTO group_ledger_entries (id, group_id, entry_date, payee, detail, money_in, money_out)
        VALUES (gen_random_uuid()::text,$1,$2::date,$3,$4,$5::numeric,$6::numeric)`,
       groupId, parseDate(r.date), str(r.payee), str(r.detail), moneyIn, moneyOut,
+    );
+  }
+
+  // 9c. Open Meetings (Calendar entries with no gkey)
+  // clearTenantData() removed the seeded "Open Meetings" event type, so re-create it.
+  // Then process the Calendar sheet — rows without a gkey are u3a-wide Open Meetings.
+  // Group-tied calendar entries (gkey set) are not restored here; that would require
+  // resolving their group and is tracked separately in KNOWN-ISSUES.
+  const openMeetingsEventTypeId = uuid();
+  await tx.$executeRawUnsafe(
+    `INSERT INTO event_types (id, name, description, is_default)
+     VALUES ($1, 'Open Meetings', 'u3a-wide events not tied to any group', true)`,
+    openMeetingsEventTypeId,
+  );
+
+  for (const r of get('Calendar')) {
+    const gkey = String(r.gkey || '').trim();
+    if (gkey) continue;
+    const dt = parseBeaconDateTime(r['date/time']);
+    if (!dt.date) continue;
+    const gvkey   = String(r.gvkey || '').trim();
+    const venueId = gvkey ? (venueMap[gvkey] || null) : null;
+    const endTimeRaw = r.end_time;
+    const endTime = endTimeRaw
+      ? (endTimeRaw instanceof Date
+          ? endTimeRaw.toISOString().slice(11, 16)
+          : String(endTimeRaw).slice(0, 5))
+      : null;
+    await tx.$executeRawUnsafe(
+      `INSERT INTO group_events
+         (id, group_id, event_date, start_time, end_time, venue_id,
+          contact, details, topic, is_private, event_type_id)
+       VALUES ($1, NULL, $2::date, $3::time, $4::time, $5, $6, $7, $8, $9, $10)`,
+      uuid(), dt.date, dt.time, endTime, venueId,
+      str(r.enquiries), str(r.detail), str(r.topic),
+      parseBool(r.exclude_public), openMeetingsEventTypeId,
     );
   }
 

--- a/docs/BeaconUG-Comparison.md
+++ b/docs/BeaconUG-Comparison.md
@@ -904,7 +904,7 @@
 | Aspect | Status | Notes |
 |--------|--------|-------|
 | 7 export types + full backup (Excel) | Built | Members, Finance (with credit batches), Groups & teams (with events/ledgers), System users, Officers, Settings (with templates/payment defaults) |
-| Full restore (Beacon2 + Beacon format) | Built | Beacon2 restore preserves all exported data including teams, custom fields, gift aid, refund links, credit batches, events, templates, payment defaults |
+| Full restore (Beacon2 + Beacon format) | Built | Beacon2 restore preserves all exported data including teams, custom fields, gift aid, refund links, credit batches, events, templates, payment defaults. Beacon restore now also re-creates the default "Open Meetings" event type and migrates Open Meetings from the legacy `Calendar` sheet (group-tied calendar rows are still skipped — see KNOWN-ISSUES.md) |
 | Member photos in export | Deferred | Base64 data too large for Excel; needs separate mechanism (see KNOWN-ISSUES.md) |
 | Email delivery history in export | Skipped | Transient SendGrid data; not meaningful to restore |
 


### PR DESCRIPTION
`restoreBeacon()` previously ignored the legacy backup's `Calendar` sheet entirely, and `clearTenantData()` deletes the seeded `Open Meetings` event type before the restore runs — so post-restore there was no Open Meetings event type and no Open Meetings.

Now `restoreBeacon()`:
- re-creates the default `Open Meetings` event type (`is_default = true`), and
- imports every Calendar row whose `gkey` is empty as a `group_events` record with `group_id NULL` and `event_type_id` pointing at the new Open Meetings type.

Date/time, end time, venue (via existing `venueMap`), topic, details, contact and `exclude_public` (`is_private`) are all preserved. A new `parseBeaconDateTime()` helper handles Excel Date cells, ISO strings and the `D/M/YYYY HH:MM` form.

Tests cover (a) the event-type insert and (b) that two open-meeting rows are inserted while a group-tied calendar row is skipped, with all parameters preserved including the link to the new event type.

https://claude.ai/code/session_01WN7pZh7yVsf9SknvYwXDS5