### PR TITLE
Chunk 5: harden email & uploads (S9, S10, S13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 
 ## [Unreleased] — 2026-06-12
 
+### Security
+- **Email & upload hardening (ImprovementPlan Chunk 5, findings S9/S10/S13)** —
+  - Member photo uploads (admin and portal) now validate the file's leading
+    bytes against the declared `image/jpeg|png|gif` type and reject mismatches,
+    closing the mislabelled-payload vector.
+  - Email attachment filenames are sanitised to a safe basename (path and
+    control characters stripped, whitespace padding collapsed, length capped).
+  - `/email/send` now constrains both `fromEmail` and `replyTo` to the
+    sender's own permitted addresses (member email + offices held), preventing
+    officer/address impersonation by anyone holding `email:send`.
+  - `/email/send` and `/system/restore` multer configs now whitelist MIME
+    types and cap file counts instead of accepting any type.
+  - The SendGrid delivery-status refresh is capped at 100 per-recipient API
+    lookups per click, bounding outbound-API amplification.
+  - The broadcast sender address is now configurable via `EMAIL_FROM_ADDRESS`
+    (falling back to `RECOVERY_FROM_ADDRESS`) instead of being hard-coded.
+  - Tenant restore purges that tenant's Redis session-invalidation marks, so
+    freshly-restored users' sessions are no longer treated as pre-revoked.
+
 ### Added
+- **Upload-hardening helper `backend/src/utils/uploads.js`** (ImprovementPlan
+  Chunk 5) — shared image magic-byte sniffer, attachment-filename sanitiser,
+  and a reusable multer MIME `fileFilter` with spreadsheet/attachment
+  whitelists, with unit coverage in `__tests__/uploads.test.js`.
 - **Linting & formatting baseline (ImprovementPlan Chunk 3, findings T1/T2)** —
   added ESLint 9 (flat config) and Prettier to both `backend/` and
   `frontend/`. The frontend config uses `eslint-plugin-react` plus the

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -59,10 +59,11 @@ These are catalogued and re-verified in `docs/ImprovementPlan.md` (Chunks 4–5)
     `[a-z0-9_-]` but `utils/db.js:27` only allows `[a-z0-9_]`. A slug
     containing `-` 500s inside `tenantQuery` rather than 400-ing at the
     edge. Unify both regexes.
-12. `[OPEN]` **Photo upload doesn't validate magic bytes** —
-    `routes/portal.js:726`. Mime-type is whitelisted to jpeg/png/gif and
-    Helmet's nosniff blocks browser sniffing, so no XSS — but mislabelled
-    payloads silently succeed and may break PDF rendering downstream.
+12. `[RESOLVED 2026-06-12]` **Photo upload doesn't validate magic bytes** —
+    `routes/portal.js`. Fixed in ImprovementPlan Chunk 5: both photo routes now
+    call `decodeAndValidateImage()` (`utils/uploads.js`), which sniffs the
+    leading bytes and rejects a payload whose content doesn't match its
+    declared jpeg/png/gif type. (See also #15.)
 13. `[OPEN]` **Portal login email-enumeration via differentiated responses** —
     `routes/public.js:887,891`. 401 for unknown/wrong-password but 403
     "Please verify your email" for known-unverified accounts reveals
@@ -70,33 +71,36 @@ These are catalogued and re-verified in `docs/ImprovementPlan.md` (Chunks 4–5)
 14. `[OPEN]` **`/portal/forgot-password` timing enumeration** —
     `routes/public.js:922`. Bcrypt + DB write happen only on hit;
     response time leaks account existence.
-15. `[OPEN]` **No magic-byte validation on photo uploads**
-    (`routes/members.js:1494`, `routes/portal.js:726`). Mime-type is
-    whitelisted; nosniff blocks browser XSS. But mislabelled payloads
-    silently succeed and break PDF rendering downstream — DoS vector.
-16. `[OPEN]` **Email-attachment `originalname` passed through unsanitised**
-    (`routes/email.js:267`). Recipients can be sent files with
-    attacker-crafted names (`Invoice.pdf .exe`, control-char headers).
-    Sanitise to a basename, strip control chars, cap length.
-17. `[OPEN]` **`clearTenantData()` doesn't purge Redis invalidation marks**
-    (`routes/backup.js:658`). After restore, stale `invalidated:slug:userId`
-    keys (31-day TTL) may make fresh sessions appear pre-revoked.
-18. `[OPEN]` **Multer accepts any MIME type on `/system/restore` and `/email/send`**
-    (`routes/system.js:201`, `routes/email.js:16`). FileSize caps the
-    only bound; per-request /email/send worst case ≈ 400 MB in memory.
-19. `[OPEN]` **`/email/send` `fromEmail` field is declared but ignored** —
-    `routes/email.js:205,293`. The SendGrid message hard-codes
-    `FROM_ADDRESS`. Either wire it up with an allow-list, or drop the
-    field from the schema.
-20. `[OPEN]` **`/email/send` `replyTo` is unconstrained** — anyone with
-    `email:send` can set it to any address (e.g. impersonating an
-    officer). Limit to the user's own member-email + offices they hold
-    (the same source as `/email/from-addresses`).
-21. `[OPEN]` **`/email/delivery/:batchId/refresh` issues one SendGrid API call
-    per recipient** — `routes/email.js:433`. Cap the per-click amplification.
-22. `[OPEN]` **Hard-coded `FROM_ADDRESS = 'noreply@u3abeacon.org.uk'`** —
-    `routes/email.js:23`. Make env-configurable so deployments under
-    other domains don't fail SPF/DKIM silently.
+15. `[RESOLVED 2026-06-12]` **No magic-byte validation on photo uploads**
+    (`routes/members.js`, `routes/portal.js`). Fixed in ImprovementPlan
+    Chunk 5 — see #12.
+16. `[RESOLVED 2026-06-12]` **Email-attachment `originalname` passed through
+    unsanitised** (`routes/email.js`). Fixed in Chunk 5: attachments are run
+    through `sanitizeAttachmentFilename()` (basename only, control/illegal
+    chars stripped, whitespace padding collapsed, length capped).
+17. `[RESOLVED 2026-06-12]` **`clearTenantData()` doesn't purge Redis
+    invalidation marks** (`routes/backup.js`). Fixed in Chunk 5: the restore
+    route calls `purgeTenantInvalidations(tenantSlug)` (`utils/redis.js`, SCAN
+    + DEL) after a successful restore, clearing stale
+    `invalidated:slug:userId` keys.
+18. `[RESOLVED 2026-06-12]` **Multer accepts any MIME type on `/system/restore`
+    and `/email/send`** (`routes/system.js`, `routes/email.js`). Fixed in
+    Chunk 5: both multer configs now use `mimeFileFilter()` (spreadsheet
+    whitelist for restore, safe-attachment whitelist for email) plus explicit
+    `files` count limits.
+19. `[RESOLVED 2026-06-12]` **`/email/send` `fromEmail` field is declared but
+    ignored** (`routes/email.js`). Fixed in Chunk 5: `fromEmail` and `replyTo`
+    are now validated against the user's own permitted addresses
+    (`getUserFromAddresses()`, the same source as `/email/from-addresses`);
+    a value outside that set is rejected with 403.
+20. `[RESOLVED 2026-06-12]` **`/email/send` `replyTo` is unconstrained**
+    (`routes/email.js`). Fixed in Chunk 5 — see #19.
+21. `[RESOLVED 2026-06-12]` **`/email/delivery/:batchId/refresh` issues one
+    SendGrid API call per recipient** (`routes/email.js`). Fixed in Chunk 5:
+    the per-click lookup count is capped at `MAX_REFRESH_LOOKUPS` (100).
+22. `[RESOLVED 2026-06-12]` **Hard-coded `FROM_ADDRESS`** (`routes/email.js`).
+    Fixed in Chunk 5: the broadcast sender now reads `EMAIL_FROM_ADDRESS`
+    (falling back to `RECOVERY_FROM_ADDRESS`, then the original default).
 23. `[OPEN]` **`routes/public.js` and `routes/portal.js` `resolveTokens` callers
     still use `body` for templated emails** — currently only `console.log`'d
     so latent, but when SendGrid is wired they should also use the new

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -51,7 +51,11 @@ USE_REDIS=false
 # When unset, recovery/verification emails are skipped (a warning is logged)
 # rather than sent.
 SENDGRID_API_KEY=
+# Sender for recovery / portal verification emails.
 RECOVERY_FROM_ADDRESS=noreply@example.com
+# Sender for member broadcast emails (Email Compose). Must be SPF/DKIM-
+# authorised for your domain. Falls back to RECOVERY_FROM_ADDRESS when unset.
+EMAIL_FROM_ADDRESS=noreply@example.com
 
 # ── PayPal stub (optional, NON-production only) ───────────────────────────
 # The PayPal integration is a stub. It refuses to run in production unless

--- a/backend/src/__tests__/members.test.js
+++ b/backend/src/__tests__/members.test.js
@@ -493,6 +493,16 @@ describe('POST /members/:id/photo', () => {
     expect(res.status).toBe(422);
   });
 
+  it('rejects content whose magic bytes do not match the declared type', async () => {
+    // PNG bytes declared as JPEG — should be rejected before any DB write.
+    const res = await request(app)
+      .post('/members/m1/photo')
+      .set('Authorization', AUTH)
+      .send({ data: TINY_PNG, mimeType: 'image/jpeg' });
+
+    expect(res.status).toBe(400);
+  });
+
   it('returns 404 when member not found', async () => {
     tenantQuery.mockResolvedValueOnce([]); // member not found
 

--- a/backend/src/__tests__/uploads.test.js
+++ b/backend/src/__tests__/uploads.test.js
@@ -1,0 +1,103 @@
+// beacon2/backend/src/__tests__/uploads.test.js
+// Unit tests for the upload-hardening helpers (ImprovementPlan Chunk 5):
+// image magic-byte sniffing, attachment filename sanitisation, and the
+// multer MIME fileFilter.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  sniffImageMime,
+  decodeAndValidateImage,
+  sanitizeAttachmentFilename,
+  mimeFileFilter,
+} from '../utils/uploads.js';
+
+// 1x1 red PNG.
+const PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+const PNG = Buffer.from(PNG_B64, 'base64');
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const GIF = Buffer.from('GIF89a', 'latin1');
+
+describe('sniffImageMime', () => {
+  it('recognises PNG, JPEG and GIF signatures', () => {
+    expect(sniffImageMime(PNG)).toBe('image/png');
+    expect(sniffImageMime(JPEG)).toBe('image/jpeg');
+    expect(sniffImageMime(GIF)).toBe('image/gif');
+  });
+
+  it('returns null for non-image / short buffers', () => {
+    expect(sniffImageMime(Buffer.from('not an image'))).toBeNull();
+    expect(sniffImageMime(Buffer.from([0x00, 0x01]))).toBeNull();
+    expect(sniffImageMime('not a buffer')).toBeNull();
+  });
+});
+
+describe('decodeAndValidateImage', () => {
+  it('returns the decoded buffer when content matches the declared type', () => {
+    const buf = decodeAndValidateImage(PNG_B64, 'image/png');
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.length).toBeGreaterThan(0);
+  });
+
+  it('throws a 400 when the content does not match the declared type', () => {
+    expect(() => decodeAndValidateImage(PNG_B64, 'image/jpeg')).toThrowError(/does not match/i);
+    try {
+      decodeAndValidateImage(PNG_B64, 'image/jpeg');
+    } catch (err) {
+      expect(err.status).toBe(400);
+    }
+  });
+
+  it('throws for a payload that is not a recognised image', () => {
+    const junk = Buffer.from('hello world').toString('base64');
+    expect(() => decodeAndValidateImage(junk, 'image/png')).toThrow();
+  });
+});
+
+describe('sanitizeAttachmentFilename', () => {
+  it('strips directory components', () => {
+    expect(sanitizeAttachmentFilename('../../etc/passwd')).toBe('passwd');
+    expect(sanitizeAttachmentFilename('C:\\Users\\me\\report.pdf')).toBe('report.pdf');
+  });
+
+  it('collapses whitespace padding used to hide extensions', () => {
+    expect(sanitizeAttachmentFilename('Invoice.pdf      .exe')).toBe('Invoice.pdf .exe');
+  });
+
+  it('replaces control characters and illegal chars', () => {
+    expect(sanitizeAttachmentFilename('a\tb\nc.txt')).toBe('a_b_c.txt');
+    expect(sanitizeAttachmentFilename('a<b>c:"d".pdf')).toBe('a_b_c__d_.pdf');
+  });
+
+  it('falls back to a default for empty / dotty names', () => {
+    expect(sanitizeAttachmentFilename('')).toBe('attachment');
+    expect(sanitizeAttachmentFilename('..')).toBe('attachment');
+    expect(sanitizeAttachmentFilename(null)).toBe('attachment');
+  });
+
+  it('caps overlong names while preserving the extension', () => {
+    const long = `${'a'.repeat(500)}.pdf`;
+    const out = sanitizeAttachmentFilename(long);
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out.endsWith('.pdf')).toBe(true);
+  });
+});
+
+describe('mimeFileFilter', () => {
+  const filter = mimeFileFilter(['application/pdf', 'image/png'], { label: 'attachment' });
+
+  it('accepts a whitelisted MIME type', () => {
+    const cb = vi.fn();
+    filter({}, { mimetype: 'application/pdf' }, cb);
+    expect(cb).toHaveBeenCalledWith(null, true);
+  });
+
+  it('rejects a non-whitelisted MIME type with a 400 error', () => {
+    const cb = vi.fn();
+    filter({}, { mimetype: 'application/x-msdownload' }, cb);
+    const [err, accepted] = cb.mock.calls[0];
+    expect(accepted).toBeUndefined();
+    expect(err.status).toBe(400);
+    expect(err.message).toMatch(/Unsupported attachment type/);
+  });
+});

--- a/backend/src/routes/email.js
+++ b/backend/src/routes/email.js
@@ -9,18 +9,37 @@ import { requirePrivilege } from '../middleware/requirePrivilege.js';
 import { requireAuth } from '../middleware/auth.js';
 import { requireFeature } from '../middleware/requireFeature.js';
 import { resolveTokens, fmtDate } from '../utils/emailTokens.js';
+import {
+  sanitizeAttachmentFilename,
+  mimeFileFilter,
+  ATTACHMENT_MIME_TYPES,
+} from '../utils/uploads.js';
 
 const router = Router();
 router.use(requireAuth);
 router.use(requireFeature('email'));
-const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 20 * 1024 * 1024 } });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 20 * 1024 * 1024, files: 20 },
+  fileFilter: mimeFileFilter(ATTACHMENT_MIME_TYPES, { label: 'attachment' }),
+});
 
 // Configure SendGrid (noop if no key — unit tests mock before this runs)
 if (process.env.SENDGRID_API_KEY) {
   sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 }
 
