### PR TITLE
Fix KNOWN-ISSUES security items 1-4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 ## [Unreleased] — 2026-06-10
 
 ### Security
+- **`force-change-password` now requires `must_change_password`** —
+  `routes/auth.js` re-reads the flag before allowing the password +
+  security Q&A overwrite. Previously any authenticated user could
+  POST `/auth/force-change-password` and rewrite their own recovery
+  Q&A without supplying the current password. (KNOWN-ISSUES #1)
+- **Password changes now revoke other sessions** — both
+  `/auth/change-password` and `/auth/force-change-password` flip
+  `refresh_tokens.revoked = true` for the user and call
+  `invalidateUserSessions()`. Stolen refresh tokens can no longer
+  outlive the password change. The user's own access token continues
+  to work until it expires (matches admin password-change). Also
+  added an audit-log entry for `/change-password` (it had none).
+  (KNOWN-ISSUES #2)
+- **Portal login now locks accounts after repeated failures** —
+  `routes/public.js` mirrors the admin-login pattern using two new
+  columns on `members` (`portal_failed_login_count`,
+  `portal_locked_until`) and the existing `MAX_FAILED_LOGINS` /
+  `LOCKOUT_MINUTES` env vars (default 5 attempts / 15 min). Failures
+  and lockouts are written to the audit log. (KNOWN-ISSUES #3)
+- **Portal forgot-password email wired up** — `/portal/forgot-password`
+  now sends the reset link via SendGrid (mirroring the recovery-email
+  pattern in `auth.js`). When `SENDGRID_API_KEY` is unset it logs a
+  warning instead of the previous `console.log` of the plaintext
+  token, and still returns the generic "If an account exists…"
+  response so enumeration protection is preserved. (KNOWN-ISSUES #4)
 - **JoinPending open-redirect closed** — `pages/public/JoinPending.jsx`
   now gates `window.location.href = redirectUrl` with
   `isSafePaymentRedirect()`, matching the existing guards on

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -9,113 +9,98 @@ Items noted during development that need addressing in future sessions.
 Items identified during the chunk 1 + chunk 2 security sweep that were not
 fixed in the same session. See CHANGELOG 2026-06-10 for what was fixed.
 
-1. **`force-change-password` does not verify `must_change_password`**
-   (`backend/src/routes/auth.js:316`). Any authenticated user can change their
-   password without supplying the current one and overwrite their security
-   Q&A. Fix: gate on `must_change_password = true` and clear the flag in the
-   same UPDATE.
-2. **Password change does not revoke other sessions**
-   (`routes/auth.js` `/change-password`, `/force-change-password`). Compromised
-   sessions outlive a password change. Fix: revoke refresh tokens + call
-   `invalidateUserSessions()`.
-3. **Portal login has no per-account lockout** (`routes/public.js:859`).
-   Admin login has lockout; portal login does not. Add the same
-   `failed_login_count` + `locked_until` pattern to the `members` portal-
-   credential path.
-4. **Portal forgot-password emits the reset link to `console.log`**
-   (`routes/public.js:955`). Either the feature is incomplete or it's leaking
-   tokens via logs in production. Wire SendGrid or refuse when email is not
-   configured.
-5. **Account-enumeration via response timing on `/auth/recover`**
+1. **Account-enumeration via response timing on `/auth/recover`**
    (`routes/auth.js:248`). Send the email asynchronously or add a constant-
    time delay.
-6. **Inconsistent password policy** — `PATCH /users/:id` accepts `min(8)` with
+2. **Inconsistent password policy** — `PATCH /users/:id` accepts `min(8)` with
    no complexity rules, while `/force-change-password` and portal reset
    require `min(10)` + complexity. Centralise into a single helper.
-7. **Refresh-token reuse detection silently no-ops without Redis**
+3. **Refresh-token reuse detection silently no-ops without Redis**
    (`utils/redis.js:48`). Document this more prominently or persist
    invalidation marks in Postgres as a fallback.
-8. **`requireSysAdmin` skips invalidation / `active` check**
+4. **`requireSysAdmin` skips invalidation / `active` check**
    (`middleware/auth.js:47`). Sysadmin tokens stay valid for the full access-
    token lifetime regardless of account state.
-9. **Temp-password generator has modulo bias** (`routes/users.js:312`,
+5. **Temp-password generator has modulo bias** (`routes/users.js:312`,
    `routes/auth.js:346`). `b % 58` over 256-byte values is biased. Use
    rejection sampling or `crypto.randomInt`.
-10. **Origin check bypass when `NODE_ENV !== 'production'`**
-    (`routes/auth.js:38`). Mis-set `NODE_ENV` in staging would silently lose
-    CSRF protection on `/refresh`.
-11. **Privilege-string format collisions** — `${resource}:${action}` with
-    resources that may contain `:` (`finance:transactions:create`). Works
-    today, fragile if a future resource code includes `:create`.
-12. **No targeted rate limit on portal endpoints** (`app.js:69-71`). Only
-    the global 300/15min/IP `generalLimiter` covers `/public/:slug/portal/*`;
-    `/auth/*` has a tighter `authLimiter`. Add a 20/15min/IP limiter per
-    portal-register/login/forgot/reset/verify-email route.
-13. **Portal JWT skips Redis session-invalidation check**
-    (`routes/portal.js:22`). Disabling a member's portal credentials does
-    not take effect until the 15-min access token expires.
-14. **Verification & reset tokens logged via `console.log`**
-    (`routes/public.js:804`, `:955`; `routes/portal.js:699`). Either wire
-    SendGrid or refuse the request when email is not configured — don't
-    persist the token and emit it to stdout.
-15. **Slug regex inconsistency** — `routes/public.js:24` allows
+6. **Origin check bypass when `NODE_ENV !== 'production'`**
+   (`routes/auth.js:38`). Mis-set `NODE_ENV` in staging would silently lose
+   CSRF protection on `/refresh`.
+7. **Privilege-string format collisions** — `${resource}:${action}` with
+   resources that may contain `:` (`finance:transactions:create`). Works
+   today, fragile if a future resource code includes `:create`.
+8. **No targeted rate limit on portal endpoints** (`app.js:69-71`). Only
+   the global 300/15min/IP `generalLimiter` covers `/public/:slug/portal/*`;
+   `/auth/*` has a tighter `authLimiter`. Add a 20/15min/IP limiter per
+   portal-register/login/forgot/reset/verify-email route.
+9. **Portal JWT skips Redis session-invalidation check**
+   (`routes/portal.js:22`). Disabling a member's portal credentials does
+   not take effect until the 15-min access token expires.
+10. **Verification tokens still logged via `console.log`**
+    (`routes/public.js:804` portal register-verify, `routes/portal.js:699`
+    portal email-change verify). The forgot-password leak was fixed
+    2026-06-10; these two remain. Either wire SendGrid or refuse the
+    request when email is not configured — don't persist the token and
+    emit it to stdout.
+11. **Slug regex inconsistency** — `routes/public.js:24` allows
     `[a-z0-9_-]` but `utils/db.js:27` only allows `[a-z0-9_]`. A slug
     containing `-` 500s inside `tenantQuery` rather than 400-ing at the
     edge. Unify both regexes.
-16. **Photo upload doesn't validate magic bytes** —
+12. **Photo upload doesn't validate magic bytes** —
     `routes/portal.js:726`. Mime-type is whitelisted to jpeg/png/gif and
     Helmet's nosniff blocks browser sniffing, so no XSS — but mislabelled
     payloads silently succeed and may break PDF rendering downstream.
-17. **Portal login email-enumeration via differentiated responses** —
+13. **Portal login email-enumeration via differentiated responses** —
     `routes/public.js:887,891`. 401 for unknown/wrong-password but 403
     "Please verify your email" for known-unverified accounts reveals
     which emails have a portal account.
-18. **`/portal/forgot-password` timing enumeration** —
+14. **`/portal/forgot-password` timing enumeration** —
     `routes/public.js:922`. Bcrypt + DB write happen only on hit;
     response time leaks account existence.
-19. **No magic-byte validation on photo uploads**
+15. **No magic-byte validation on photo uploads**
     (`routes/members.js:1494`, `routes/portal.js:726`). Mime-type is
     whitelisted; nosniff blocks browser XSS. But mislabelled payloads
     silently succeed and break PDF rendering downstream — DoS vector.
-20. **Email-attachment `originalname` passed through unsanitised**
+16. **Email-attachment `originalname` passed through unsanitised**
     (`routes/email.js:267`). Recipients can be sent files with
     attacker-crafted names (`Invoice.pdf .exe`, control-char headers).
     Sanitise to a basename, strip control chars, cap length.
-21. **`clearTenantData()` doesn't purge Redis invalidation marks**
+17. **`clearTenantData()` doesn't purge Redis invalidation marks**
     (`routes/backup.js:658`). After restore, stale `invalidated:slug:userId`
     keys (31-day TTL) may make fresh sessions appear pre-revoked.
-22. **Multer accepts any MIME type on `/system/restore` and `/email/send`**
+18. **Multer accepts any MIME type on `/system/restore` and `/email/send`**
     (`routes/system.js:201`, `routes/email.js:16`). FileSize caps the
     only bound; per-request /email/send worst case ≈ 400 MB in memory.
-23. **`/email/send` `fromEmail` field is declared but ignored** —
+19. **`/email/send` `fromEmail` field is declared but ignored** —
     `routes/email.js:205,293`. The SendGrid message hard-codes
     `FROM_ADDRESS`. Either wire it up with an allow-list, or drop the
     field from the schema.
-24. **`/email/send` `replyTo` is unconstrained** — anyone with
+20. **`/email/send` `replyTo` is unconstrained** — anyone with
     `email:send` can set it to any address (e.g. impersonating an
     officer). Limit to the user's own member-email + offices they hold
     (the same source as `/email/from-addresses`).
-25. **`/email/delivery/:batchId/refresh` issues one SendGrid API call
+21. **`/email/delivery/:batchId/refresh` issues one SendGrid API call
     per recipient** — `routes/email.js:433`. Cap the per-click amplification.
-26. **Hard-coded `FROM_ADDRESS = 'noreply@u3abeacon.org.uk'`** —
+22. **Hard-coded `FROM_ADDRESS = 'noreply@u3abeacon.org.uk'`** —
     `routes/email.js:23`. Make env-configurable so deployments under
     other domains don't fail SPF/DKIM silently.
-27. **`routes/public.js` and `routes/portal.js` `resolveTokens` callers
+23. **`routes/public.js` and `routes/portal.js` `resolveTokens` callers
     still use `body` for templated emails** — currently only `console.log`'d
     so latent, but when SendGrid is wired they should also use the new
     `bodyHtml` for the html field.
-28. **`uuid<11.1.1` buffer-bounds advisory remains** — backend `npm audit`
+24. **`uuid<11.1.1` buffer-bounds advisory remains** — backend `npm audit`
     shows 2 moderate findings against the `uuid` package (direct +
     transitive via `exceljs`). The advisory only affects v3/v5/v6 when a
     `buf` argument is passed. Beacon2 imports only `v4` and never passes
     a buffer, so the runtime is unaffected. Major bump (`uuid@14`) is a
     breaking change for `exceljs` and should wait for an upstream release.
-29. **Frontend CSP shipped in report-only mode** — after a deploy window
+25. **Frontend CSP shipped in report-only mode** — after a deploy window
     of clean reports, change `Content-Security-Policy-Report-Only` to
     `Content-Security-Policy` in `frontend/vercel.json` to enforce.
     Consider tightening `connect-src 'self' https:` to the concrete
     backend host once known.
-30. **Stale comment in `App.jsx:132`** — "auth handled inside pages via
+26. **Stale comment in `App.jsx:132`** — "auth handled inside pages via
     sessionStorage" no longer reflects the in-memory sys-token model.
     Tidy when next touching the file.
 

--- a/backend/prisma/tenant_schema.sql
+++ b/backend/prisma/tenant_schema.sql
@@ -738,6 +738,8 @@ ALTER TABLE :schema.members ADD COLUMN IF NOT EXISTS portal_verification_token T
 ALTER TABLE :schema.members ADD COLUMN IF NOT EXISTS portal_verification_expires TIMESTAMPTZ;
 ALTER TABLE :schema.members ADD COLUMN IF NOT EXISTS portal_reset_token TEXT;
 ALTER TABLE :schema.members ADD COLUMN IF NOT EXISTS portal_reset_expires TIMESTAMPTZ;
+ALTER TABLE :schema.members ADD COLUMN IF NOT EXISTS portal_failed_login_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE :schema.members ADD COLUMN IF NOT EXISTS portal_locked_until TIMESTAMPTZ;
 
 CREATE INDEX IF NOT EXISTS :schema_idx_members_portal_email ON :schema.members (portal_email) WHERE portal_email IS NOT NULL;
 

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
-import { makeAuthHeader, TEST_TENANT } from './helpers.js';
+import { makeAuthHeader, TEST_TENANT, TEST_USER_ID } from './helpers.js';
 
 // ── Module mocks (hoisted before imports by vitest) ───────────────────────
 
@@ -18,6 +18,13 @@ vi.mock('../utils/redis.js', () => ({
   invalidateUserSessions: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../utils/password.js', () => ({
+  hashPassword:   vi.fn().mockResolvedValue('$hashed$'),
+  verifyPassword: vi.fn().mockResolvedValue(true),
+  generateToken:  vi.fn(() => 'opaque-token'),
+  hashOpaqueToken: vi.fn((t) => `hashed:${t}`),
+}));
+
 vi.mock('../services/authService.js', () => ({
   loginUser:     vi.fn(),
   logoutUser:    vi.fn().mockResolvedValue(undefined),
@@ -28,6 +35,8 @@ vi.mock('../services/authService.js', () => ({
 const { default: app } = await import('../app.js');
 const { loginUser, logoutUser, refreshTokens, loginSysAdmin } =
   await import('../services/authService.js');
+const { tenantQuery } = await import('../utils/db.js');
+const { invalidateUserSessions } = await import('../utils/redis.js');
 
 // ── POST /auth/login ──────────────────────────────────────────────────────
 
@@ -185,5 +194,107 @@ describe('POST /auth/system/login', () => {
       .send({ email: 'admin@beacon2.local' });
 
     expect(res.status).toBe(422);
+  });
+});
+
+// ── POST /auth/change-password ────────────────────────────────────────────
+
+describe('POST /auth/change-password', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const validBody = { currentPassword: 'oldpass', newPassword: 'NewPass99X!' };
+
+  it('revokes refresh tokens and invalidates sessions on success', async () => {
+    // 1: SELECT user → returns the user row
+    tenantQuery.mockResolvedValueOnce([{ id: TEST_USER_ID, password_hash: '$old$' }]);
+    // 2: UPDATE password — no rows needed
+    tenantQuery.mockResolvedValueOnce([]);
+    // 3: UPDATE refresh_tokens
+    tenantQuery.mockResolvedValueOnce([]);
+    // 4: audit log INSERT (best-effort)
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .post('/auth/change-password')
+      .set('Authorization', makeAuthHeader())
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+
+    const sqlCalls = tenantQuery.mock.calls.map((c) => c[1]);
+    expect(sqlCalls.some((s) => /UPDATE refresh_tokens SET revoked = true/.test(s))).toBe(true);
+    expect(invalidateUserSessions).toHaveBeenCalledWith(TEST_TENANT, TEST_USER_ID);
+  });
+
+  it('returns 400 when the current password is wrong', async () => {
+    const { verifyPassword } = await import('../utils/password.js');
+    verifyPassword.mockResolvedValueOnce(false);
+    tenantQuery.mockResolvedValueOnce([{ id: TEST_USER_ID, password_hash: '$old$' }]);
+
+    const res = await request(app)
+      .post('/auth/change-password')
+      .set('Authorization', makeAuthHeader())
+      .send(validBody);
+
+    expect(res.status).toBe(400);
+    expect(invalidateUserSessions).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST /auth/force-change-password ──────────────────────────────────────
+
+describe('POST /auth/force-change-password', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const validBody = {
+    newPassword: 'NewPass99X!',
+    question:    'Favourite colour?',
+    answer:      'Blue',
+  };
+
+  it('returns 403 when must_change_password is false', async () => {
+    tenantQuery.mockResolvedValueOnce([{ must_change_password: false }]);
+
+    const res = await request(app)
+      .post('/auth/force-change-password')
+      .set('Authorization', makeAuthHeader())
+      .send(validBody);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Password change not required.');
+    expect(invalidateUserSessions).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the user row is missing', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .post('/auth/force-change-password')
+      .set('Authorization', makeAuthHeader())
+      .send(validBody);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('updates password and revokes sessions when must_change_password is true', async () => {
+    // 1: SELECT must_change_password
+    tenantQuery.mockResolvedValueOnce([{ must_change_password: true }]);
+    // 2: UPDATE users
+    tenantQuery.mockResolvedValueOnce([]);
+    // 3: UPDATE refresh_tokens
+    tenantQuery.mockResolvedValueOnce([]);
+    // 4: audit
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .post('/auth/force-change-password')
+      .set('Authorization', makeAuthHeader())
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    const sqlCalls = tenantQuery.mock.calls.map((c) => c[1]);
+    expect(sqlCalls.some((s) => /UPDATE users SET password_hash = \$1, must_change_password = false/.test(s))).toBe(true);
+    expect(sqlCalls.some((s) => /UPDATE refresh_tokens SET revoked = true/.test(s))).toBe(true);
+    expect(invalidateUserSessions).toHaveBeenCalledWith(TEST_TENANT, TEST_USER_ID);
   });
 });

--- a/backend/src/__tests__/portalAuth.test.js
+++ b/backend/src/__tests__/portalAuth.test.js
@@ -1,0 +1,192 @@
+// beacon2/backend/src/__tests__/portalAuth.test.js
+// Tests for portal login lockout (KNOWN-ISSUES #3) and portal
+// forgot-password email wiring (KNOWN-ISSUES #4).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('../utils/db.js', () => ({
+  prisma:      { sysTenant: { findUnique: vi.fn() } },
+  tenantQuery: vi.fn(),
+  withTenant:  vi.fn(),
+}));
+
+vi.mock('../utils/redis.js', () => ({
+  isSessionInvalidated:   vi.fn().mockResolvedValue(false),
+  invalidateUserSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/password.js', () => ({
+  hashPassword:    vi.fn().mockResolvedValue('$hashed$'),
+  verifyPassword:  vi.fn(),
+  generateToken:   vi.fn(() => 'opaque-reset-token'),
+  hashOpaqueToken: vi.fn((t) => `hashed:${t}`),
+}));
+
+const sgSend = vi.fn().mockResolvedValue(undefined);
+vi.mock('@sendgrid/mail', () => ({
+  default: { setApiKey: vi.fn(), send: sgSend },
+}));
+
+const { default: app } = await import('../app.js');
+const { tenantQuery, prisma } = await import('../utils/db.js');
+const { verifyPassword } = await import('../utils/password.js');
+
+const TENANT = 'test-u3a';
+
+function mockTenantExists() {
+  prisma.sysTenant.findUnique.mockResolvedValue({ slug: TENANT, active: true, name: 'Test u3a' });
+}
+
+// ── POST /:slug/portal/login — lockout ───────────────────────────────────
+
+describe('POST /public/:slug/portal/login lockout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTenantExists();
+  });
+
+  it('returns 401 generic error when account is currently locked', async () => {
+    const future = new Date(Date.now() + 5 * 60_000);
+    tenantQuery.mockResolvedValueOnce([{
+      id: 'm1', membership_number: '101', forenames: 'A', surname: 'B', email: 'a@b.com',
+      portal_password_hash: '$hash$', portal_email_verified: true,
+      portal_failed_login_count: 0, portal_locked_until: future,
+    }]);
+
+    const res = await request(app)
+      .post(`/public/${TENANT}/portal/login`)
+      .send({ email: 'a@b.com', password: 'whatever' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid email or password.');
+    // Lock check must short-circuit before bcrypt
+    expect(verifyPassword).not.toHaveBeenCalled();
+  });
+
+  it('increments portal_failed_login_count on a bad password', async () => {
+    tenantQuery.mockResolvedValueOnce([{
+      id: 'm1', membership_number: '101', forenames: 'A', surname: 'B', email: 'a@b.com',
+      portal_password_hash: '$hash$', portal_email_verified: true,
+      portal_failed_login_count: 1, portal_locked_until: null,
+    }]);
+    verifyPassword.mockResolvedValueOnce(false);
+    // UPDATE for failure bookkeeping
+    tenantQuery.mockResolvedValueOnce([]);
+    // audit insert
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .post(`/public/${TENANT}/portal/login`)
+      .send({ email: 'a@b.com', password: 'wrong' });
+
+    expect(res.status).toBe(401);
+    const update = tenantQuery.mock.calls.find(
+      (c) => /UPDATE members SET portal_failed_login_count/.test(c[1]),
+    );
+    expect(update).toBeDefined();
+    // count of 1 → 2, not locked
+    expect(update[2]).toEqual([2, null, 'm1']);
+  });
+
+  it('locks the account on the Nth failed attempt', async () => {
+    tenantQuery.mockResolvedValueOnce([{
+      id: 'm1', membership_number: '101', forenames: 'A', surname: 'B', email: 'a@b.com',
+      portal_password_hash: '$hash$', portal_email_verified: true,
+      portal_failed_login_count: 4, portal_locked_until: null,
+    }]);
+    verifyPassword.mockResolvedValueOnce(false);
+    tenantQuery.mockResolvedValueOnce([]);
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .post(`/public/${TENANT}/portal/login`)
+      .send({ email: 'a@b.com', password: 'wrong' });
+
+    expect(res.status).toBe(401);
+    const update = tenantQuery.mock.calls.find(
+      (c) => /UPDATE members SET portal_failed_login_count/.test(c[1]),
+    );
+    expect(update[2][0]).toBe(0);          // count reset on lock
+    expect(update[2][1]).toBeInstanceOf(Date);  // locked_until set
+    expect(update[2][1].getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('resets counter on successful login', async () => {
+    tenantQuery.mockResolvedValueOnce([{
+      id: 'm1', membership_number: '101', forenames: 'A', surname: 'B', email: 'a@b.com',
+      portal_password_hash: '$hash$', portal_email_verified: true,
+      portal_failed_login_count: 3, portal_locked_until: null,
+    }]);
+    verifyPassword.mockResolvedValueOnce(true);
+    // UPDATE counter reset
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .post(`/public/${TENANT}/portal/login`)
+      .send({ email: 'a@b.com', password: 'right' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+    const reset = tenantQuery.mock.calls.find(
+      (c) => /portal_failed_login_count = 0, portal_locked_until = NULL/.test(c[1]),
+    );
+    expect(reset).toBeDefined();
+    expect(reset[2]).toEqual(['m1']);
+  });
+});
+
+// ── POST /:slug/portal/forgot-password — email wiring ───────────────────
+
+describe('POST /public/:slug/portal/forgot-password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTenantExists();
+    delete process.env.SENDGRID_API_KEY;
+  });
+
+  it('no longer leaks the reset link to console.log', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'm1', forenames: 'A', surname: 'B' }]);
+    tenantQuery.mockResolvedValueOnce([]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await request(app)
+      .post(`/public/${TENANT}/portal/forgot-password`)
+      .send({ email: 'a@b.com' });
+
+    for (const call of logSpy.mock.calls) {
+      const line = call.join(' ');
+      expect(line).not.toContain('opaque-reset-token');
+      expect(line).not.toContain('reset-password');
+    }
+    logSpy.mockRestore();
+  });
+
+  it('warns when SENDGRID_API_KEY is unset but still returns the generic success', async () => {
+    tenantQuery.mockResolvedValueOnce([{ id: 'm1', forenames: 'A', surname: 'B' }]);
+    tenantQuery.mockResolvedValueOnce([]);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const res = await request(app)
+      .post(`/public/${TENANT}/portal/forgot-password`)
+      .send({ email: 'a@b.com' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/If an account exists/);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(sgSend).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('returns the generic success when no member matches (no enumeration)', async () => {
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .post(`/public/${TENANT}/portal/forgot-password`)
+      .send({ email: 'nobody@b.com' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/If an account exists/);
+    expect(sgSend).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -9,6 +9,7 @@ import { loginUser, logoutUser, refreshTokens, loginSysAdmin } from '../services
 import { requireAuth } from '../middleware/auth.js';
 import { tenantQuery, prisma } from '../utils/db.js';
 import { verifyPassword, hashPassword } from '../utils/password.js';
+import { invalidateUserSessions } from '../utils/redis.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logAudit } from '../utils/audit.js';
 
@@ -161,6 +162,15 @@ router.post('/change-password', requireAuth, async (req, res, next) => {
 
     const newHash = await hashPassword(newPassword);
     await tenantQuery(slug, `UPDATE users SET password_hash = $1, updated_at = now() WHERE id = $2`, [newHash, user.id]);
+
+    // Revoke all other refresh tokens for this user and mark sessions
+    // invalidated in Redis so any access tokens still in flight stop working
+    // at their next request. The caller's current access token continues to
+    // work until it expires (matches admin password-change behaviour).
+    await tenantQuery(slug, `UPDATE refresh_tokens SET revoked = true WHERE user_id = $1`, [user.id]);
+    await invalidateUserSessions(slug, user.id);
+
+    logAudit(slug, { userId: req.user.userId, userName: req.user.name, action: 'change_password', entityType: 'user', entityId: user.id, entityName: req.user.name });
     res.json({ message: 'Password changed.' });
   } catch (err) { next(err); }
 });
@@ -324,6 +334,20 @@ router.post('/force-change-password', requireAuth, async (req, res, next) => {
     if (!/[0-9]/.test(newPassword)) throw AppError('Password must include at least one number.', 400);
 
     const slug = req.user.tenantSlug;
+
+    // Gate: this route bypasses the current-password check and overwrites
+    // the security Q&A, so only allow it when the flag is actually set.
+    // Without this guard any authenticated user can rewrite their own
+    // recovery question + answer at will.
+    const [current] = await tenantQuery(
+      slug,
+      `SELECT must_change_password FROM users WHERE id = $1`,
+      [req.user.userId],
+    );
+    if (!current || !current.must_change_password) {
+      throw AppError('Password change not required.', 403);
+    }
+
     const newHash = await hashPassword(newPassword);
     const answerHash = await hashPassword(answer);
 
@@ -334,6 +358,9 @@ router.post('/force-change-password', requireAuth, async (req, res, next) => {
        WHERE id = $4`,
       [newHash, question, answerHash, req.user.userId],
     );
+
+    await tenantQuery(slug, `UPDATE refresh_tokens SET revoked = true WHERE user_id = $1`, [req.user.userId]);
+    await invalidateUserSessions(slug, req.user.userId);
 
     logAudit(slug, { userId: req.user.userId, userName: req.user.name, action: 'force_change_password', entityType: 'user', entityId: req.user.userId, entityName: req.user.name });
     res.json({ message: 'Password changed successfully.' });

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -5,6 +5,7 @@
 import { Router } from 'express';
 import { randomBytes } from 'crypto';
 import { z } from 'zod';
+import sgMail from '@sendgrid/mail';
 import { prisma, tenantQuery, withTenant } from '../utils/db.js';
 import { hashPassword, verifyPassword, generateToken, hashOpaqueToken } from '../utils/password.js';
 import { signAccessToken } from '../utils/jwt.js';
@@ -16,6 +17,45 @@ import { logAudit } from '../utils/audit.js';
 import portalRoutes from './portal.js';
 
 const router = Router();
+
+if (process.env.SENDGRID_API_KEY) {
+  sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+}
+
+const PORTAL_FROM = process.env.RECOVERY_FROM_ADDRESS ?? 'noreply@u3abeacon.org.uk';
+
+// Portal-login lockout — reuses the admin login env vars so operators have a
+// single knob. Mirrors registerFailedLogin() in services/authService.js.
+const MAX_FAILED_LOGINS = parseInt(process.env.MAX_FAILED_LOGINS ?? '5', 10);
+const LOCKOUT_MINUTES   = parseInt(process.env.LOCKOUT_MINUTES   ?? '15', 10);
+
+async function registerPortalFailedLogin(slug, members, attemptedEmail) {
+  for (const m of members) {
+    const newCount = (m.portal_failed_login_count ?? 0) + 1;
+    const willLock = newCount >= MAX_FAILED_LOGINS;
+    const lockedUntil = willLock
+      ? new Date(Date.now() + LOCKOUT_MINUTES * 60_000)
+      : null;
+
+    await tenantQuery(
+      slug,
+      `UPDATE members SET portal_failed_login_count = $1, portal_locked_until = $2 WHERE id = $3`,
+      [willLock ? 0 : newCount, lockedUntil, m.id],
+    );
+
+    await logAudit(slug, {
+      userId:     null,
+      userName:   `${m.forenames} ${m.surname}`,
+      action:     willLock ? 'portal_login_locked' : 'portal_login_failed',
+      entityType: 'member',
+      entityId:   m.id,
+      entityName: `${m.forenames} ${m.surname}`,
+      detail:     willLock
+        ? `Portal account locked for ${LOCKOUT_MINUTES} min after ${MAX_FAILED_LOGINS} failed attempts (email ${attemptedEmail})`
+        : `Failed portal attempt ${newCount}/${MAX_FAILED_LOGINS} (email ${attemptedEmail})`,
+    });
+  }
+}
 
 // ─── Middleware: resolve tenant from slug ────────────────────────────────
 
@@ -881,13 +921,26 @@ router.post('/:slug/portal/login', async (req, res, next) => {
     const members = await tenantQuery(
       slug,
       `SELECT m.id, m.membership_number, m.forenames, m.surname, m.email,
-              m.portal_password_hash, m.portal_email_verified
+              m.portal_password_hash, m.portal_email_verified,
+              m.portal_failed_login_count, m.portal_locked_until
        FROM members m
        WHERE m.portal_email = $1 AND m.portal_password_hash IS NOT NULL`,
       [data.email.toLowerCase()],
     );
 
     if (members.length === 0) {
+      return res.status(401).json({ error: 'Invalid email or password.' });
+    }
+
+    // If any member behind this email is currently locked, refuse the
+    // attempt without recording another failure (otherwise hammering during
+    // a lock window would extend it indefinitely). Same generic message as
+    // a wrong-password response — never reveal the lock to the attacker.
+    const now = new Date();
+    const anyLocked = members.some(
+      (m) => m.portal_locked_until && new Date(m.portal_locked_until) > now,
+    );
+    if (anyLocked) {
       return res.status(401).json({ error: 'Invalid email or password.' });
     }
 
@@ -902,11 +955,22 @@ router.post('/:slug/portal/login', async (req, res, next) => {
     }
 
     if (!authenticatedMember) {
+      await registerPortalFailedLogin(slug, members, data.email.toLowerCase());
       return res.status(401).json({ error: 'Invalid email or password.' });
     }
 
     if (!authenticatedMember.portal_email_verified) {
       return res.status(403).json({ error: 'Please verify your email address before signing in.' });
+    }
+
+    // Successful login — clear any failure counter / lockout window on the
+    // winning member row.
+    if (authenticatedMember.portal_failed_login_count > 0 || authenticatedMember.portal_locked_until) {
+      await tenantQuery(
+        slug,
+        `UPDATE members SET portal_failed_login_count = 0, portal_locked_until = NULL WHERE id = $1`,
+        [authenticatedMember.id],
+      );
     }
 
     // Issue a portal JWT (different from admin JWT)
@@ -971,13 +1035,50 @@ router.post('/:slug/portal/forgot-password', async (req, res, next) => {
 
     const frontendBase = process.env.CORS_ORIGIN || 'http://localhost:5173';
     const resetLink = `${frontendBase}/public/${slug}/portal/reset-password?token=${resetToken}`;
-    console.log(`[Portal] Would send password reset email to ${email}: ${resetLink}`);
+
+    await sendPortalResetEmail(email.toLowerCase(), resetLink);
 
     res.json({ message: 'If an account exists with that email, a reset link has been sent.' });
   } catch (err) {
     next(err);
   }
 });
+
+/** Send the portal password-reset email. Mirrors sendRecoveryEmail() in
+ *  auth.js — if SendGrid is not configured we log a warning (without the
+ *  token) and return silently so the caller still gets the generic
+ *  "If an account exists…" response. A SendGrid failure is logged but
+ *  also swallowed to keep enumeration protection intact. */
+async function sendPortalResetEmail(toEmail, resetLink) {
+  const subject = 'Reset your Members Portal password';
+  const body = `A password reset was requested for your Members Portal account.
+
+Use the link below to choose a new password. The link expires in one hour.
+
+${resetLink}
+
+If you did not request this, you can ignore this email.`;
+
+  if (!process.env.SENDGRID_API_KEY) {
+    console.warn(
+      `[Portal] SendGrid not configured — cannot deliver password reset email to ${toEmail}. ` +
+      `Set SENDGRID_API_KEY to enable portal reset emails.`,
+    );
+    return;
+  }
+
+  try {
+    await sgMail.send({
+      to: toEmail,
+      from: PORTAL_FROM,
+      subject,
+      text: body,
+    });
+  } catch (err) {
+    // Never include the reset link in the error log.
+    console.error(`[Portal] Failed to send password reset email to ${toEmail}:`, err.message);
+  }
+}
 
 // ─── POST /:slug/portal/reset-password ──────────────────────────────────
 


### PR DESCRIPTION
- Gate /auth/force-change-password on must_change_password=true so an authenticated user can't rewrite their own security Q&A on demand.
- Revoke refresh tokens + invalidate Redis sessions in both /auth/change-password and /auth/force-change-password; add audit log entry to /change-password.
- Add per-account portal-login lockout mirroring the admin pattern (new members.portal_failed_login_count + portal_locked_until columns; reuses MAX_FAILED_LOGINS / LOCKOUT_MINUTES env vars).
- Wire SendGrid into /portal/forgot-password and remove the console.log of the plaintext reset link. Mirrors auth.js sendRecoveryEmail: warns when SENDGRID_API_KEY is unset while still returning the generic enumeration-safe response.

Tests: new tests in auth.test.js cover the must_change_password gate and session revocation; new portalAuth.test.js covers lockout increment, lock-on-threshold, counter reset on success, locked-account rejection, and forgot-password no-log + warn-on-missing-SendGrid.