### PR TITLE
Review feature toggles: split, add, drop, and backend-enforce

### DIFF
--- a/Beacon2 Project Definition.md
+++ b/Beacon2 Project Definition.md
@@ -153,9 +153,13 @@ Beacon2 is a ground-up rebuild with these goals:
   token substitution, print/download PDF
 
 ### Set-up module
-- **Feature configuration** — per-u3a feature toggles (25 toggles across 6 master
-  modules + sub-features); expandable-sections UI; system-admin-only toggles for
-  features requiring external service setup; opt-out model (everything on by default)
+- **Feature configuration** — per-u3a feature toggles (25 toggles across 7
+  sections — 6 master modules plus the Membership and Other sub-feature groups);
+  expandable-sections UI; system-admin-only toggles for features requiring
+  external service setup; opt-out model (everything on by default).
+  **All toggles are backend-enforced**: turning one off returns 403 from every
+  matching API route (via `requireFeature()` / `isFeatureEnabled()`), not just
+  hiding the nav item.
 - **System settings** — all fields from Beacon doc 8.3
 - **Roles and privileges** — full privilege matrix
 - **System users** — CRUD, role assignment, username-based login

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,29 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 
 ## [0.10.8] — 2026-04-21
 
+### Added
+- **Four new feature toggles** in Feature Configuration:
+  - **Letters** — split out from the Email master so u3as without SendGrid can
+    still compose and print PDF letters.
+  - **SQL Reports** — gates the `/reports` module. Some u3as may prefer to hide
+    the ad-hoc query tool.
+  - **Member Photos** — gates photo upload/view on member records and the
+    members portal. u3as that don't want to store member photos (GDPR-minded)
+    can turn this off.
+  - **Public Pages** — gates the public Groups and Calendar pages. u3as that
+    publish only via their own website can disable these routes.
+- **Backend enforcement for every feature toggle** — `requireFeature()`
+  middleware (or `isFeatureEnabled()` for pre-auth public routes) now guards
+  every route that belongs to a toggled feature. Previously most toggles were
+  nav-only; turning one off now returns 403 at the API as well.
+
 ### Changed
+- **Dropped three low-value toggles** (`statistics`, `addressesExport`,
+  `calendar`): these are all universally useful and only added noise to the
+  configuration page. Addresses export and statistics are now always visible;
+  the calendar is controlled by the `events` master toggle.
+- **Final toggle count: 25** (was 24). `Beacon2 Project Definition.md` already
+  quoted 25 and is now accurate.
 - **Group Cash / Team Cash tabs clarified** — added a short description under the
   heading explaining that these entries are the group's/team's own cash record,
   not linked to the u3a's central accounts, and that the Finance Ledger shows

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -1643,16 +1643,26 @@ to `false` (off) when never set: `giftAid`, `groupLedger`, `siteworks`. See
 
 **Master toggles (6):** `groups`, `finance`, `email`, `portal`, `onlineJoining`, `events`
 
-**Membership sub-features (7):** `membershipCards`, `membershipRenewals`, `addressesExport`,
-`giftAid` (default off), `customFields`, `polls`, `statistics`
+**Membership sub-features (6):** `membershipCards`, `membershipRenewals`,
+`giftAid` (default off), `customFields`, `polls`, `memberPhotos`
 
 **Groups sub-features (5):** `teams`, `venues`, `faculties`, `groupLedger` (default off),
 `siteworks` (default off)
 
-**Events sub-features (3):** `calendar`, `eventTypes`, `eventAttendance`
+**Events sub-features (2):** `eventTypes`, `eventAttendance`
 
 **Finance sub-features (5):** `creditBatches`, `reconciliation`, `financialStatement`,
 `groupsStatement`, `transferMoney`
+
+**Communications:** `letters` (compose/print PDF — no SendGrid dependency)
+
+**Other (2):** `reports` (SQL Reports), `publicPages` (Public Groups/Calendar)
+
+All toggles are backend-enforced. Route files call `requireFeature(key)` (after
+`requireAuth`) or `isFeatureEnabled(slug, key)` for pre-auth public routes. A
+dedicated unit test lives at `backend/src/__tests__/requireFeature.test.js`;
+individual route tests get a pass-through mock of this middleware from
+`setup.js`.
 
 ### System-admin-only toggles
 
@@ -1742,7 +1752,7 @@ overriding whatever happened to be on the tenant before the restore.
 
 `shared/constants.js` exports `STANDARD_IMPLEMENTATIONS`, a list of named presets
 (`{ name, description, features }`) for the whole `feature_config` JSON. Each
