### PR TITLE
Chunk 4: security hardening for auth & enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 ## [Unreleased] — 2026-06-12
 
 ### Added
+- **Shared password policy & temp-password generator (ImprovementPlan Chunk 4)** —
+  new `backend/src/utils/passwordPolicy.js` exports `passwordSchema` (10–72
+  chars, at least one upper, lower, and digit) and a `crypto.randomInt`-based
+  `generateTempPassword()`. The schema is now the single source of truth for
+  `PATCH /users`, `POST /system/tenants`, `/auth/change-password`,
+  `/auth/force-change-password`, and all portal register/reset/change flows.
+- **Targeted portal-auth rate limiter (ImprovementPlan Chunk 4, finding S11)** —
+  a dedicated 20/15 min/IP limiter (env `PORTAL_AUTH_RATE_LIMIT_MAX`) now guards
+  the portal register, login, forgot-password, reset-password, and verify-email
+  endpoints, in addition to the global limiter.
+
 - **Linting & formatting baseline (ImprovementPlan Chunk 3, findings T1/T2)** —
   added ESLint 9 (flat config) and Prettier to both `backend/` and
   `frontend/`. The frontend config uses `eslint-plugin-react` plus the
@@ -37,6 +48,30 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
   tooling/lint-fix changes. No logic changes.
 
 ### Fixed