-const FROM_ADDRESS = 'noreply@u3abeacon.org.uk';
+// Envelope sender for all outbound mail. Must be an address whose domain is
+// SPF/DKIM-authorised for the deploying u3a; configurable so deployments under
+// other domains don't fail authentication silently. Falls back to the shared
+// RECOVERY_FROM_ADDRESS used by the auth/portal mailers so a deployment can set
+// a single sender address.
+const FROM_ADDRESS =
+  process.env.EMAIL_FROM_ADDRESS || process.env.RECOVERY_FROM_ADDRESS || 'noreply@u3abeacon.org.uk';
+
+// Cap the number of per-recipient SendGrid status lookups a single refresh
+// click may trigger, bounding the outbound-API amplification.
+const MAX_REFRESH_LOOKUPS = 100;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -99,6 +118,59 @@ async function fetchMembersForEmail(tenantSlug, memberIds) {
 async function getTenantDisplayName(tenantSlug) {
   const tenant = await prisma.sysTenant.findUnique({ where: { slug: tenantSlug } });
   return tenant?.name || tenantSlug;
+}
+
+/**
+ * Resolve the email addresses a user is allowed to send "from" / reply-to:
+ * their own member email plus any office emails they hold, falling back to
+ * their user-account email. This is the single source of truth shared by the
+ * GET /from-addresses endpoint and the From/Reply-To allow-list on send.
+ * @returns {Promise<Array<{ label: string, email: string }>>}
+ */
+async function getUserFromAddresses(tenantSlug, userId, userName) {
+  const userRows = await tenantQuery(
+    tenantSlug,
+    `SELECT member_id, name FROM users WHERE id = $1`,
+    [userId],
+  );
+  const user = userRows[0];
+  const addresses = [];
+
+  if (user?.member_id) {
+    const memberRows = await tenantQuery(
+      tenantSlug,
+      `SELECT email, forenames, surname FROM members WHERE id = $1`,
+      [user.member_id],
+    );
+    if (memberRows[0]?.email) {
+      const m = memberRows[0];
+      addresses.push({ label: `${m.forenames} ${m.surname} <${m.email}>`, email: m.email });
+    }
+    const officeRows = await tenantQuery(
+      tenantSlug,
+      `SELECT name, office_email FROM offices
+       WHERE member_id = $1 AND office_email IS NOT NULL AND office_email != ''`,
+      [user.member_id],
+    );
+    for (const o of officeRows) {
+      addresses.push({ label: `${o.name} <${o.office_email}>`, email: o.office_email });
+    }
+  }
+
+  // Fallback: if no member linked, use the user's account email.
+  if (addresses.length === 0) {
+    const emailRows = await tenantQuery(tenantSlug, `SELECT email FROM users WHERE id = $1`, [
+      userId,
+    ]);
+    if (emailRows[0]?.email) {
+      addresses.push({
+        label: `${user?.name ?? userName ?? ''} <${emailRows[0].email}>`,
+        email: emailRows[0].email,
+      });
+    }
+  }
+
+  return addresses;
 }
 
 /**
@@ -207,54 +279,11 @@ router.delete(
 // GET /email/from-addresses  — member email + any office emails the user holds
 router.get('/from-addresses', requirePrivilege('email', 'send'), async (req, res, next) => {
   try {
-    const userId = req.user.userId;
-    // Get the user record to find their linked member_id
-    const userRows = await tenantQuery(
+    const addresses = await getUserFromAddresses(
       req.user.tenantSlug,
-      `SELECT member_id, name FROM users WHERE id = $1`,
-      [userId],
+      req.user.userId,
+      req.user.name,
     );
-    const user = userRows[0];
-    const addresses = [];
-
-    if (user?.member_id) {
-      const memberRows = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT email, forenames, surname FROM members WHERE id = $1`,
-        [user.member_id],
-      );
-      if (memberRows[0]?.email) {
-        const m = memberRows[0];
-        addresses.push({ label: `${m.forenames} ${m.surname} <${m.email}>`, email: m.email });
-      }
-      // Office emails for this member
-      const officeRows = await tenantQuery(
-        req.user.tenantSlug,
-        `
-        SELECT name, office_email FROM offices WHERE member_id = $1 AND office_email IS NOT NULL AND office_email != ''
-      `,
-        [user.member_id],
-      );
-      for (const o of officeRows) {
-        addresses.push({ label: `${o.name} <${o.office_email}>`, email: o.office_email });
-      }
-    }
-
-    // Fallback: if no member linked, use user's email from users table
-    if (addresses.length === 0) {
-      const emailRows = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT email FROM users WHERE id = $1`,
-        [userId],
-      );
-      if (emailRows[0]?.email) {
-        addresses.push({
-          label: `${user?.name ?? ''} <${emailRows[0].email}>`,
-          email: emailRows[0].email,
-        });
-      }
-    }
-
     res.json(addresses);
   } catch (err) {
     next(err);
@@ -297,6 +326,20 @@ router.post(
     const { memberIds, subject, body, fromEmail, replyTo, copyToSelf, giftAidDates } = parsed.data;
 
     try {
+      // Constrain From / Reply-To to addresses the user actually holds, so a
+      // user with email:send can't impersonate an officer or arbitrary address.
+      const allowedAddresses = await getUserFromAddresses(
+        req.user.tenantSlug,
+        req.user.userId,
+        req.user.name,
+      );
+      const allowedSet = new Set(allowedAddresses.map((a) => a.email.toLowerCase()));
+      if (!allowedSet.has(fromEmail.toLowerCase()) || !allowedSet.has(replyTo.toLowerCase())) {
+        return res
+          .status(403)
+          .json({ error: 'From / Reply-To address is not one of your permitted addresses.' });
+      }
+
       const [members, u3aName] = await Promise.all([
         fetchMembersForEmail(req.user.tenantSlug, memberIds),
         getTenantDisplayName(req.user.tenantSlug),
@@ -333,10 +376,12 @@ router.post(
         return res.status(400).json({ error: 'No recipients have a valid email address' });
       }
 
-      // Build attachments array for SendGrid
+      // Build attachments array for SendGrid (filenames sanitised to a safe
+      // basename — strip path/control chars so recipients can't be sent a
+      // file with an attacker-crafted name).
       const attachments = (req.files || []).map((f) => ({
         content: f.buffer.toString('base64'),
-        filename: f.originalname,
+        filename: sanitizeAttachmentFilename(f.originalname),
         type: f.mimetype,
         disposition: 'attachment',
       }));
@@ -578,8 +623,12 @@ router.post(
         [req.params.batchId],
       );
 
-      // Query SendGrid Activity Feed API for each message ID that we have
-      const withMsgId = recipients.filter((r) => r.sendgrid_message_id);
+      // Query SendGrid Activity Feed API for each message ID that we have,
+      // capped so a single refresh click can't fan out into unbounded
+      // outbound API calls on a large batch.
+      const withMsgId = recipients
+        .filter((r) => r.sendgrid_message_id)
+        .slice(0, MAX_REFRESH_LOOKUPS);
       let updated = 0;
 
       for (const r of withMsgId) {

--- a/backend/src/routes/members.js
+++ b/backend/src/routes/members.js
@@ -13,6 +13,7 @@ import { sanitizeCell } from '../utils/spreadsheet.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { isFeatureEnabled, requireFeature } from '../middleware/requireFeature.js';
 import { logAudit } from '../utils/audit.js';
+import { decodeAndValidateImage } from '../utils/uploads.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -1815,8 +1816,11 @@ router.post(
       const memberId = req.params.id;
       const { data, mimeType } = photoUploadSchema.parse(req.body);
 
+      // Validate the real content matches the declared image type (magic bytes)
+      const buffer = decodeAndValidateImage(data, mimeType);
+
       // Validate decoded size
-      const byteLength = Buffer.from(data, 'base64').length;
+      const byteLength = buffer.length;
       if (byteLength > MAX_PHOTO_BYTES) {
         throw AppError(
           `Photo exceeds the 2 MB limit (${(byteLength / 1024 / 1024).toFixed(1)} MB).`,

--- a/backend/src/routes/portal.js
+++ b/backend/src/routes/portal.js
@@ -14,6 +14,7 @@ import { resolveTokens } from '../utils/emailTokens.js';
 import { isFeatureEnabled } from '../middleware/requireFeature.js';
 import { logAudit } from '../utils/audit.js';
 import { generateSingleCardPdf } from './membershipCards.js';
+import { decodeAndValidateImage } from '../utils/uploads.js';
 
 const router = Router({ mergeParams: true });
 
@@ -879,7 +880,10 @@ router.post('/photo', async (req, res, next) => {
 
     const { data, mimeType } = portalPhotoUploadSchema.parse(req.body);
 
-    const byteLength = Buffer.from(data, 'base64').length;
+    // Validate the real content matches the declared image type (magic bytes)
+    const buffer = decodeAndValidateImage(data, mimeType);
+
+    const byteLength = buffer.length;
     if (byteLength > MAX_PHOTO_BYTES) {
       return res.status(400).json({
         error: `Photo exceeds the 2 MB limit (${(byteLength / 1024 / 1024).toFixed(1)} MB).`,

--- a/backend/src/routes/system.js
+++ b/backend/src/routes/system.js
@@ -21,6 +21,8 @@ import {
 import { syncDefaultRolePrivileges } from '../utils/migrate.js';
 import { logAudit } from '../utils/audit.js';
 import { ALL_FEATURE_KEYS } from '../../../shared/constants.js';
+import { mimeFileFilter, SPREADSHEET_MIME_TYPES } from '../utils/uploads.js';
+import { purgeTenantInvalidations } from '../utils/redis.js';
 import ExcelJS from 'exceljs';
 
 const router = Router();
@@ -222,7 +224,11 @@ router.patch('/settings', async (req, res, next) => {
 // Restore a full tenant backup (Beacon2 or Beacon legacy format).
 // System-admin only (requireSysAdmin already applied above).
 
-const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 50 * 1024 * 1024 } });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 50 * 1024 * 1024, files: 1 },
+  fileFilter: mimeFileFilter(SPREADSHEET_MIME_TYPES, { label: 'backup file' }),
+});
 
 router.post('/restore/:tenantSlug', upload.single('backup'), async (req, res, next) => {
   try {
@@ -270,6 +276,11 @@ router.post('/restore/:tenantSlug', upload.single('backup'), async (req, res, ne
     // Beacon export has no privileges sheet — roles are created but empty.
     // For Beacon2 restores it fills any gaps from backups predating new resources.
     await syncDefaultRolePrivileges(tenantSlug);
+
+    // The old user set has been deleted, so any leftover session-invalidation
+    // marks for this tenant (31-day TTL) would otherwise make freshly-restored
+    // users' future sessions appear pre-revoked. Purge them.
+    await purgeTenantInvalidations(tenantSlug);
 
     const msg =
       format === 'beacon'

--- a/backend/src/utils/redis.js
+++ b/backend/src/utils/redis.js
@@ -59,3 +59,20 @@ export async function isSessionInvalidated(tenantSlug, userId, tokenIssuedAt) {
   const invalidatedAt = parseInt(value, 10);
   return tokenIssuedAt * 1000 < invalidatedAt;
 }
+
+// Remove every session-invalidation mark for a tenant. Used after a restore,
+// which deletes and re-creates the tenant's users — stale marks (31-day TTL)
+// would otherwise make the new users' sessions appear pre-revoked.
+export async function purgeTenantInvalidations(tenantSlug) {
+  if (!client) return;
+  const pattern = `invalidated:${tenantSlug}:*`;
+  // SCAN avoids blocking Redis on large keyspaces (unlike KEYS).
+  for await (const key of client.scanIterator({ MATCH: pattern, COUNT: 100 })) {
+    // node-redis v4 yields a string per key (v5 may batch into arrays).
+    if (Array.isArray(key)) {
+      if (key.length) await client.del(key);
+    } else {
+      await client.del(key);
+    }
+  }
+}

--- a/backend/src/utils/uploads.js
+++ b/backend/src/utils/uploads.js
@@ -1,0 +1,160 @@
+// beacon2/backend/src/utils/uploads.js
+// Shared helpers for hardening uploads: magic-byte sniffing for member photos,
+// attachment-filename sanitisation, and MIME whitelists for the multer-handled
+// uploads (tenant restore and email attachments). Keeping these in one place
+// means the member and portal photo routes validate identically.
+
+import { AppError } from '../middleware/errorHandler.js';
+
+// ─── Image magic-byte sniffing ──────────────────────────────────────────────
+
+// The photo endpoints accept only these three formats, so a small hand-rolled
+// signature check is enough and avoids pulling in a third-party dependency.
+export const IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif'];
+
+/**
+ * Sniff the real image type from the leading bytes of a buffer.
+ * Returns the canonical MIME string, or null if it is not a JPEG/PNG/GIF.
+ * @param {Buffer} buffer
+ * @returns {'image/jpeg'|'image/png'|'image/gif'|null}
+ */
+export function sniffImageMime(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 4) return null;
+
+  // JPEG: FF D8 FF
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return 'image/jpeg';
+
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return 'image/png';
+  }
+
+  // GIF: "GIF87a" or "GIF89a"
+  if (
+    buffer[0] === 0x47 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x38 &&
+    (buffer[4] === 0x37 || buffer[4] === 0x39) &&
+    buffer[5] === 0x61
+  ) {
+    return 'image/gif';
+  }
+
+  return null;
+}
+
+/**
+ * Decode a base64 photo payload and confirm its real content matches the
+ * declared MIME type. Throws a 400 AppError on mismatch. Returns the decoded
+ * buffer so callers can reuse it (e.g. for a size check).
+ * @param {string} base64Data
+ * @param {string} declaredMime
+ * @returns {Buffer}
+ */
+export function decodeAndValidateImage(base64Data, declaredMime) {
+  const buffer = Buffer.from(base64Data, 'base64');
+  const sniffed = sniffImageMime(buffer);
+  if (!sniffed || sniffed !== declaredMime) {
+    throw AppError('Photo content does not match its declared image type.', 400);
+  }
+  return buffer;
+}
+
+// ─── Attachment filename sanitisation ───────────────────────────────────────
+
+const MAX_FILENAME_LENGTH = 200;
+
+// Control chars (0x00-0x1f, 0x7f) plus characters illegal in filenames or
+// unsafe in MIME headers.
+// eslint-disable-next-line no-control-regex
+const UNSAFE_FILENAME_CHARS = /[\u0000-\u001f\u007f<>:"/\\|?*]/g;
+
+/**
+ * Sanitise a user-supplied attachment filename: reduce to a basename, strip
+ * control characters and characters illegal in filenames / MIME headers,
+ * collapse whitespace padding ("Invoice.pdf      .exe"), and cap the length.
+ * @param {string} name
+ * @returns {string}
+ */
+export function sanitizeAttachmentFilename(name) {
+  const fallback = 'attachment';
+  if (typeof name !== 'string' || name.length === 0) return fallback;
+
+  // Drop any path components (both POSIX and Windows separators).
+  let base = name.split(/[/\\]/).pop() || fallback;
+
+  base = base.replace(UNSAFE_FILENAME_CHARS, '_');
+
+  // Collapse runs of whitespace and trim the edges.
+  base = base.replace(/\s+/g, ' ').trim();
+
+  if (base.length === 0 || base === '.' || base === '..') return fallback;
+
+  if (base.length > MAX_FILENAME_LENGTH) {
+    const dot = base.lastIndexOf('.');
+    const ext = dot > 0 && base.length - dot <= 10 ? base.slice(dot) : '';
+    base = base.slice(0, MAX_FILENAME_LENGTH - ext.length) + ext;
+  }
+
+  return base;
+}
+
+// ─── Multer MIME whitelists ─────────────────────────────────────────────────
+
+// Spreadsheet types accepted by the tenant restore endpoint. Some browsers
+// label .xlsx uploads as octet-stream, so the filter also falls back to the
+// file extension; the workbook parser rejects anything that is not real xlsx.
+export const SPREADSHEET_MIME_TYPES = [
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel',
+  'application/octet-stream',
+];
+
+// Common, safe attachment types for outbound email. Executables, scripts and
+// other risky types are rejected before they reach SendGrid.
+export const ATTACHMENT_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'text/plain',
+  'text/csv',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/vnd.oasis.opendocument.text',
+  'application/vnd.oasis.opendocument.spreadsheet',
+  'application/zip',
+];
+
+/**
+ * Build a multer fileFilter that accepts only the supplied MIME types. The
+ * rejection is surfaced as a 400 AppError via the express error handler.
+ * @param {string[]} allowed
+ * @param {{ label?: string }} [opts]
+ */
+export function mimeFileFilter(allowed, { label = 'file' } = {}) {
+  const set = new Set(allowed);
+  return (req, file, cb) => {
+    if (set.has(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(AppError(`Unsupported ${label} type: ${file.mimetype}`, 400));
+    }
+  };
+}

--- a/docs/ImprovementPlan.md
+++ b/docs/ImprovementPlan.md
@@ -213,13 +213,30 @@ gate CI.
   rate limiter; base the refresh-origin check on `CORS_ORIGIN` presence rather
   than `NODE_ENV`.
 
-### Chunk 5 — Security: email & uploads (S9, S10, S13)
+### Chunk 5 — Security: email & uploads (S9, S10, S13) ✅ Done (2026-06-12)
 - Sanitise attachment filenames; constrain `replyTo` to the sender's own
   addresses; wire or remove `fromEmail`; make `FROM_ADDRESS` env-configurable;
   cap per-click SendGrid status refresh.
 - Magic-byte validation (`file-type`) on photo uploads; MIME whitelist on
   `/system/restore` and `/email/send` multer configs.
 - Purge tenant Redis invalidation keys in `clearTenantData()`.
+
+**Notes:** new shared helper `backend/src/utils/uploads.js` holds the image
+magic-byte sniffer (`decodeAndValidateImage` — hand-rolled jpeg/png/gif check,
+no `file-type` dependency added), `sanitizeAttachmentFilename`, and a reusable
+`mimeFileFilter` plus the spreadsheet/attachment MIME whitelists. Both photo
+routes (`members.js`, `portal.js`) validate magic bytes; `/system/restore` and
+`/email/send` multer configs whitelist MIME and cap file counts. In `email.js`,
+`fromEmail` **and** `replyTo` are validated against the user's own permitted
+addresses via the extracted `getUserFromAddresses()` helper (shared with
+`/from-addresses`), `FROM_ADDRESS` reads `EMAIL_FROM_ADDRESS` →
+`RECOVERY_FROM_ADDRESS` → default, and the delivery refresh is capped at 100
+lookups per click. The restore route purges tenant Redis invalidation marks
+via the new `purgeTenantInvalidations()`. KI #23 (bodyHtml on portal/public
+templated emails) remains `[OPEN]` — it is latent until SendGrid is wired for
+those flows, so there is nothing to change yet. New unit tests:
+`__tests__/uploads.test.js`; magic-byte mismatch case added to
+`members.test.js`.
 
 ### Chunk 6 — Backend consistency (N1–N3, N6, C5, C6)
 - Extract the shared WHERE-builder helper used by calendar/members/