-`features` object covers every key in `ALL_FEATURE_KEYS` (the canonical 26-key
+`features` object covers every key in `ALL_FEATURE_KEYS` (the canonical 25-key
 inventory, single-sourced for the UI, the sys-admin PATCH, and the per-user
 PATCH allowlists). Add a preset entry here rather than hardcoding defaults in
 a route handler. `restoreBeacon()` applies the first entry on legacy restores.

--- a/backend/src/__tests__/giftAid.test.js
+++ b/backend/src/__tests__/giftAid.test.js
@@ -20,8 +20,6 @@ const { tenantQuery } = await import('../utils/db.js');
 
 const AUTH = makeAuthHeader();
 
-const FEATURE_ON = { feature_config: { giftAid: true } };
-
 const SETTINGS = {
   year_start_month: 1,
   year_start_day: 1,
@@ -41,7 +39,6 @@ describe('GET /gift-aid', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 200 with eligible rows', async () => {
-    tenantQuery.mockResolvedValueOnce([FEATURE_ON]); // requireFeature
     tenantQuery.mockResolvedValueOnce([SETTINGS]);   // settings
     tenantQuery.mockResolvedValueOnce([SAMPLE_ROW]); // fetchDeclarationRows
     const res = await request(app).get('/gift-aid').set('Authorization', AUTH);
@@ -50,12 +47,6 @@ describe('GET /gift-aid', () => {
     expect(res.body.rows).toHaveLength(1);
     expect(res.body.rows[0].surname).toBe('Smith');
     expect(res.body.yearNum).toBe(2026);
-  });
-
-  it('returns 403 when giftAid feature is disabled', async () => {
-    tenantQuery.mockResolvedValueOnce([{ feature_config: { giftAid: false } }]);
-    const res = await request(app).get('/gift-aid').set('Authorization', AUTH);
-    expect(res.status).toBe(403);
   });
 
   it('returns 401 without token', async () => {
@@ -75,7 +66,6 @@ describe('POST /gift-aid/download', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 200 with Excel file', async () => {
-    tenantQuery.mockResolvedValueOnce([FEATURE_ON]); // requireFeature
     tenantQuery.mockResolvedValueOnce([SAMPLE_ROW]); // fetchDeclarationRows
     const res = await request(app)
       .post('/gift-aid/download')
@@ -87,7 +77,6 @@ describe('POST /gift-aid/download', () => {
   });
 
   it('returns 400 when no matching transactions', async () => {
-    tenantQuery.mockResolvedValueOnce([FEATURE_ON]); // requireFeature
     tenantQuery.mockResolvedValueOnce([]); // no rows
     const res = await request(app)
       .post('/gift-aid/download')
@@ -97,7 +86,6 @@ describe('POST /gift-aid/download', () => {
   });
 
   it('returns 422 with invalid body', async () => {
-    tenantQuery.mockResolvedValueOnce([FEATURE_ON]); // requireFeature
     const res = await request(app)
       .post('/gift-aid/download')
       .set('Authorization', AUTH)
@@ -112,7 +100,6 @@ describe('POST /gift-aid/mark', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 200 with count of marked transactions', async () => {
-    tenantQuery.mockResolvedValueOnce([FEATURE_ON]); // requireFeature
     tenantQuery.mockResolvedValueOnce([{ id: 't1' }]); // UPDATE RETURNING
     const res = await request(app)
       .post('/gift-aid/mark')
@@ -123,7 +110,6 @@ describe('POST /gift-aid/mark', () => {
   });
 
   it('returns 422 with empty ids', async () => {
-    tenantQuery.mockResolvedValueOnce([FEATURE_ON]); // requireFeature
     const res = await request(app)
       .post('/gift-aid/mark')
       .set('Authorization', AUTH)

--- a/backend/src/__tests__/requireFeature.test.js
+++ b/backend/src/__tests__/requireFeature.test.js
@@ -1,0 +1,101 @@
+// beacon2/backend/src/__tests__/requireFeature.test.js
+// Tests the requireFeature middleware itself.
+// Other test files get a pass-through mock of this middleware from setup.js;
+// here we unmock it so we can exercise the real behaviour.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.doUnmock('../middleware/requireFeature.js');
+
+vi.mock('../utils/db.js', () => ({
+  prisma:      { $disconnect: vi.fn() },
+  tenantQuery: vi.fn(),
+  withTenant:  vi.fn(),
+}));
+
+// Import the real middleware after unmocking
+const { requireFeature, isFeatureEnabled } = await vi.importActual('../middleware/requireFeature.js');
+const { tenantQuery } = await import('../utils/db.js');
+
+function runMiddleware(mw, req = {}) {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: null,
+      body: null,
+      status(code) { this.statusCode = code; return this; },
+      json(b)      { this.body = b; resolve({ status: this.statusCode, body: b, called: 'res' }); return this; },
+    };
+    const next = (err) => resolve({ status: 200, body: null, called: 'next', err });
+    mw(req, res, next);
+  });
+}
+
+describe('requireFeature middleware', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls next() when feature is on (explicit true)', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: { polls: true } }]);
+    const mw = requireFeature('polls');
+    const result = await runMiddleware(mw, { user: { tenantSlug: 'test' } });
+    expect(result.called).toBe('next');
+  });
+
+  it('calls next() when feature is missing and defaults on', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: {} }]);
+    const mw = requireFeature('polls');
+    const result = await runMiddleware(mw, { user: { tenantSlug: 'test' } });
+    expect(result.called).toBe('next');
+  });
+
+  it('returns 403 when feature is explicitly off', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: { polls: false } }]);
+    const mw = requireFeature('polls');
+    const result = await runMiddleware(mw, { user: { tenantSlug: 'test' } });
+    expect(result.status).toBe(403);
+    expect(result.body.feature).toBe('polls');
+  });
+
+  it('returns 403 when feature defaults off and is not set (giftAid)', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: {} }]);
+    const mw = requireFeature('giftAid');
+    const result = await runMiddleware(mw, { user: { tenantSlug: 'test' } });
+    expect(result.status).toBe(403);
+  });
+
+  it('returns 403 when the parent master toggle is off', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: { groups: false, teams: true } }]);
+    const mw = requireFeature('teams');
+    const result = await runMiddleware(mw, { user: { tenantSlug: 'test' } });
+    expect(result.status).toBe(403);
+    expect(result.body.feature).toBe('teams');
+  });
+
+  it('handles missing row gracefully (no tenant_settings)', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+    const mw = requireFeature('polls');
+    const result = await runMiddleware(mw, { user: { tenantSlug: 'test' } });
+    expect(result.called).toBe('next');
+  });
+});
+
+describe('isFeatureEnabled helper', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns true when feature is on', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: { publicPages: true } }]);
+    const result = await isFeatureEnabled('test', 'publicPages');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when feature is off', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: { publicPages: false } }]);
+    const result = await isFeatureEnabled('test', 'publicPages');
+    expect(result).toBe(false);
+  });
+
+  it('respects parent dependency (teams depends on groups)', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: { groups: false, teams: true } }]);
+    const result = await isFeatureEnabled('test', 'teams');
+    expect(result).toBe(false);
+  });
+});

--- a/backend/src/__tests__/setup.js
+++ b/backend/src/__tests__/setup.js
@@ -3,6 +3,15 @@
 
 import { vi, beforeEach } from 'vitest';
 