+- **Security: auth & enumeration hardening (ImprovementPlan Chunk 4,
+  findings S2–S8, S11, S12)** —
+  - **Temp-password modulo bias (S2)** — replaced biased `byte % length`
+    selection with `crypto.randomInt` in the shared generator.
+  - **Inconsistent password policy (S4)** — unified behind `passwordSchema`
+    (see Added); `PATCH /users` no longer accepts weak 8-char passwords.
+  - **Sys-admin state check (S7)** — `requireSysAdmin` now re-loads the
+    sys-admin each request and rejects (401) if the account is missing or
+    inactive, instead of trusting the token for its full lifetime.
+  - **Portal session invalidation (S3)** — `requirePortalAuth` honours the
+    Redis invalidation marker; portal password change/reset now set it.
+  - **Account-enumeration (S5)** — `/auth/recover` and
+    `/portal/forgot-password` send their emails fire-and-forget so response
+    time no longer leaks account existence; portal login runs a throwaway
+    bcrypt comparison for unknown emails to equalise timing.
+  - **Verification tokens no longer logged (S6)** — portal register and
+    email-change email the verification link via SendGrid (or log a token-free
+    warning when SendGrid is unset) rather than printing it to stdout.
+  - **Slug regex unified (S8)** — the public `resolveTenant` guard now matches
+    `utils/db.js` (`[a-z0-9_]+`), so a hyphenated slug returns 400 at the edge
+    instead of 500 inside `tenantQuery`.
+  - **CSRF origin check (S12)** — `/auth/refresh` gates the Origin check on
+    `CORS_ORIGIN` being set rather than on `NODE_ENV`, so a mis-set `NODE_ENV`
+    can no longer silently disable it.
 - **ESLint violations cleared (ImprovementPlan Chunk 3)** — removed unused
   imports and variables and dropped dead destructured bindings across 27
   backend and ~25 frontend files (e.g. unused `useNavigate`/`Link` imports,

--- a/CLAUDE-STANDARDS.md
+++ b/CLAUDE-STANDARDS.md
@@ -56,6 +56,15 @@ Every item below applies to every new feature — no exceptions.
   follow their own rules; this rule is specifically for
   random-bytes-hex tokens looked up by equality.
 
+- [ ] **Any user-chosen password is validated with `passwordSchema`** from
+  `backend/src/utils/passwordPolicy.js` (10–72 chars, upper+lower+digit).
+  Never re-declare an ad-hoc `min(8)`/`min(10)` password rule on a route —
+  import the shared schema so every flow enforces the same policy. Generate
+  temporary passwords with `generateTempPassword()` from the same module
+  (uses `crypto.randomInt`, no modulo bias). This module is deliberately
+  separate from `password.js` because several test files mock the latter
+  wholesale.
+
 - [ ] **Role grant/revoke routes call `assertActorHoldsRolePrivileges`**
   in `backend/src/routes/users.js`. Any new endpoint that mutates
   `user_roles` (assign, remove, bulk-update) must run the

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -7,6 +7,8 @@ Items noted during development that need addressing in future sessions.
 - `[OPEN]` — a genuine issue to fix when convenient.
 - `[ACCEPTED]` — understood and deliberately not changing (rationale given).
 - `[DEFERRED]` — worth doing but parked for a later phase / dependency.
+- `[FIXED]` — resolved; kept here (not deleted) so the numbered cross-references
+  from `docs/ImprovementPlan.md` stay stable. See CHANGELOG for the date.
 
 **Related documents:** the consolidated, chunked work plan is
 [`docs/ImprovementPlan.md`](docs/ImprovementPlan.md); pure code-rationalisation
@@ -21,55 +23,66 @@ Items identified during the chunk 1 + chunk 2 security sweep that were not
 fixed in the same session. See CHANGELOG 2026-06-10 for what was fixed.
 These are catalogued and re-verified in `docs/ImprovementPlan.md` (Chunks 4–5).
 
-1. `[OPEN]` **Account-enumeration via response timing on `/auth/recover`**
-   (`routes/auth.js:248`). Send the email asynchronously or add a constant-
-   time delay.
-2. `[OPEN]` **Inconsistent password policy** — `PATCH /users/:id` accepts `min(8)` with
-   no complexity rules, while `/force-change-password` and portal reset
-   require `min(10)` + complexity. Centralise into a single helper.
+1. `[FIXED]` **Account-enumeration via response timing on `/auth/recover`**
+   (`routes/auth.js:248`). `sendRecoveryEmail` (and the verify variant) are now
+   fire-and-forget, so the bcrypt hash + DB write no longer add latency to the
+   matched-account response. (Chunk 4, 2026-06-12.)
+2. `[FIXED]` **Inconsistent password policy** — centralised into
+   `utils/passwordPolicy.js` (`passwordSchema`: 10–72 chars, upper+lower+digit)
+   and applied to `PATCH /users`, `POST /system/tenants`, `/auth/change-password`,
+   `/auth/force-change-password`, and all portal register/reset/change flows.
+   (Chunk 4, 2026-06-12.)
 3. `[OPEN]` **Refresh-token reuse detection silently no-ops without Redis**
    (`utils/redis.js:48`). Document this more prominently or persist
    invalidation marks in Postgres as a fallback.
-4. `[OPEN]` **`requireSysAdmin` skips invalidation / `active` check**
-   (`middleware/auth.js:47`). Sysadmin tokens stay valid for the full access-
-   token lifetime regardless of account state.
-5. `[OPEN]` **Temp-password generator has modulo bias** (`routes/users.js:312`,
-   `routes/auth.js:346`). `b % 58` over 256-byte values is biased. Use
-   rejection sampling or `crypto.randomInt`.
-6. `[OPEN]` **Origin check bypass when `NODE_ENV !== 'production'`**
-   (`routes/auth.js:38`). Mis-set `NODE_ENV` in staging would silently lose
-   CSRF protection on `/refresh`.
+4. `[FIXED]` **`requireSysAdmin` skips invalidation / `active` check**
+   (`middleware/auth.js:47`). The middleware now re-loads the sys-admin via
+   Prisma on every request and rejects (401) if the account is missing or
+   `active = false`. Sys-admin tokens carry no Redis invalidation marker, so the
+   active flag is the meaningful state check. (Chunk 4, 2026-06-12.)
+5. `[FIXED]` **Temp-password generator has modulo bias**. Replaced with
+   `crypto.randomInt`-based `generateTempPassword()` in `utils/passwordPolicy.js`,
+   shared by `routes/users.js` and `routes/auth.js`. (Chunk 4, 2026-06-12.)
+6. `[FIXED]` **Origin check bypass when `NODE_ENV !== 'production'`**
+   (`routes/auth.js`). `isAllowedOrigin()` now gates enforcement solely on
+   `CORS_ORIGIN` being set; a missing `Origin` header (non-browser caller) is
+   always allowed and `NODE_ENV` no longer influences the decision.
+   (Chunk 4, 2026-06-12.)
 7. `[OPEN]` **Privilege-string format collisions** — `${resource}:${action}` with
    resources that may contain `:` (`finance:transactions:create`). Works
    today, fragile if a future resource code includes `:create`.
-8. `[OPEN]` **No targeted rate limit on portal endpoints** (`app.js:69-71`). Only
-   the global 300/15min/IP `generalLimiter` covers `/public/:slug/portal/*`;
-   `/auth/*` has a tighter `authLimiter`. Add a 20/15min/IP limiter per
-   portal-register/login/forgot/reset/verify-email route.
-9. `[OPEN]` **Portal JWT skips Redis session-invalidation check**
-   (`routes/portal.js:22`). Disabling a member's portal credentials does
-   not take effect until the 15-min access token expires.
-10. `[OPEN]` **Verification tokens still logged via `console.log`**
-    (`routes/public.js:804` portal register-verify, `routes/portal.js:699`
-    portal email-change verify). The forgot-password leak was fixed
-    2026-06-10; these two remain. Either wire SendGrid or refuse the
-    request when email is not configured — don't persist the token and
-    emit it to stdout.
-11. `[OPEN]` **Slug regex inconsistency** — `routes/public.js:24` allows
-    `[a-z0-9_-]` but `utils/db.js:27` only allows `[a-z0-9_]`. A slug
-    containing `-` 500s inside `tenantQuery` rather than 400-ing at the
-    edge. Unify both regexes.
+8. `[FIXED]` **No targeted rate limit on portal endpoints**. A dedicated
+   `portalAuthLimiter` (20/15 min/IP, env `PORTAL_AUTH_RATE_LIMIT_MAX`) now
+   guards `register`, `login`, `forgot-password`, `reset-password`, and
+   `verify-email` in `routes/public.js`. (Chunk 4, 2026-06-12.)
+9. `[FIXED]` **Portal JWT skips Redis session-invalidation check**
+   (`routes/portal.js`). `requirePortalAuth` now checks the
+   `invalidated:<slug>:<memberId>` marker on every request, and portal
+   password change/reset set it. (Chunk 4, 2026-06-12.)
+10. `[FIXED]` **Verification tokens still logged via `console.log`**. Portal
+    register and email-change now send the link via SendGrid
+    (`sendPortalVerificationEmail`), or log a token-free warning when SendGrid
+    is unset — the token is never written to stdout. (Chunk 4, 2026-06-12.)
+11. `[FIXED]` **Slug regex inconsistency**. `routes/public.js` `resolveTenant`
+    now uses `[a-z0-9_]+`, identical to `utils/db.js`, so a `-`-containing slug
+    400s at the edge instead of 500-ing in `tenantQuery`. (Chunk 4, 2026-06-12.)
 12. `[OPEN]` **Photo upload doesn't validate magic bytes** —
     `routes/portal.js:726`. Mime-type is whitelisted to jpeg/png/gif and
     Helmet's nosniff blocks browser sniffing, so no XSS — but mislabelled
     payloads silently succeed and may break PDF rendering downstream.
-13. `[OPEN]` **Portal login email-enumeration via differentiated responses** —
-    `routes/public.js:887,891`. 401 for unknown/wrong-password but 403
-    "Please verify your email" for known-unverified accounts reveals
-    which emails have a portal account.
-14. `[OPEN]` **`/portal/forgot-password` timing enumeration** —
-    `routes/public.js:922`. Bcrypt + DB write happen only on hit;
-    response time leaks account existence.
+13. `[ACCEPTED]` **Portal login "verify your email" differentiated response** —
+    `routes/public.js`. The 403 "Please verify your email" branch is only
+    reachable *after* a correct password match, so it does not enable
+    email-enumeration by an attacker who lacks the password (they would already
+    be that account). It is retained for usability — collapsing it to a generic
+    401 would leave verified-but-unable-to-sign-in users with no guidance. The
+    real vector (response timing) is closed: a no-account login now runs a
+    throwaway bcrypt comparison so a miss costs the same as a wrong-password hit.
+    (Reviewed Chunk 4, 2026-06-12.)
+14. `[FIXED]` **`/portal/forgot-password` timing enumeration** —
+    `routes/public.js`. The reset email is now fire-and-forget, so the
+    matched-account response no longer waits on email delivery. (Chunk 4,
+    2026-06-12.)
 15. `[OPEN]` **No magic-byte validation on photo uploads**
     (`routes/members.js:1494`, `routes/portal.js:726`). Mime-type is
     whitelisted; nosniff blocks browser XSS. But mislabelled payloads

--- a/backend/src/__tests__/portalAuth.test.js
+++ b/backend/src/__tests__/portalAuth.test.js
@@ -32,7 +32,7 @@ const { default: app } = await import('../app.js');
 const { tenantQuery, prisma } = await import('../utils/db.js');
 const { verifyPassword } = await import('../utils/password.js');
 
-const TENANT = 'test-u3a';
+const TENANT = 'test_u3a';
 
 function mockTenantExists() {
   prisma.sysTenant.findUnique.mockResolvedValue({ slug: TENANT, active: true, name: 'Test u3a' });
@@ -134,6 +134,29 @@ describe('POST /public/:slug/portal/login lockout', () => {
     expect(update[2][0]).toBe(0); // count reset on lock
     expect(update[2][1]).toBeInstanceOf(Date); // locked_until set
     expect(update[2][1].getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('runs a dummy comparison and returns generic 401 for an unknown email', async () => {
+    // No matching member rows
+    tenantQuery.mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .post(`/public/${TENANT}/portal/login`)
+      .send({ email: 'nobody@b.com', password: 'whatever' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid email or password.');
+    // The throwaway bcrypt comparison runs so timing matches a wrong-password hit
+    expect(verifyPassword).toHaveBeenCalled();
+  });
+
+  it('rejects a slug containing a hyphen with 400 (matches db.js guard)', async () => {
+    const res = await request(app)
+      .post('/public/bad-slug/portal/login')
+      .send({ email: 'a@b.com', password: 'x' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid tenant slug/i);
   });
 
   it('resets counter on successful login', async () => {

--- a/backend/src/__tests__/restoreBeacon.test.js
+++ b/backend/src/__tests__/restoreBeacon.test.js
@@ -17,6 +17,7 @@ vi.mock('../utils/db.js', () => ({
   prisma: {
     $disconnect: vi.fn(),
     sysTenant: { findUnique: vi.fn() },
+    sysAdmin: { findUnique: vi.fn() },
     $queryRawUnsafe: vi.fn(),
     $transaction: vi.fn(),
   },
@@ -232,6 +233,7 @@ describe('PATCH /system/tenants/:slug/feature-config (sys admin)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('accepts eventAttendance and persists it', async () => {
+    prisma.sysAdmin.findUnique.mockResolvedValueOnce({ id: 'admin-1', active: true });
     prisma.sysTenant.findUnique.mockResolvedValueOnce({ slug: 'demo' });
     tenantQuery.mockResolvedValueOnce([{ feature_config: { eventAttendance: false } }]);
 
@@ -249,5 +251,18 @@ describe('PATCH /system/tenants/:slug/feature-config (sys admin)', () => {
     );
     expect(updateCall).toBeTruthy();
     expect(JSON.parse(updateCall[2][0])).toEqual({ eventAttendance: false });
+  });
+
+  it('rejects a sys-admin whose account is no longer active', async () => {
+    prisma.sysAdmin.findUnique.mockResolvedValueOnce({ id: 'admin-1', active: false });
+
+    const res = await request(app)
+      .patch('/system/tenants/demo/feature-config')
+      .set('Authorization', makeSysAdminHeader())
+      .send({ eventAttendance: false });
+
+    expect(res.status).toBe(401);
+    // Must short-circuit before touching tenant data
+    expect(tenantQuery).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/__tests__/users.test.js
+++ b/backend/src/__tests__/users.test.js
@@ -172,6 +172,17 @@ describe('PATCH /users/:id', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects a password that fails the shared policy (too short / no complexity)', async () => {
+    const res = await request(app)
+      .patch('/users/u1')
+      .set('Authorization', AUTH)
+      .send({ password: 'short' });
+
+    expect(res.status).toBe(422);
+    // No UPDATE should have run
+    expect(tenantQuery).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when user does not exist', async () => {
     tenantQuery.mockResolvedValueOnce([]); // UPDATE returns nothing
 

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -4,6 +4,7 @@
 
 import { verifyAccessToken } from '../utils/jwt.js';
 import { isSessionInvalidated } from '../utils/redis.js';
+import { prisma } from '../utils/db.js';
 
 /**
  * Standard user auth middleware.
@@ -48,14 +49,29 @@ export async function requireSysAdmin(req, res, next) {
 
   const token = authHeader.slice(7);
 
+  let payload;
   try {
-    const payload = verifyAccessToken(token);
-    if (!payload.isSysAdmin) {
-      return res.status(403).json({ error: 'Access denied.' });
-    }
-    req.sysAdmin = payload;
-    next();
+    payload = verifyAccessToken(token);
   } catch {
     return res.status(401).json({ error: 'Invalid token.' });
   }
+
+  if (!payload.isSysAdmin) {
+    return res.status(403).json({ error: 'Access denied.' });
+  }
+
+  try {
+    // Re-check account state on every request. Unlike a tenant user, a sys-admin
+    // token carries no Redis invalidation marker, so without this a deactivated
+    // (or deleted) sys-admin would keep full access until the token expires.
+    const admin = await prisma.sysAdmin.findUnique({ where: { id: payload.sysAdminId } });
+    if (!admin || !admin.active) {
+      return res.status(401).json({ error: 'Session expired. Please log in again.' });
+    }
+  } catch (err) {
+    return next(err);
+  }
+
+  req.sysAdmin = payload;
+  next();
 }

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -2,13 +2,13 @@
 // Authentication endpoints: login, logout, token refresh
 
 import { Router } from 'express';
-import crypto from 'crypto';
 import { z } from 'zod';
 import sgMail from '@sendgrid/mail';
 import { loginUser, logoutUser, refreshTokens, loginSysAdmin } from '../services/authService.js';
 import { requireAuth } from '../middleware/auth.js';
 import { tenantQuery, prisma } from '../utils/db.js';
 import { verifyPassword, hashPassword } from '../utils/password.js';
+import { passwordSchema, generateTempPassword } from '../utils/passwordPolicy.js';
 import { invalidateUserSessions } from '../utils/redis.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logAudit } from '../utils/audit.js';
@@ -42,8 +42,10 @@ function isAllowedOrigin(req) {
   const origin = req.headers.origin;
   if (!origin) {
     // Browsers always send Origin on cross-origin POST. Absence means a
-    // non-browser caller (server-to-server, tests) — no CSRF risk.
-    return process.env.NODE_ENV !== 'production';
+    // non-browser caller (server-to-server, tests) — no CSRF risk. Whether to
+    // enforce is gated on CORS_ORIGIN being set (above), never on NODE_ENV, so
+    // a mis-set NODE_ENV in staging cannot silently drop this protection.
+    return true;
   }
   try {
     return new URL(origin).origin === new URL(allowed).origin;
@@ -151,7 +153,7 @@ router.post('/system/login', async (req, res, next) => {
 
 const changePwSchema = z.object({
   currentPassword: z.string().min(1),
-  newPassword: z.string().min(10).max(72),
+  newPassword: passwordSchema,
 });
 
 router.post('/change-password', requireAuth, async (req, res, next) => {
@@ -293,8 +295,13 @@ router.post('/recover', async (req, res, next) => {
       return res.json({ securityQuestion: user.security_question, userId: user.id });
     }
 
-    // No security question set — send recovery email directly
-    await sendRecoveryEmail(data.tenantSlug, user);
+    // No security question set — send recovery email. Fire-and-forget so the
+    // response time does not depend on the bcrypt hash + DB write inside
+    // sendRecoveryEmail (which would otherwise leak account existence by
+    // timing — a matched account responds noticeably slower than a miss).
+    void sendRecoveryEmail(data.tenantSlug, user).catch((err) =>
+      console.error('[Recovery] Background recovery email failed:', err.message),
+    );
     res.json({ message: RECOVER_GENERIC });
   } catch (err) {
     next(err);
@@ -337,7 +344,9 @@ router.post('/recover/verify', async (req, res, next) => {
       });
     }
 
-    await sendRecoveryEmail(data.tenantSlug, user);
+    void sendRecoveryEmail(data.tenantSlug, user).catch((err) =>
+      console.error('[Recovery] Background recovery email failed:', err.message),
+    );
     res.json({ message: RECOVER_GENERIC });
   } catch (err) {
     next(err);
@@ -349,7 +358,7 @@ router.post('/recover/verify', async (req, res, next) => {
 // Sets new password + security Q&A. Does NOT require current password.
 
 const forceChangePwSchema = z.object({
-  newPassword: z.string().min(10).max(72),
+  newPassword: passwordSchema,
   question: z.string().min(1).max(200),
   answer: z.string().min(1).max(200),
 });
@@ -357,15 +366,6 @@ const forceChangePwSchema = z.object({
 router.post('/force-change-password', requireAuth, async (req, res, next) => {
   try {
     const { newPassword, question, answer } = forceChangePwSchema.parse(req.body);
-
-    // Validate password rules: no spaces, upper+lower+number
-    if (/\s/.test(newPassword)) throw AppError('Password must not contain spaces.', 400);
-    if (!/[A-Z]/.test(newPassword))
-      throw AppError('Password must include at least one uppercase letter.', 400);
-    if (!/[a-z]/.test(newPassword))
-      throw AppError('Password must include at least one lowercase letter.', 400);
-    if (!/[0-9]/.test(newPassword))
-      throw AppError('Password must include at least one number.', 400);
 
     const slug = req.user.tenantSlug;
 
@@ -413,15 +413,6 @@ router.post('/force-change-password', requireAuth, async (req, res, next) => {
 });
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
-
-/** Generate a random temporary password like "!xZ#8kP2" */
-function generateTempPassword() {
-  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$%';
-  const bytes = crypto.randomBytes(8);
-  return Array.from(bytes)
-    .map((b) => chars[b % chars.length])
-    .join('');
-}
 
 /** Generate temp password, update user, and send recovery email.
  *  The temp password is never logged. If SendGrid is not configured the

--- a/backend/src/routes/portal.js
+++ b/backend/src/routes/portal.js
@@ -5,17 +5,26 @@
 
 import { Router } from 'express';
 import { z } from 'zod';
+import sgMail from '@sendgrid/mail';
 import PDFDocument from 'pdfkit';
 import { tenantQuery, prisma } from '../utils/db.js';
 import { verifyAccessToken } from '../utils/jwt.js';
 import { hashPassword, verifyPassword } from '../utils/password.js';
 import { generateToken, hashOpaqueToken } from '../utils/password.js';
+import { passwordSchema } from '../utils/passwordPolicy.js';
+import { isSessionInvalidated, invalidateUserSessions } from '../utils/redis.js';
 import { resolveTokens } from '../utils/emailTokens.js';
 import { isFeatureEnabled } from '../middleware/requireFeature.js';
 import { logAudit } from '../utils/audit.js';
 import { generateSingleCardPdf } from './membershipCards.js';
 
 const router = Router({ mergeParams: true });
+
+if (process.env.SENDGRID_API_KEY) {
+  sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+}
+
+const PORTAL_FROM = process.env.RECOVERY_FROM_ADDRESS ?? 'noreply@u3abeacon.org.uk';
 
 // ─── Portal auth middleware ──────────────────────────────────────────────────
 
@@ -31,6 +40,16 @@ async function requirePortalAuth(req, res, next) {
     }
     if (payload.tenantSlug !== req.params.slug) {
       return res.status(403).json({ error: 'Token does not match this organisation.' });
+    }
+    // Honour session invalidation (e.g. portal password change/reset) the same
+    // way requireAuth does for tenant users, keyed on the member id.
+    const invalidated = await isSessionInvalidated(
+      payload.tenantSlug,
+      payload.memberId,
+      payload.iat,
+    );
+    if (invalidated) {
+      return res.status(401).json({ error: 'Session expired. Please sign in again.' });
     }
     req.portal = payload; // { memberId, tenantSlug, name, isPortal }
     next();
@@ -822,7 +841,11 @@ router.patch('/personal-details', async (req, res, next) => {
 
       const frontendBase = process.env.CORS_ORIGIN || 'http://localhost:5173';
       const verifyLink = `${frontendBase}/public/${slug}/portal/verify?token=${verificationToken}`;
-      console.log(`[Portal] Would send email verification to ${data.email}: ${verifyLink}`);
+      // Send the link by email. Fire-and-forget; never log the token (a leaked
+      // verification token lets an attacker confirm a changed email address).
+      void sendPortalVerificationEmail(data.email.toLowerCase(), verifyLink).catch((err) =>
+        console.error('[Portal] Background email-verification send failed:', err.message),
+      );
     }
 
     // Send confirmation email via system_messages template
@@ -968,14 +991,7 @@ router.get('/photo', async (req, res, next) => {
 
 const changePasswordSchema = z.object({
   currentPassword: z.string().min(1),
-  newPassword: z
-    .string()
-    .min(10)
-    .max(72)
-    .refine((pw) => /[a-z]/.test(pw) && /[A-Z]/.test(pw) && /[0-9]/.test(pw), {
-      message:
-        'Password must contain at least one uppercase, one lowercase, and one numeric character.',
-    }),
+  newPassword: passwordSchema,
 });
 
 router.post('/change-password', async (req, res, next) => {
@@ -1004,6 +1020,10 @@ router.post('/change-password', async (req, res, next) => {
       `UPDATE members SET portal_password_hash = $1, updated_at = now() WHERE id = $2`,
       [newHash, memberId],
     );
+
+    // Invalidate any other portal sessions for this member (requirePortalAuth
+    // checks this marker on every request).
+    await invalidateUserSessions(slug, memberId);
 
     logAudit(slug, {
       userId: null,
@@ -1800,6 +1820,35 @@ async function sendDetailsUpdateEmail(slug, memberId, emailChanged) {
     }
   } catch (err) {
     console.error('[Portal] Failed to send details update email:', err.message);
+  }
+}
+
+/** Send the portal email-change verification link. Mirrors sendPortalResetEmail()
+ *  in public.js — if SendGrid is not configured we log a warning (without the
+ *  token) and return silently rather than emitting the link to stdout. */
+async function sendPortalVerificationEmail(toEmail, verifyLink) {
+  const subject = 'Verify your new Members Portal email address';
+  const body = `You changed the email address on your Members Portal account.
+
+Use the link below to verify this new address. The link expires in one hour.
+
+${verifyLink}
+
+If you did not request this, please contact your u3a.`;
+
+  if (!process.env.SENDGRID_API_KEY) {
+    console.warn(
+      `[Portal] SendGrid not configured — cannot deliver email-verification message to ${toEmail}. ` +
+        `Set SENDGRID_API_KEY to enable portal verification emails.`,
+    );
+    return;
+  }
+
+  try {
+    await sgMail.send({ to: toEmail, from: PORTAL_FROM, subject, text: body });
+  } catch (err) {
+    // Never include the verification link in the error log.
+    console.error(`[Portal] Failed to send email-verification message to ${toEmail}:`, err.message);
   }
 }
 

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -6,8 +6,11 @@ import { Router } from 'express';
 import { randomBytes } from 'crypto';
 import { z } from 'zod';
 import sgMail from '@sendgrid/mail';
+import { rateLimit } from 'express-rate-limit';
 import { prisma, tenantQuery } from '../utils/db.js';
 import { hashPassword, verifyPassword, generateToken, hashOpaqueToken } from '../utils/password.js';
+import { passwordSchema } from '../utils/passwordPolicy.js';
+import { invalidateUserSessions } from '../utils/redis.js';
 import { signAccessToken } from '../utils/jwt.js';
 import { resolveTokens } from '../utils/emailTokens.js';
 import { generateSingleCardPdf } from './membershipCards.js';
@@ -23,6 +26,20 @@ if (process.env.SENDGRID_API_KEY) {
 }
 
 const PORTAL_FROM = process.env.RECOVERY_FROM_ADDRESS ?? 'noreply@u3abeacon.org.uk';
+
+// Dummy bcrypt hash used to equalise response timing when no matching portal
+// account exists, so a miss takes the same time as a wrong-password hit and
+// cannot be distinguished by an attacker probing for registered emails.
+const DUMMY_PORTAL_HASH = '$2b$12$invalidhashfortimingattackprevention000000000000000000000';
+
+// Targeted rate limiter for the unauthenticated portal-auth endpoints
+// (register/login/forgot/reset/verify). The global limiter is 300/15min/IP;
+// these are far more sensitive, so cap them tightly. Env-tunable.
+const portalAuthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: parseInt(process.env.PORTAL_AUTH_RATE_LIMIT_MAX ?? '20', 10),
+  message: { error: 'Too many attempts, please try again later.' },
+});
 
 // Portal-login lockout — reuses the admin login env vars so operators have a
 // single knob. Mirrors registerFailedLogin() in services/authService.js.
@@ -59,7 +76,9 @@ async function registerPortalFailedLogin(slug, members, attemptedEmail) {
 
 async function resolveTenant(req, res, next) {
   const { slug } = req.params;
-  if (!slug || !/^[a-z0-9_-]+$/.test(slug)) {
+  // Keep this identical to the guard in utils/db.js so a slug that the edge
+  // accepts can never 500 inside tenantQuery (schema names cannot contain `-`).
+  if (!slug || !/^[a-z0-9_]+$/.test(slug)) {
     return res.status(400).json({ error: 'Invalid tenant slug.' });
   }
   try {
@@ -840,17 +859,10 @@ const portalRegisterSchema = z.object({
   surname: z.string().min(1),
   postcode: z.string().min(1),
   email: z.string().email(),
-  password: z
-    .string()
-    .min(10)
-    .max(72)
-    .refine((pw) => /[a-z]/.test(pw) && /[A-Z]/.test(pw) && /[0-9]/.test(pw), {
-      message:
-        'Password must contain at least one uppercase, one lowercase, and one numeric character.',
-    }),
+  password: passwordSchema,
 });
 
-router.post('/:slug/portal/register', async (req, res, next) => {
+router.post('/:slug/portal/register', portalAuthLimiter, async (req, res, next) => {
   try {
     const slug = req.tenantSlug;
     const data = portalRegisterSchema.parse(req.body);
@@ -923,10 +935,14 @@ router.post('/:slug/portal/register', async (req, res, next) => {
       ],
     );
 
-    // In production, send verification email with link
+    // Send the verification email with the link. Fire-and-forget; never log
+    // the token (a leaked verification token would let an attacker activate an
+    // account they registered against someone else's membership record).
     const frontendBase = process.env.CORS_ORIGIN || 'http://localhost:5173';
     const verifyLink = `${frontendBase}/public/${slug}/portal/verify?token=${verificationToken}`;
-    console.log(`[Portal] Would send verification email to ${data.email}: ${verifyLink}`);
+    void sendPortalVerificationEmail(data.email.toLowerCase(), verifyLink).catch((err) =>
+      console.error('[Portal] Background verification email failed:', err.message),
+    );
 
     logAudit(slug, {
       userId: null,
@@ -951,7 +967,7 @@ const verifyEmailSchema = z.object({
   token: z.string().min(1),
 });
 
-router.post('/:slug/portal/verify-email', async (req, res, next) => {
+router.post('/:slug/portal/verify-email', portalAuthLimiter, async (req, res, next) => {
   try {
     const slug = req.tenantSlug;
     const { token } = verifyEmailSchema.parse(req.body);
@@ -1000,7 +1016,7 @@ const portalLoginSchema = z.object({
   password: z.string().min(1),
 });
 
-router.post('/:slug/portal/login', async (req, res, next) => {
+router.post('/:slug/portal/login', portalAuthLimiter, async (req, res, next) => {
   try {
     const slug = req.tenantSlug;
     const data = portalLoginSchema.parse(req.body);
@@ -1016,6 +1032,10 @@ router.post('/:slug/portal/login', async (req, res, next) => {
     );
 
     if (members.length === 0) {
+      // Run a throwaway comparison so an unknown email takes about the same
+      // time as a wrong password — otherwise response timing reveals which
+      // emails have a portal account.
+      await verifyPassword(data.password, DUMMY_PORTAL_HASH);
       return res.status(401).json({ error: 'Invalid email or password.' });
     }
 
@@ -1090,7 +1110,7 @@ const forgotPasswordSchema = z.object({
   email: z.string().email(),
 });
 
-router.post('/:slug/portal/forgot-password', async (req, res, next) => {
+router.post('/:slug/portal/forgot-password', portalAuthLimiter, async (req, res, next) => {
   try {
     const slug = req.tenantSlug;
     const { email } = forgotPasswordSchema.parse(req.body);
@@ -1128,7 +1148,11 @@ router.post('/:slug/portal/forgot-password', async (req, res, next) => {
     const frontendBase = process.env.CORS_ORIGIN || 'http://localhost:5173';
     const resetLink = `${frontendBase}/public/${slug}/portal/reset-password?token=${resetToken}`;
 
-    await sendPortalResetEmail(email.toLowerCase(), resetLink);
+    // Fire-and-forget so the response time does not depend on email delivery
+    // (which only happens on a hit) and so cannot be used to enumerate accounts.
+    void sendPortalResetEmail(email.toLowerCase(), resetLink).catch((err) =>
+      console.error('[Portal] Background reset email failed:', err.message),
+    );
 
     res.json({ message: 'If an account exists with that email, a reset link has been sent.' });
   } catch (err) {
@@ -1172,21 +1196,44 @@ If you did not request this, you can ignore this email.`;
   }
 }
 
+/** Send the portal email-verification link (registration + email change).
+ *  Mirrors sendPortalResetEmail() — if SendGrid is not configured we log a
+ *  warning (without the token) and return silently rather than emitting the
+ *  link to stdout. */
+async function sendPortalVerificationEmail(toEmail, verifyLink) {
+  const subject = 'Verify your Members Portal account';
+  const body = `Please verify your Members Portal email address.
+
+Use the link below to confirm your account. The link expires in one hour.
+
+${verifyLink}
+
+If you did not request this, you can ignore this email.`;
+
+  if (!process.env.SENDGRID_API_KEY) {
+    console.warn(
+      `[Portal] SendGrid not configured — cannot deliver verification email to ${toEmail}. ` +
+        `Set SENDGRID_API_KEY to enable portal verification emails.`,
+    );
+    return;
+  }
+
+  try {
+    await sgMail.send({ to: toEmail, from: PORTAL_FROM, subject, text: body });
+  } catch (err) {
+    // Never include the verification link in the error log.
+    console.error(`[Portal] Failed to send verification email to ${toEmail}:`, err.message);
+  }
+}
+
 // ─── POST /:slug/portal/reset-password ──────────────────────────────────
 
 const resetPasswordSchema = z.object({
   token: z.string().min(1),
-  password: z
-    .string()
-    .min(10)
-    .max(72)
-    .refine((pw) => /[a-z]/.test(pw) && /[A-Z]/.test(pw) && /[0-9]/.test(pw), {
-      message:
-        'Password must contain at least one uppercase, one lowercase, and one numeric character.',
-    }),
+  password: passwordSchema,
 });
 
-router.post('/:slug/portal/reset-password', async (req, res, next) => {
+router.post('/:slug/portal/reset-password', portalAuthLimiter, async (req, res, next) => {
   try {
     const slug = req.tenantSlug;
     const { token, password } = resetPasswordSchema.parse(req.body);
@@ -1220,6 +1267,9 @@ router.post('/:slug/portal/reset-password', async (req, res, next) => {
        WHERE id = $2`,
       [passwordHash, member.id],
     );
+
+    // Invalidate any existing portal sessions for this member.
+    await invalidateUserSessions(slug, member.id);
 
     res.json({ message: 'Password has been reset successfully. You can now sign in.' });
   } catch (err) {

--- a/backend/src/routes/system.js
+++ b/backend/src/routes/system.js
@@ -9,6 +9,7 @@ import multer from 'multer';
 import { requireSysAdmin } from '../middleware/auth.js';
 import { prisma, tenantQuery } from '../utils/db.js';
 import { hashPassword } from '../utils/password.js';
+import { passwordSchema } from '../utils/passwordPolicy.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { createTenantSchema } from '../seed/createTenant.js';
 import {
@@ -45,7 +46,7 @@ const newTenantSchema = z.object({
   slug: z.string().regex(/^[a-z0-9_]+$/, 'Slug must be lowercase alphanumeric with underscores'),
   adminEmail: z.string().email(),
   adminName: z.string().min(1),
-  adminPassword: z.string().min(8),
+  adminPassword: passwordSchema,
   adminUsername: z
     .string()
     .regex(/^[a-z0-9]+$/, 'Username must be lowercase letters and numbers only'),

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,12 +1,12 @@
 // beacon2/backend/src/routes/users.js
 
 import { Router } from 'express';
-import crypto from 'crypto';
 import { z } from 'zod';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
 import { tenantQuery } from '../utils/db.js';
 import { hashPassword } from '../utils/password.js';
+import { passwordSchema, generateTempPassword } from '../utils/passwordPolicy.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { invalidateUserSessions } from '../utils/redis.js';
 import { logAudit } from '../utils/audit.js';
@@ -179,7 +179,7 @@ const updateUserSchema = z.object({
     .nullable()
     .optional(),
   name: z.string().min(1).optional(),
-  password: z.string().min(8).optional(),
+  password: passwordSchema.optional(),
   active: z.boolean().optional(),
   memberId: z.string().nullable().optional(),
 });
@@ -402,16 +402,5 @@ router.delete(
     }
   },
 );
-
-// ─── Helpers ──────────────────────────────────────────────────────────────
-
-/** Generate a random temporary password like "!xZ#8kP2" */
-function generateTempPassword() {
-  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$%';
-  const bytes = crypto.randomBytes(8);
-  return Array.from(bytes)
-    .map((b) => chars[b % chars.length])
-    .join('');
-}
 
 export default router;

--- a/backend/src/utils/passwordPolicy.js
+++ b/backend/src/utils/passwordPolicy.js
@@ -1,0 +1,40 @@
+// beacon2/backend/src/utils/passwordPolicy.js
+// Single source of truth for the password-strength policy and temporary-
+// password generation, so every flow (admin change, force-change, user
+// create/update, tenant create, and all portal reset/register flows) enforces
+// the same rules. Kept separate from password.js — which several test files
+// mock wholesale — so importing the schema never depends on that mock.
+
+import crypto from 'crypto';
+import { z } from 'zod';
+
+// Canonical password rules: 10–72 chars (72 is bcrypt's input limit) with at
+// least one lowercase, one uppercase, and one digit. Apply everywhere a user
+// chooses a password.
+export const passwordSchema = z
+  .string()
+  .min(10, 'Password must be at least 10 characters.')
+  .max(72, 'Password must be at most 72 characters.')
+  .refine((pw) => /[a-z]/.test(pw) && /[A-Z]/.test(pw) && /[0-9]/.test(pw), {
+    message:
+      'Password must contain at least one uppercase, one lowercase, and one numeric character.',
+  });
+
+// Alphabet for generated temporary passwords — omits easily-confused
+// characters (0/O, 1/I/l). These are set with must_change_password = true, so
+// they are not validated against passwordSchema; the user replaces them on
+// first login.
+const TEMP_PASSWORD_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$%';
+
+/**
+ * Generate a random temporary password. Uses crypto.randomInt for a uniform
+ * index into the alphabet — unlike `randomBytes()[i] % length`, which is
+ * modulo-biased when the alphabet length does not divide 256.
+ */
+export function generateTempPassword(length = 12) {
+  let out = '';
+  for (let i = 0; i < length; i++) {
+    out += TEMP_PASSWORD_CHARS[crypto.randomInt(TEMP_PASSWORD_CHARS.length)];
+  }
+  return out;
+}

--- a/docs/ImprovementPlan.md
+++ b/docs/ImprovementPlan.md
@@ -202,7 +202,7 @@ disabled (noise). `exhaustive-deps` left as a warning (30 sites). Backend
 separately. Node bumped 20 → 22 in `ci.yml`; `lint` + `format:check` now
 gate CI.
 
-### Chunk 4 — Security: auth & enumeration (S2–S8, S11, S12)
+### Chunk 4 — Security: auth & enumeration (S2–S8, S11, S12) ✅ Done (2026-06-12)
 - Centralise password policy into one shared Zod schema; apply to
   `PATCH /users`, `/system/tenants`, and all reset flows.
 - Replace biased temp-password generation with `crypto.randomInt`.
@@ -212,6 +212,24 @@ gate CI.
 - Stop logging verification tokens; unify the slug regexes; add a portal auth
   rate limiter; base the refresh-origin check on `CORS_ORIGIN` presence rather
   than `NODE_ENV`.
+
+**Notes:** New `backend/src/utils/passwordPolicy.js` is the single source of
+truth for `passwordSchema` (10–72 chars, upper+lower+digit) and
+`generateTempPassword()` (now `crypto.randomInt`, no modulo bias); it lives
+apart from `password.js` because several test files mock the latter wholesale.
+`requireSysAdmin` now re-checks `sysAdmin.active` on every request (sys-admin
+tokens carry no Redis invalidation marker, so the active flag is the meaningful
+state check). Portal auth honours the Redis invalidation marker (set on portal
+password change/reset). **Deviation:** the portal-login "verify your email"
+response is *retained* (not collapsed to a generic 401) — it is only reachable
+after a correct password, so it is not an email-enumeration vector; the actual
+vector (response timing) was closed with a dummy bcrypt comparison on the
+no-account path. Recover / forgot-password emails are now fire-and-forget so
+response time no longer leaks account existence. Verification tokens are emailed
+via SendGrid (or a token-free warning when unset), never `console.log`'d. The
+public slug regex was tightened to `[a-z0-9_]+` to match `utils/db.js`. A
+dedicated `portalAuthLimiter` (20/15 min/IP, `PORTAL_AUTH_RATE_LIMIT_MAX`)
+guards register/login/forgot/reset/verify.
 
 ### Chunk 5 — Security: email & uploads (S9, S10, S13)
 - Sanitise attachment filenames; constrain `replyTo` to the sender's own


### PR DESCRIPTION
Implements **Chunk 4 — Security: auth & enumeration** from `docs/ImprovementPlan.md` (findings S2–S8, S11, S12).

## Changes

**New `backend/src/utils/passwordPolicy.js`** — single source of truth for `passwordSchema` (10–72 chars, upper+lower+digit) and `generateTempPassword()` (`crypto.randomInt`, no modulo bias). Kept separate from `password.js` because several test files mock that module wholesale.

- **S2** — replaced biased `byte % length` temp-password selection with `crypto.randomInt`.
- **S4** — unified the password policy onto `passwordSchema` for `PATCH /users` (was a weak `min(8)`), `POST /system/tenants`, `/auth/change-password`, `/auth/force-change-password`, and all portal register/reset/change flows.
- **S7** — `requireSysAdmin` now re-loads the sys-admin each request and rejects (401) if the account is missing or inactive.
- **S3** — `requirePortalAuth` honours the Redis invalidation marker; portal password change/reset now set it.
- **S5** — `/auth/recover` and `/portal/forgot-password` send emails fire-and-forget (no bcrypt/DB latency leak); portal login runs a throwaway bcrypt comparison for unknown emails to equalise timing.
- **S6** — verification tokens are emailed via SendGrid (or a token-free warning when unset), never `console.log`'d.
- **S8** — public slug regex tightened to `[a-z0-9_]+` to match `utils/db.js` (hyphenated slug → 400 at the edge, not 500 in `tenantQuery`).
- **S11** — `portalAuthLimiter` (20/15 min/IP, env `PORTAL_AUTH_RATE_LIMIT_MAX`) guards portal register/login/forgot/reset/verify.
- **S12** — `/auth/refresh` Origin check is gated on `CORS_ORIGIN` being set rather than `NODE_ENV`.

## Deliberate deviation

The plan listed "portal login 401 for unverified." The "Please verify your email" response is **retained** instead, because that branch is only reachable after a correct password — so it is not an email-enumeration vector, and a generic 401 would leave legitimate unverified users with no guidance. The real vector (response timing) is closed with the dummy bcrypt comparison. Documented in `KNOWN-ISSUES.md` #13 (`[ACCEPTED]`) and the ImprovementPlan Chunk 4 notes.

## Verification

- +4 regression tests added (password-policy rejection, sys-admin inactive, portal-login dummy-bcrypt, slug rejection).
- **474 backend tests pass**; ESLint and Prettier clean.
- No frontend code changes.

## Docs

ImprovementPlan (Chunk 4 ✅), KNOWN-ISSUES (#1, 2, 4, 5, 6, 8, 9, 10, 11, 14 → `[FIXED]`; #13 → `[ACCEPTED]`), CHANGELOG, and a new CLAUDE-STANDARDS rule for the shared password policy.

https://claude.ai/code/session_01Swzw5kQLx7FHH1oe8NoXdv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Swzw5kQLx7FHH1oe8NoXdv)_