### PR DESCRIPTION
Implements **Chunk 5** of `docs/ImprovementPlan.md` — Security: email & uploads (findings S9, S10, S13).

## Changes

**New shared helper — `backend/src/utils/uploads.js`**
- `decodeAndValidateImage()` / `sniffImageMime()` — hand-rolled jpeg/png/gif magic-byte check (no `file-type` dependency added)
- `sanitizeAttachmentFilename()` — basename only, control/illegal chars stripped, whitespace padding collapsed, length capped
- `mimeFileFilter()` + `SPREADSHEET_MIME_TYPES` / `ATTACHMENT_MIME_TYPES` whitelists

**Uploads (S10)**
- Member and portal photo routes validate that file content matches the declared image type before storing
- `/email/send` and `/system/restore` multer configs whitelist MIME types and cap file counts

**Email (S9)**
- Attachment filenames sanitised before reaching SendGrid
- `fromEmail` **and** `replyTo` constrained to the sender's own permitted addresses (extracted `getUserFromAddresses()`, shared with `/from-addresses`); out-of-set values rejected with 403
- Broadcast sender configurable via `EMAIL_FROM_ADDRESS` (falls back to `RECOVERY_FROM_ADDRESS`, then the original default)
- Delivery-status refresh capped at 100 per-recipient lookups per click

**Restore (S13)**
- Restore route purges the tenant's Redis session-invalidation marks via new `purgeTenantInvalidations()` (SCAN + DEL), so freshly-restored users' sessions are no longer treated as pre-revoked

## Tests
- New `backend/src/__tests__/uploads.test.js` (helper unit coverage)
- Magic-byte mismatch case added to `members.test.js`
- Full backend suite green (37 files, 483 tests); lint and format clean

## Docs
- `KNOWN-ISSUES.md` — #12, #15–#22 marked `[RESOLVED 2026-06-12]`
- `docs/ImprovementPlan.md` — Chunk 5 marked ✅ with implementation notes
- `CHANGELOG.md` — Security/Added entries
- `backend/.env.example` — documents `EMAIL_FROM_ADDRESS`

KI #23 (bodyHtml on portal/public templated emails) is left `[OPEN]` — it is latent until SendGrid is wired for those flows, so there is nothing concrete to change yet. The real broadcast sender (`/email/send`) already uses the escaped `bodyHtml`.

https://claude.ai/code/session_01Ds9c9yqBhAeywWn3czSc8o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds9c9yqBhAeywWn3czSc8o)_