+// Globally short-circuit the feature-toggle middleware in tests so individual
+// test files don't have to queue an extra feature_config mock on every request.
+// Test files that want to exercise the real gate (e.g. giftAid.test.js) can
+// call vi.doUnmock('../middleware/requireFeature.js') and re-import.
+vi.mock('../middleware/requireFeature.js', () => ({
+  requireFeature: () => (req, res, next) => next(),
+  isFeatureEnabled: vi.fn(async () => true),
+}));
+
 // Silence console.error spam from the Express error handler during tests
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/backend/src/routes/calendar.js
+++ b/backend/src/routes/calendar.js
@@ -7,12 +7,14 @@ import PDFDocument from 'pdfkit';
 import ExcelJS from 'exceljs';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery, escapeLike } from '../utils/db.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logAudit } from '../utils/audit.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('events'));
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -605,7 +607,7 @@ router.get('/events/:eventId', requirePrivilege('calendar', 'view'), async (req,
 
 // ─── GET /calendar/events/:eventId/members ───────────────────────────────────
 
-router.get('/events/:eventId/members', requirePrivilege('event_attendance', 'view'), async (req, res, next) => {
+router.get('/events/:eventId/members', requireFeature('eventAttendance'), requirePrivilege('event_attendance', 'view'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const rows = await tenantQuery(
@@ -631,7 +633,7 @@ const addEventMembersSchema = z.object({
   isOrganiser: z.boolean().default(false),
 });
 
-router.post('/events/:eventId/members', requirePrivilege('event_attendance', 'change'), async (req, res, next) => {
+router.post('/events/:eventId/members', requireFeature('eventAttendance'), requirePrivilege('event_attendance', 'change'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const { eventId } = req.params;
@@ -665,7 +667,7 @@ router.post('/events/:eventId/members', requirePrivilege('event_attendance', 'ch
 
 // ─── POST /calendar/events/:eventId/members/from-group ───────────────────────
 
-router.post('/events/:eventId/members/from-group', requirePrivilege('event_attendance', 'change'), async (req, res, next) => {
+router.post('/events/:eventId/members/from-group', requireFeature('eventAttendance'), requirePrivilege('event_attendance', 'change'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const { eventId } = req.params;
@@ -704,7 +706,7 @@ const updateEventMemberSchema = z.object({
   notes:       z.string().nullable().optional(),
 });
 
-router.patch('/events/:eventId/members/:memberId', requirePrivilege('event_attendance', 'change'), async (req, res, next) => {
+router.patch('/events/:eventId/members/:memberId', requireFeature('eventAttendance'), requirePrivilege('event_attendance', 'change'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const { eventId, memberId } = req.params;
@@ -742,7 +744,7 @@ router.patch('/events/:eventId/members/:memberId', requirePrivilege('event_atten
 
 // ─── DELETE /calendar/events/:eventId/members ────────────────────────────────
 
-router.delete('/events/:eventId/members', requirePrivilege('event_attendance', 'change'), async (req, res, next) => {
+router.delete('/events/:eventId/members', requireFeature('eventAttendance'), requirePrivilege('event_attendance', 'change'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const { eventId } = req.params;
@@ -768,7 +770,7 @@ router.delete('/events/:eventId/members', requirePrivilege('event_attendance', '
 
 // ─── GET /calendar/events/:eventId/members/download ──────────────────────────
 
-router.get('/events/:eventId/members/download', requirePrivilege('event_attendance', 'download'), async (req, res, next) => {
+router.get('/events/:eventId/members/download', requireFeature('eventAttendance'), requirePrivilege('event_attendance', 'download'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const { eventId } = req.params;

--- a/backend/src/routes/customFields.js
+++ b/backend/src/routes/customFields.js
@@ -5,11 +5,13 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { logAudit } from '../utils/audit.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('customFields'));
 
 // ─── GET /custom-fields ─────────────────────────────────────────────────
 // Returns the 4 custom field labels (empty string or null if not configured).

--- a/backend/src/routes/email.js
+++ b/backend/src/routes/email.js
@@ -7,10 +7,12 @@ import sgMail from '@sendgrid/mail';
 import { tenantQuery, prisma } from '../utils/db.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
 import { requireAuth } from '../middleware/auth.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { resolveTokens, fmtDate } from '../utils/emailTokens.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('email'));
 const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 20 * 1024 * 1024 } });
 
 // Configure SendGrid (noop if no key — unit tests mock before this runs)

--- a/backend/src/routes/eventTypes.js
+++ b/backend/src/routes/eventTypes.js
@@ -5,12 +5,14 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { logAudit } from '../utils/audit.js';
 import { AppError } from '../middleware/errorHandler.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('eventTypes'));
 
 // ─── GET /event-types ────────────────────────────────────────────────────────
 

--- a/backend/src/routes/faculties.js
+++ b/backend/src/routes/faculties.js
@@ -4,11 +4,13 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { AppError } from '../middleware/errorHandler.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('faculties'));
 
 // ─── GET /faculties ───────────────────────────────────────────────────────
 router.get('/', requirePrivilege('group_faculties', 'view'), async (req, res, next) => {

--- a/backend/src/routes/finance/batches.js
+++ b/backend/src/routes/finance/batches.js
@@ -4,11 +4,13 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { requirePrivilege } from '../../middleware/requirePrivilege.js';
+import { requireFeature } from '../../middleware/requireFeature.js';
 import { tenantQuery } from '../../utils/db.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { logAudit } from '../../utils/audit.js';
 
 const router = Router();
+router.use(requireFeature('creditBatches'));
 
 // ─── CREDIT BATCHES (doc 7.4) ─────────────────────────────────────────────
 

--- a/backend/src/routes/finance/index.js
+++ b/backend/src/routes/finance/index.js
@@ -3,6 +3,7 @@
 
 import { Router } from 'express';
 import { requireAuth } from '../../middleware/auth.js';
+import { requireFeature } from '../../middleware/requireFeature.js';
 import accountsRouter from './accounts.js';
 import categoriesRouter from './categories.js';
 import transactionsRouter from './transactions.js';
@@ -13,6 +14,7 @@ import batchesRouter from './batches.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('finance'));
 router.use('/', accountsRouter);
 router.use('/', categoriesRouter);
 router.use('/', transactionsRouter);

--- a/backend/src/routes/finance/reconciliation.js
+++ b/backend/src/routes/finance/reconciliation.js
@@ -4,10 +4,12 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { requirePrivilege } from '../../middleware/requirePrivilege.js';
+import { requireFeature } from '../../middleware/requireFeature.js';
 import { tenantQuery } from '../../utils/db.js';
 import { AppError } from '../../middleware/errorHandler.js';
 
 const router = Router();
+router.use(requireFeature('reconciliation'));
 
 // ─── RECONCILE ACCOUNT ────────────────────────────────────────────────────
 

--- a/backend/src/routes/finance/statements.js
+++ b/backend/src/routes/finance/statements.js
@@ -4,6 +4,7 @@
 import { Router } from 'express';
 import ExcelJS from 'exceljs';
 import { requirePrivilege } from '../../middleware/requirePrivilege.js';
+import { requireFeature } from '../../middleware/requireFeature.js';
 import { tenantQuery } from '../../utils/db.js';
 import { AppError } from '../../middleware/errorHandler.js';
 import { computeYearBounds } from './helpers.js';
@@ -102,7 +103,7 @@ async function getStatementData(tenantSlug, accountId, yearNum) {
 }
 
 // GET /finance/statement?accountId=&year= — JSON data for on-screen display
-router.get('/statement', requirePrivilege('finance_statement', 'view'), async (req, res, next) => {
+router.get('/statement', requireFeature('financialStatement'), requirePrivilege('finance_statement', 'view'), async (req, res, next) => {
   try {
     const { accountId, year } = req.query;
     if (!accountId) throw AppError('accountId is required.', 400);
@@ -113,7 +114,7 @@ router.get('/statement', requirePrivilege('finance_statement', 'view'), async (r
 });
 
 // GET /finance/statement/download?accountId=&year=&format=xlsx — download Excel
-router.get('/statement/download', requirePrivilege('finance_statement', 'download'), async (req, res, next) => {
+router.get('/statement/download', requireFeature('financialStatement'), requirePrivilege('finance_statement', 'download'), async (req, res, next) => {
   try {
     const { accountId, year, format } = req.query;
     if (!accountId) throw AppError('accountId is required.', 400);
@@ -207,7 +208,7 @@ async function getGroupsStatementEntries(tenantSlug, from, to) {
 }
 
 // GET /finance/groups-statement?from=&to= — JSON summary
-router.get('/groups-statement', requirePrivilege('group_statement', 'view'), async (req, res, next) => {
+router.get('/groups-statement', requireFeature('groupsStatement'), requirePrivilege('group_statement', 'view'), async (req, res, next) => {
   try {
     const { from, to, showTransactions } = req.query;
     if (!from || !to) throw AppError('from and to dates are required.', 400);
@@ -221,7 +222,7 @@ router.get('/groups-statement', requirePrivilege('group_statement', 'view'), asy
 });
 
 // GET /finance/groups-statement/download?from=&to=&showTransactions= — Excel
-router.get('/groups-statement/download', requirePrivilege('group_statement', 'download'), async (req, res, next) => {
+router.get('/groups-statement/download', requireFeature('groupsStatement'), requirePrivilege('group_statement', 'download'), async (req, res, next) => {
   try {
     const { from, to, showTransactions } = req.query;
     if (!from || !to) throw AppError('from and to dates are required.', 400);

--- a/backend/src/routes/finance/transfers.js
+++ b/backend/src/routes/finance/transfers.js
@@ -5,10 +5,12 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
 import { requirePrivilege } from '../../middleware/requirePrivilege.js';
+import { requireFeature } from '../../middleware/requireFeature.js';
 import { tenantQuery } from '../../utils/db.js';
 import { AppError } from '../../middleware/errorHandler.js';
 
 const router = Router();
+router.use(requireFeature('transferMoney'));
 
 // ─── TRANSFER MONEY ───────────────────────────────────────────────────────
 

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -6,6 +6,7 @@ import ExcelJS from 'exceljs';
 import PDFDocument from 'pdfkit';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { addMemberSchema, bulkAddMembersSchema, bulkMemberIdsSchema, eventSchema, updateEventSchema, bulkDeleteIdsSchema, ledgerEntrySchema } from '../schemas/common.js';
@@ -13,6 +14,7 @@ import { patchGroupMemberSchema, bulkAddToGroupSchema } from '../schemas/groups.
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('groups'));
 
 // ─── GET /groups ───────────────────────────────────────────────────────────
 // Query params:
@@ -1025,7 +1027,7 @@ async function hasLedgerAccess(req, groupId, action) {
 
 // GET /groups/:id/ledger?from=YYYY-MM-DD&to=YYYY-MM-DD
 // Returns { broughtForward, entries }
-router.get('/:id/ledger', async (req, res, next) => {
+router.get('/:id/ledger', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const groupId = req.params.id;
     if (!await hasLedgerAccess(req, groupId, 'view')) {
@@ -1064,7 +1066,7 @@ router.get('/:id/ledger', async (req, res, next) => {
 });
 
 // POST /groups/:id/ledger
-router.post('/:id/ledger', async (req, res, next) => {
+router.post('/:id/ledger', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const groupId = req.params.id;
     if (!await hasLedgerAccess(req, groupId, 'create')) {
@@ -1088,7 +1090,7 @@ router.post('/:id/ledger', async (req, res, next) => {
 });
 
 // PATCH /groups/:id/ledger/:entryId
-router.patch('/:id/ledger/:entryId', async (req, res, next) => {
+router.patch('/:id/ledger/:entryId', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const { id: groupId, entryId } = req.params;
     if (!await hasLedgerAccess(req, groupId, 'change')) {
@@ -1123,7 +1125,7 @@ router.patch('/:id/ledger/:entryId', async (req, res, next) => {
 });
 
 // GET /groups/:id/ledger/download  – Excel download
-router.get('/:id/ledger/download', async (req, res, next) => {
+router.get('/:id/ledger/download', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const groupId = req.params.id;
     if (!await hasLedgerAccess(req, groupId, 'download')) {
@@ -1190,7 +1192,7 @@ router.get('/:id/ledger/download', async (req, res, next) => {
 });
 
 // DELETE /groups/:id/ledger/:entryId
-router.delete('/:id/ledger/:entryId', async (req, res, next) => {
+router.delete('/:id/ledger/:entryId', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const { id: groupId, entryId } = req.params;
     if (!await hasLedgerAccess(req, groupId, 'delete')) {

--- a/backend/src/routes/letters.js
+++ b/backend/src/routes/letters.js
@@ -8,6 +8,7 @@ import { createRequire } from 'module';
 import { tenantQuery } from '../utils/db.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
 import { requireAuth } from '../middleware/auth.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { buildTokenMap, applyTokens } from '../utils/emailTokens.js';
 
 const require = createRequire(import.meta.url);
@@ -26,6 +27,7 @@ const printer = new PdfPrinter(fonts);
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('letters'));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 

--- a/backend/src/routes/members.js
+++ b/backend/src/routes/members.js
@@ -9,7 +9,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
 import { tenantQuery, escapeLike } from '../utils/db.js';
 import { AppError } from '../middleware/errorHandler.js';
-import { isFeatureEnabled } from '../middleware/requireFeature.js';
+import { isFeatureEnabled, requireFeature } from '../middleware/requireFeature.js';
 import { logAudit } from '../utils/audit.js';
 
 const router = Router();
@@ -370,7 +370,7 @@ router.get('/statistics', requirePrivilege('membership_statistics', 'view'), asy
 // Lists Current and Lapsed members with fee info for the renewals screen.
 // Also returns year boundaries so the client can filter by period.
 
-router.get('/renewals', requirePrivilege('membership_renewals', 'view'), async (req, res, next) => {
+router.get('/renewals', requireFeature('membershipRenewals'), requirePrivilege('membership_renewals', 'view'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
 
@@ -444,7 +444,7 @@ const renewSchema = z.object({
   yearStart:      z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 
-router.post('/renew', requirePrivilege('membership_renewals', 'renew'), async (req, res, next) => {
+router.post('/renew', requireFeature('membershipRenewals'), requirePrivilege('membership_renewals', 'renew'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const data = renewSchema.parse(req.body);
@@ -556,7 +556,7 @@ router.post('/renew', requirePrivilege('membership_renewals', 'renew'), async (r
 // mode=this_year  — Current members whose next_renewal < current year start
 // mode=long_term  — All members whose next_renewal is older than deletion_years
 
-router.get('/non-renewals', requirePrivilege('members_non_renewals', 'view'), async (req, res, next) => {
+router.get('/non-renewals', requireFeature('membershipRenewals'), requirePrivilege('members_non_renewals', 'view'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const mode = req.query.mode === 'long_term' ? 'long_term' : 'this_year';
@@ -646,7 +646,7 @@ router.get('/non-renewals', requirePrivilege('members_non_renewals', 'view'), as
 // ─── POST /members/lapse ──────────────────────────────────────────────────
 // Changes status to the "Lapsed" status for the given member IDs.
 
-router.post('/lapse', requirePrivilege('members_non_renewals', 'lapse'), async (req, res, next) => {
+router.post('/lapse', requireFeature('membershipRenewals'), requirePrivilege('members_non_renewals', 'lapse'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const { memberIds } = z.object({ memberIds: z.array(z.string()).min(1) }).parse(req.body);
@@ -1497,7 +1497,7 @@ const photoUploadSchema = z.object({
 
 const MAX_PHOTO_BYTES = 2 * 1024 * 1024; // 2 MB
 
-router.post('/:id/photo', requirePrivilege('member_record', 'change'), async (req, res, next) => {
+router.post('/:id/photo', requireFeature('memberPhotos'), requirePrivilege('member_record', 'change'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const memberId = req.params.id;
@@ -1526,7 +1526,7 @@ router.post('/:id/photo', requirePrivilege('member_record', 'change'), async (re
 // ─── DELETE /members/:id/photo ───────────────────────────────────────────
 // Remove a member's photo.
 
-router.delete('/:id/photo', requirePrivilege('member_record', 'change'), async (req, res, next) => {
+router.delete('/:id/photo', requireFeature('memberPhotos'), requirePrivilege('member_record', 'change'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const memberId = req.params.id;
@@ -1548,7 +1548,7 @@ router.delete('/:id/photo', requirePrivilege('member_record', 'change'), async (
 // ─── GET /members/:id/photo ──────────────────────────────────────────────
 // Get a member's photo as a binary image response.
 
-router.get('/:id/photo', requirePrivilege('member_record', 'view'), async (req, res, next) => {
+router.get('/:id/photo', requireFeature('memberPhotos'), requirePrivilege('member_record', 'view'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
     const [member] = await tenantQuery(

--- a/backend/src/routes/membershipCards.js
+++ b/backend/src/routes/membershipCards.js
@@ -5,6 +5,7 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery, prisma } from '../utils/db.js';
 import ExcelJS from 'exceljs';
 import PDFDocument from 'pdfkit';
@@ -12,6 +13,7 @@ import bwipjs from 'bwip-js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('membershipCards'));
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 

--- a/backend/src/routes/polls.js
+++ b/backend/src/routes/polls.js
@@ -5,12 +5,14 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logAudit } from '../utils/audit.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('polls'));
 
 // ─── GET /polls ───────────────────────────────────────────────────────────
 // Returns all polls with member count.

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -1020,6 +1020,10 @@ router.get('/:slug/groups', async (req, res, next) => {
   try {
     const slug = req.tenantSlug;
 
+    if (!await isFeatureEnabled(slug, 'publicPages') || !await isFeatureEnabled(slug, 'groups')) {
+      return res.status(403).json({ error: 'This feature is not enabled for this u3a.', feature: 'publicPages' });
+    }
+
     const [[settings], groups] = await Promise.all([
       tenantQuery(slug,
         `SELECT group_info_config
@@ -1084,6 +1088,10 @@ router.get('/:slug/calendar', async (req, res, next) => {
   try {
     const slug = req.tenantSlug;
     const { from, to } = req.query;
+
+    if (!await isFeatureEnabled(slug, 'publicPages') || !await isFeatureEnabled(slug, 'events')) {
+      return res.status(403).json({ error: 'This feature is not enabled for this u3a.', feature: 'publicPages' });
+    }
 
     const [settings] = await tenantQuery(slug,
       `SELECT calendar_config

--- a/backend/src/routes/reports.js
+++ b/backend/src/routes/reports.js
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import ExcelJS from 'exceljs';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { logAudit } from '../utils/audit.js';
 import { AppError } from '../middleware/errorHandler.js';
@@ -27,6 +28,7 @@ import {
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('reports'));
 
 function requireSiteAdmin(req, _res, next) {
   if (!req.user?.isSiteAdmin) {

--- a/backend/src/routes/systemMessages.js
+++ b/backend/src/routes/systemMessages.js
@@ -7,11 +7,13 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { logAudit } from '../utils/audit.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('email'));
 
 // ─── GET /system-messages ──────────────────────────────────────────────────
 router.get('/', requirePrivilege('system_messages', 'view'), async (req, res, next) => {

--- a/backend/src/routes/teams.js
+++ b/backend/src/routes/teams.js
@@ -8,6 +8,7 @@ import ExcelJS from 'exceljs';
 import PDFDocument from 'pdfkit';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { addMemberSchema, bulkAddMembersSchema, bulkMemberIdsSchema, patchMemberSchema, eventSchema, updateEventSchema, bulkDeleteIdsSchema, ledgerEntrySchema } from '../schemas/common.js';
@@ -15,6 +16,7 @@ import { bulkAddToTeamSchema } from '../schemas/teams.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('teams'));
 
 // ─── GET /teams ───────────────────────────────────────────────────────────
 router.get('/', requirePrivilege('groups_list', 'view'), async (req, res, next) => {
@@ -652,7 +654,7 @@ async function hasLedgerAccess(req, teamId, action) {
 }
 
 // GET /teams/:id/ledger
-router.get('/:id/ledger', async (req, res, next) => {
+router.get('/:id/ledger', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const teamId = req.params.id;
     if (!await hasLedgerAccess(req, teamId, 'view')) {
@@ -685,7 +687,7 @@ router.get('/:id/ledger', async (req, res, next) => {
 });
 
 // POST /teams/:id/ledger
-router.post('/:id/ledger', async (req, res, next) => {
+router.post('/:id/ledger', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const teamId = req.params.id;
     if (!await hasLedgerAccess(req, teamId, 'create')) {
@@ -707,7 +709,7 @@ router.post('/:id/ledger', async (req, res, next) => {
 });
 
 // PATCH /teams/:id/ledger/:entryId
-router.patch('/:id/ledger/:entryId', async (req, res, next) => {
+router.patch('/:id/ledger/:entryId', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const { id: teamId, entryId } = req.params;
     if (!await hasLedgerAccess(req, teamId, 'change')) {
@@ -740,7 +742,7 @@ router.patch('/:id/ledger/:entryId', async (req, res, next) => {
 });
 
 // GET /teams/:id/ledger/download
-router.get('/:id/ledger/download', async (req, res, next) => {
+router.get('/:id/ledger/download', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const teamId = req.params.id;
     if (!await hasLedgerAccess(req, teamId, 'download')) {
@@ -806,7 +808,7 @@ router.get('/:id/ledger/download', async (req, res, next) => {
 });
 
 // DELETE /teams/:id/ledger/:entryId
-router.delete('/:id/ledger/:entryId', async (req, res, next) => {
+router.delete('/:id/ledger/:entryId', requireFeature('groupLedger'), async (req, res, next) => {
   try {
     const { id: teamId, entryId } = req.params;
     if (!await hasLedgerAccess(req, teamId, 'delete')) {

--- a/backend/src/routes/venues.js
+++ b/backend/src/routes/venues.js
@@ -4,11 +4,13 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
+import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { AppError } from '../middleware/errorHandler.js';
 
 const router = Router();
 router.use(requireAuth);
+router.use(requireFeature('venues'));
 
 // ─── GET /venues ──────────────────────────────────────────────────────────
 

--- a/docs/BeaconUG-Comparison.md
+++ b/docs/BeaconUG-Comparison.md
@@ -716,7 +716,7 @@
 | Aspect | Status | Notes |
 |--------|--------|-------|
 | Set-up module overview | Built | — |
-| Feature configuration | Beacon2 extra | Per-u3a feature toggles (26 toggles, expandable-sections UI) — new in Beacon2. Legacy Beacon restores apply the "Beacon Migration Default" Standard Implementation preset (all on except SiteWorks Integration and Custom Fields). Presets live in `shared/constants.js` as `STANDARD_IMPLEMENTATIONS` |
+| Feature configuration | Beacon2 extra | Per-u3a feature toggles (25 toggles across 7 sections — 6 master modules plus Membership and Other sub-feature groups) — new in Beacon2. All toggles are backend-enforced via `requireFeature()` middleware. Legacy Beacon restores apply the "Beacon Migration Default" Standard Implementation preset (all on except SiteWorks Integration and Custom Fields). Presets live in `shared/constants.js` as `STANDARD_IMPLEMENTATIONS` |
 
 ---
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -155,12 +155,12 @@ const router = createBrowserRouter([
       { path: '/preferences',         element: <ProtectedRoute><PersonalPreferences /></ProtectedRoute> },
       { path: '/public-links',        element: <ProtectedRoute><PublicLinks /></ProtectedRoute> },
 
-      // Reports — gated by reports:view/run privileges; editor and sql pages self-check isSiteAdmin
-      { path: '/reports',             element: <ProtectedRoute><ReportList /></ProtectedRoute> },
-      { path: '/reports/new',         element: <ProtectedRoute><ReportEditor /></ProtectedRoute> },
-      { path: '/reports/sql',         element: <ProtectedRoute><ReportSql /></ProtectedRoute> },
-      { path: '/reports/:id',         element: <ProtectedRoute><ReportRun /></ProtectedRoute> },
-      { path: '/reports/:id/edit',    element: <ProtectedRoute><ReportEditor /></ProtectedRoute> },
+      // Reports — gated by 'reports' feature + reports:view/run privileges; editor and sql pages self-check isSiteAdmin
+      { path: '/reports',             element: <ProtectedFeatureRoute feature="reports"><ReportList /></ProtectedFeatureRoute> },
+      { path: '/reports/new',         element: <ProtectedFeatureRoute feature="reports"><ReportEditor /></ProtectedFeatureRoute> },
+      { path: '/reports/sql',         element: <ProtectedFeatureRoute feature="reports"><ReportSql /></ProtectedFeatureRoute> },
+      { path: '/reports/:id',         element: <ProtectedFeatureRoute feature="reports"><ReportRun /></ProtectedFeatureRoute> },
+      { path: '/reports/:id/edit',    element: <ProtectedFeatureRoute feature="reports"><ReportEditor /></ProtectedFeatureRoute> },
 
       // Membership — always available (core), sub-features gated
       { path: '/members',             element: <ProtectedRoute><MemberList /></ProtectedRoute> },
@@ -175,8 +175,8 @@ const router = createBrowserRouter([
       { path: '/membership/renewals',     element: <ProtectedFeatureRoute feature="membershipRenewals"><MembershipRenewals /></ProtectedFeatureRoute> },
       { path: '/membership/non-renewals', element: <ProtectedFeatureRoute feature="membershipRenewals"><NonRenewals /></ProtectedFeatureRoute> },
       { path: '/membership/cards',        element: <ProtectedFeatureRoute feature="membershipCards"><MembershipCards /></ProtectedFeatureRoute> },
-      { path: '/members/statistics',      element: <ProtectedFeatureRoute feature="statistics"><MemberStatistics /></ProtectedFeatureRoute> },
-      { path: '/addresses-export',        element: <ProtectedFeatureRoute feature="addressesExport"><AddressesExport /></ProtectedFeatureRoute> },
+      { path: '/members/statistics',      element: <ProtectedRoute><MemberStatistics /></ProtectedRoute> },
+      { path: '/addresses-export',        element: <ProtectedRoute><AddressesExport /></ProtectedRoute> },
       { path: '/polls',                   element: <ProtectedFeatureRoute feature="polls"><PollList /></ProtectedFeatureRoute> },
       { path: '/custom-fields',           element: <ProtectedFeatureRoute feature="customFields"><CustomFields /></ProtectedFeatureRoute> },
       { path: '/gift-aid-log',            element: <ProtectedFeatureRoute feature="giftAid"><GiftAidLog /></ProtectedFeatureRoute> },
@@ -193,9 +193,9 @@ const router = createBrowserRouter([
       { path: '/venues/new',   element: <ProtectedFeatureRoute feature="venues"><VenueEditor /></ProtectedFeatureRoute> },
       { path: '/venues/:id',   element: <ProtectedFeatureRoute feature="venues"><VenueEditor /></ProtectedFeatureRoute> },
 
-      // Events & Calendar — gated by 'events' / sub-toggles
-      { path: '/calendar',                      element: <ProtectedFeatureRoute feature="calendar"><Calendar /></ProtectedFeatureRoute> },
-      { path: '/calendar/events/:eventId',      element: <ProtectedFeatureRoute feature="calendar"><EventRecord /></ProtectedFeatureRoute> },
+      // Events & Calendar — gated by 'events' master + sub-toggles
+      { path: '/calendar',                      element: <ProtectedFeatureRoute feature="events"><Calendar /></ProtectedFeatureRoute> },
+      { path: '/calendar/events/:eventId',      element: <ProtectedFeatureRoute feature="events"><EventRecord /></ProtectedFeatureRoute> },
       { path: '/calendar/open-meetings',        element: <Navigate to="/calendar?filter=other" replace /> },
       { path: '/event-types',            element: <ProtectedFeatureRoute feature="eventTypes"><EventTypeList /></ProtectedFeatureRoute> },
 
@@ -215,13 +215,14 @@ const router = createBrowserRouter([
       { path: '/finance/gift-aid',                   element: <ProtectedFeatureRoute feature="giftAid"><GiftAidDeclaration /></ProtectedFeatureRoute> },
       { path: '/finance/batches',                    element: <ProtectedFeatureRoute feature="creditBatches"><CreditBatches /></ProtectedFeatureRoute> },
 
-      // Email & Letters — gated by 'email' master toggle
+      // Email — gated by 'email' master toggle
       { path: '/email/compose',        element: <ProtectedFeatureRoute feature="email"><EmailCompose /></ProtectedFeatureRoute> },
       { path: '/email/delivery',       element: <ProtectedFeatureRoute feature="email"><EmailDelivery /></ProtectedFeatureRoute> },
       { path: '/email/delivery/:id',   element: <ProtectedFeatureRoute feature="email"><EmailDeliveryDetail /></ProtectedFeatureRoute> },
       { path: '/email/unblocker',      element: <ProtectedFeatureRoute feature="email"><EmailUnblocker /></ProtectedFeatureRoute> },
       { path: '/system-messages',      element: <ProtectedFeatureRoute feature="email"><SystemMessages /></ProtectedFeatureRoute> },
-      { path: '/letters/compose',      element: <ProtectedFeatureRoute feature="email"><LetterCompose /></ProtectedFeatureRoute> },
+      // Letters — PDF generation, does not require SendGrid
+      { path: '/letters/compose',      element: <ProtectedFeatureRoute feature="letters"><LetterCompose /></ProtectedFeatureRoute> },
 
       // Public pages (no auth required)
       { path: '/public/:slug/join',                     element: <JoinForm /> },

--- a/frontend/src/__tests__/MemberEditor.test.jsx
+++ b/frontend/src/__tests__/MemberEditor.test.jsx
@@ -13,6 +13,7 @@ vi.mock('../context/AuthContext.jsx', () => ({
   useAuth: () => ({
     tenant: 'test-u3a',
     can:    vi.fn().mockReturnValue(true),
+    hasFeature: vi.fn().mockReturnValue(true),
   }),
 }));
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -21,7 +21,7 @@ export default function Home() {
   }, []);
 
   // Lazy-load upcoming events only when the panel is expanded and user has privilege
-  const showUpcoming = hasFeature('calendar') && can('calendar', 'view');
+  const showUpcoming = hasFeature('events') && can('calendar', 'view');
   useEffect(() => {
     if (!showUpcoming || !upcomingExpanded || upcomingEvents !== null) return;
     const today = new Date().toISOString().slice(0, 10);
@@ -72,8 +72,8 @@ export default function Home() {
         { label: 'Recent members',      tip: 'View recently added or changed members', to: can('members_recent', 'view') ? '/members/recent' : null },
         { label: 'Non-renewals',        tip: 'View and lapse members who have not renewed', to: can('members_non_renewals', 'view') ? '/membership/non-renewals' : null, f: 'membershipRenewals' },
         { label: 'Membership cards',    tip: 'Generate and download membership cards', to: can('membership_cards', 'view') ? '/membership/cards' : null, f: 'membershipCards' },
-        { label: 'Addresses export',    tip: 'Export member addresses for labels or mail merge', to: can('addresses_export', 'view') ? '/addresses-export' : null, f: 'addressesExport' },
-        { label: 'Statistics',          tip: 'Membership counts and trends',        to: can('membership_statistics', 'view') ? '/members/statistics' : null, f: 'statistics' },
+        { label: 'Addresses export',    tip: 'Export member addresses for labels or mail merge', to: can('addresses_export', 'view') ? '/addresses-export' : null },
+        { label: 'Statistics',          tip: 'Membership counts and trends',        to: can('membership_statistics', 'view') ? '/members/statistics' : null },
       ],
     },
     {
@@ -83,7 +83,7 @@ export default function Home() {
         { label: 'Groups',    tip: 'View and manage interest groups',              to: can('groups_list',    'view') ? '/groups'    : null },
         { label: 'Venues',    tip: 'Manage venues where groups meet',              to: can('group_venues',   'view') ? '/venues'    : null, f: 'venues' },
         { label: 'Faculties', tip: 'Organise groups into subject categories',      to: can('group_faculties','view') ? '/faculties' : null, f: 'faculties' },
-        { label: 'Events',    tip: 'View group meetings and other events (calendar or table)', to: can('calendar', 'view') ? '/calendar' : null, f: 'calendar' },
+        { label: 'Events',    tip: 'View group meetings and other events (calendar or table)', to: can('calendar', 'view') ? '/calendar' : null, f: 'events' },
         { label: 'Teams',     tip: 'View and manage teams',                        to: can('groups_list',    'view') ? '/teams'     : null, f: 'teams' },
       ],
     },
@@ -114,7 +114,7 @@ export default function Home() {
         { label: 'E-mail unblocker',      tip: 'Remove members from the email block list',     to: can('email_delivery', 'all')  ? '/email/unblocker' : null, f: 'email' },
         { label: 'Personal preferences',  tip: 'Change your password, name display and timeout settings', to: '/preferences' },
         { label: 'Utilities',              tip: 'Administrative utilities',                                to: can('utilities', 'view') ? '/utilities' : null },
-        { label: 'SQL reports',            tip: 'Run saved SQL reports and ad-hoc queries',                to: can('reports', 'view') ? '/reports' : null },
+        { label: 'SQL reports',            tip: 'Run saved SQL reports and ad-hoc queries',                to: can('reports', 'view') ? '/reports' : null, f: 'reports' },
       ],
     },
     {
@@ -150,10 +150,10 @@ export default function Home() {
 
   // Public website links use the tenant slug — filtered by feature toggles
   const publicLinks = [
-    hasFeature('onlineJoining') && { label: `Join ${tenantName || 'us'} now!`, to: `/public/${tenant}/join` },
-    hasFeature('portal')        && { label: 'Members Portal', to: `/public/${tenant}/portal` },
-    hasFeature('groups')        && { label: 'Public groups list', to: `/public/${tenant}/groups` },
-    hasFeature('calendar')      && { label: 'Public calendar', to: `/public/${tenant}/calendar` },
+    hasFeature('onlineJoining')                              && { label: `Join ${tenantName || 'us'} now!`, to: `/public/${tenant}/join` },
+    hasFeature('portal')                                      && { label: 'Members Portal', to: `/public/${tenant}/portal` },
+    hasFeature('publicPages') && hasFeature('groups')         && { label: 'Public groups list', to: `/public/${tenant}/groups` },
+    hasFeature('publicPages') && hasFeature('events')         && { label: 'Public calendar', to: `/public/${tenant}/calendar` },
   ].filter(Boolean);
 
   return (

--- a/frontend/src/pages/members/MemberEditor.jsx
+++ b/frontend/src/pages/members/MemberEditor.jsx
@@ -66,8 +66,9 @@ function computeNextRenewal(joinedOnIso, config) {
 export default function MemberEditor() {
   const { id }    = useParams();
   const navigate  = useNavigate();
-  const { can, tenant } = useAuth();
+  const { can, tenant, hasFeature } = useAuth();
   const isNew     = !id || id === 'new';
+  const photosEnabled = hasFeature('memberPhotos');
 
   const [form,           setForm]           = useState(BLANK_FORM);
   const [statuses,       setStatuses]       = useState([]);
@@ -1052,6 +1053,7 @@ export default function MemberEditor() {
             )}
 
             {/* ── Member Photo ───────────────────────────────────────── */}
+            {photosEnabled && (
             <div className="mt-4">
               <label className={labelCls}>Member Photo</label>
               <div className="flex items-start gap-4">
@@ -1099,6 +1101,7 @@ export default function MemberEditor() {
                 </div>
               </div>
             </div>
+            )}
           </div>
 
           {/* ── iii) Address ─────────────────────────────────────────── */}

--- a/frontend/src/pages/members/MemberList.jsx
+++ b/frontend/src/pages/members/MemberList.jsx
@@ -41,7 +41,7 @@ import { ALL_PAYMENT_METHODS as PAYMENT_METHODS } from '../../lib/constants.js';
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 export default function MemberList() {
-  const { can, tenant } = useAuth();
+  const { can, tenant, hasFeature } = useAuth();
   const navigate = useNavigate();
 
   const [memberList,  setMemberList]  = useState([]);
@@ -566,8 +566,8 @@ export default function MemberList() {
                         className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                       >
                         <option value="">— choose action —</option>
-                        {can('email', 'send') && <option value="send_email">Send email</option>}
-                        {can('letters', 'view') && <option value="send_letter">Send letter</option>}
+                        {can('email', 'send') && hasFeature('email') && <option value="send_email">Send email</option>}
+                        {can('letters', 'view') && hasFeature('letters') && <option value="send_letter">Send letter</option>}
                         {hasBulkPolls && <option value="add_to_poll">Add to poll</option>}
                         {hasBulkGroups && <option value="add_to_group">Add to group</option>}
                         {hasBulkTeams && <option value="add_to_team">Add to team</option>}

--- a/frontend/src/pages/members/RecentMembers.jsx
+++ b/frontend/src/pages/members/RecentMembers.jsx
@@ -48,7 +48,7 @@ function fmtDate(d) {
 }
 
 export default function RecentMembers() {
-  const { can, tenant } = useAuth();
+  const { can, tenant, hasFeature } = useAuth();
   const navigate = useNavigate();
   const [list,       setList]       = useState([]);
   const [loading,    setLoading]    = useState(true);
@@ -357,8 +357,8 @@ export default function RecentMembers() {
                     >
                       <option value="">— choose action —</option>
                       <option value="download_names">Download names as txt file</option>
-                      {can('email', 'send') && <option value="send_email">Send E-mail</option>}
-                      {can('letters', 'view') && <option value="send_letter">Send Letter</option>}
+                      {can('email', 'send') && hasFeature('email') && <option value="send_email">Send E-mail</option>}
+                      {can('letters', 'view') && hasFeature('letters') && <option value="send_letter">Send Letter</option>}
                       {hasBulkPolls && <option value="add_to_poll">Add to poll</option>}
                       {hasBulkGroups && <option value="add_to_group">Add to group</option>}
                       <option value="download_excel">Download Excel</option>

--- a/frontend/src/pages/membership/MembershipRenewals.jsx
+++ b/frontend/src/pages/membership/MembershipRenewals.jsx
@@ -27,7 +27,7 @@ function fmtAmount(n) {
 }
 
 export default function MembershipRenewals() {
-  const { can, tenant } = useAuth();
+  const { can, tenant, hasFeature } = useAuth();
   const navigate = useNavigate();
 
   const [data,      setData]      = useState(null);   // { members, yearStart, prevYearStart, nextYearStart, showNextYear }
@@ -446,8 +446,8 @@ export default function MembershipRenewals() {
                     <label className="block text-sm font-medium text-slate-700 mb-1">Do with {selected.size} selected member{selected.size !== 1 ? 's' : ''}</label>
                     <select name="action" value={action} onChange={(e) => setAction(e.target.value)} className={SELECT}>
                       <option value="renew">Renew selected members</option>
-                      {can('email', 'send') && <option value="send_email">Send email</option>}
-                      {can('letters', 'view') && <option value="send_letter">Send letter</option>}
+                      {can('email', 'send') && hasFeature('email') && <option value="send_email">Send email</option>}
+                      {can('letters', 'view') && hasFeature('letters') && <option value="send_letter">Send letter</option>}
                       {can('poll_set_up', 'view') && <option value="add_to_poll">Add to poll</option>}
                     </select>
                   </div>

--- a/frontend/src/pages/membership/NonRenewals.jsx
+++ b/frontend/src/pages/membership/NonRenewals.jsx
@@ -21,7 +21,7 @@ function fmtDate(d) {
 }
 
 export default function NonRenewals() {
-  const { can } = useAuth();
+  const { can, hasFeature } = useAuth();
   const navigate = useNavigate();
 
   const [mode,         setMode]         = useState('this_year');
@@ -330,8 +330,8 @@ export default function NonRenewals() {
                     >
                       {mode === 'this_year' && canLapse && <option value="lapse">Lapse</option>}
                       {mode === 'long_term' && canLapse && <option value="delete">Delete</option>}
-                      {can('email', 'send') && <option value="send_email">Send email</option>}
-                      {can('letters', 'view') && <option value="send_letter">Send letter</option>}
+                      {can('email', 'send') && hasFeature('email') && <option value="send_email">Send email</option>}
+                      {can('letters', 'view') && hasFeature('letters') && <option value="send_letter">Send letter</option>}
                     </select>
                   </div>
                   <button

--- a/frontend/src/pages/settings/FeatureConfig.jsx
+++ b/frontend/src/pages/settings/FeatureConfig.jsx
@@ -22,11 +22,10 @@ const SECTIONS = [
     toggles: [
       { key: 'membershipCards',     label: 'Membership Cards',     defaultValue: true,  tip: 'Generate and download membership cards' },
       { key: 'membershipRenewals',  label: 'Membership Renewals',  defaultValue: true,  tip: 'Process annual renewals and non-renewals' },
-      { key: 'addressesExport',     label: 'Addresses Export',     defaultValue: true,  tip: 'Export member addresses for labels or mail merge' },
       { key: 'giftAid',            label: 'Gift Aid',             defaultValue: false, tip: 'Gift Aid declarations, logging, and transaction fields' },
       { key: 'customFields',       label: 'Custom Fields',        defaultValue: true,  tip: 'Up to 4 free-form fields on member records' },
       { key: 'polls',              label: 'Polls',                defaultValue: true,  tip: 'Member polls for filtering and bulk actions' },
-      { key: 'statistics',         label: 'Membership Statistics', defaultValue: true,  tip: 'Membership counts and trends' },
+      { key: 'memberPhotos',       label: 'Member Photos',        defaultValue: true,  tip: 'Photo upload on member records and portal; shown on cards and group PDFs' },
     ],
   },
   {
@@ -46,7 +45,6 @@ const SECTIONS = [
     description: 'Calendar views and non-group event types.',
     master: { key: 'events', label: 'Events & Calendar module', defaultValue: true, tip: 'Calendar page and event management' },
     toggles: [
-      { key: 'calendar',        label: 'Calendar',          defaultValue: true, dependsOn: 'events', tip: 'Calendar view of group meetings and events' },
       { key: 'eventTypes',      label: 'Event Types',       defaultValue: true, dependsOn: 'events', tip: 'Non-group event types (Open Meetings, etc.)' },
       { key: 'eventAttendance', label: 'Event Attendance',  defaultValue: true, dependsOn: 'events', tip: 'Track members registered for each event' },
     ],
@@ -65,9 +63,11 @@ const SECTIONS = [
   },
   {
     title: 'Email & Letters',
-    description: 'Email sending, delivery tracking, and letter generation. Requires SendGrid configuration.',
-    master: { key: 'email', label: 'Email & Letters module', defaultValue: true, sysAdminOnly: true, tip: 'Requires SendGrid setup by system administrator' },
-    toggles: [],
+    description: 'Email sending (requires SendGrid) and letter generation (PDF, no external service).',
+    master: { key: 'email', label: 'Email module', defaultValue: true, sysAdminOnly: true, tip: 'Requires SendGrid setup by system administrator' },
+    toggles: [
+      { key: 'letters', label: 'Letters', defaultValue: true, tip: 'Compose and download letters as PDF (does not require SendGrid)' },
+    ],
   },
   {
     title: 'Members Portal',
@@ -80,6 +80,15 @@ const SECTIONS = [
     description: 'Public online joining form for new members.',
     master: { key: 'onlineJoining', label: 'Online Joining', defaultValue: true, sysAdminOnly: true, tip: 'Requires PayPal setup by system administrator' },
     toggles: [],
+  },
+  {
+    title: 'Other',
+    description: 'Additional features that do not belong to a specific module.',
+    master: null,
+    toggles: [
+      { key: 'reports',     label: 'SQL Reports',  defaultValue: true, tip: 'Saved parameterised reports and ad-hoc SQL editor (read-only)' },
+      { key: 'publicPages', label: 'Public Pages', defaultValue: true, tip: 'Public Groups and Public Calendar pages visible without login' },
+    ],
   },
 ];
 

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -9,7 +9,7 @@
 export const FEATURE_DEPS = {
   teams: 'groups', venues: 'groups', faculties: 'groups',
   groupLedger: 'groups', siteworks: 'groups',
-  calendar: 'events', eventTypes: 'events',
+  eventTypes: 'events', eventAttendance: 'events',
   creditBatches: 'finance', reconciliation: 'finance',
   financialStatement: 'finance', groupsStatement: 'finance',
   transferMoney: 'finance',
@@ -33,15 +33,19 @@ export const ALL_FEATURE_KEYS = Object.freeze([
   // Masters
   'groups', 'finance', 'email', 'portal', 'onlineJoining', 'events',
   // Membership sub-features
-  'membershipCards', 'membershipRenewals', 'addressesExport',
-  'giftAid', 'customFields', 'polls', 'statistics',
+  'membershipCards', 'membershipRenewals',
+  'giftAid', 'customFields', 'polls', 'memberPhotos',
   // Groups sub-features
   'teams', 'venues', 'faculties', 'groupLedger', 'siteworks',
   // Events sub-features
-  'calendar', 'eventTypes', 'eventAttendance',
+  'eventTypes', 'eventAttendance',
   // Finance sub-features
   'creditBatches', 'reconciliation', 'financialStatement',
   'groupsStatement', 'transferMoney',
+  // Communications
+  'letters',
+  // Other
+  'reports', 'publicPages',
 ]);
 
 // ── Standard Beacon Implementations ─────────────────────────────────────


### PR DESCRIPTION
- Drop three low-value toggles that every u3a wants on anyway: statistics, addressesExport, and calendar (redundant with events master)
- Split letters out of the email master so u3as without SendGrid can still compose and print PDF letters
- Add three new toggles: reports (SQL Reports module), memberPhotos (photo upload on member records and portal), publicPages (public Groups and Calendar pages)
- Enforce every feature toggle on the backend via requireFeature() or isFeatureEnabled() for pre-auth public routes. Previously most toggles were nav-only; disabling one now returns 403 at the API.
- Add dedicated unit tests for requireFeature / isFeatureEnabled; route-level tests get a pass-through mock via setup.js.

Final toggle count: 25.