### PR TITLE
Chunk 6: backend consistency + KNOWN-ISSUES cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,37 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
     freshly-restored users' sessions are no longer treated as pre-revoked.
 
 ### Added
+- **Shared event-filter builders `backend/src/utils/eventFilters.js`**
+  (ImprovementPlan Chunk 6, findings N1/N3) — `buildCalendarEventFilters()` and
+  `buildPortalCalendarFilters()` replace five byte-identical inline WHERE-clause
+  blocks across `calendar.js` (events / pdf / excel) and `portal.js`
+  (calendar / pdf). Both validate the query string with Zod, so a malformed
+  `from`/`to` now returns **422** at the edge instead of **500**-ing on the
+  Postgres `::date` cast. Unit coverage in `__tests__/eventFilters.test.js`.
+- **Audit logging on groups and teams (ImprovementPlan Chunk 6, finding C6)** —
+  the group and team create/update/delete handlers now write `logAudit()`
+  entries, matching members/finance.
 - **Upload-hardening helper `backend/src/utils/uploads.js`** (ImprovementPlan
   Chunk 5) — shared image magic-byte sniffer, attachment-filename sanitiser,
   and a reusable multer MIME `fileFilter` with spreadsheet/attachment
   whitelists, with unit coverage in `__tests__/uploads.test.js`.
+
+### Changed
+- **Backend consistency cleanup (ImprovementPlan Chunk 6, findings N2/N6)** —
+  documented a single response-shape + status-code convention in
+  `CLAUDE-STANDARDS.md` (`{ error }` for all error bodies via `AppError`;
+  `{ message }` only for action-only successes; 201 create / 200 fetch+update).
+  Replaced the lone bare `throw new Error` in `membershipCards.js` with
+  `AppError(…, 404)`, and hoisted scattered pagination limits to named constants
+  (`EVENT_SEARCH_DEFAULT_LIMIT`/`EVENT_SEARCH_MAX_LIMIT` in `calendar.js`,
+  `CONSENT_HISTORY_MAX_ROWS` in `giftAid.js`).
+
+### Fixed
+- **Duplicated security findings in `KNOWN-ISSUES.md`** — the Chunk 4 and Chunk 5
+  edits had appended a second copy of findings #8–#22, leaving two contradictory
+  blocks (each showing only one chunk's fixes). Consolidated back to a single,
+  consistent 1–26 list with correct status tags, and normalised the non-standard
+  `[RESOLVED]` tag to `[FIXED]`.
 - **Shared password policy & temp-password generator (ImprovementPlan Chunk 4)** —
   new `backend/src/utils/passwordPolicy.js` exports `passwordSchema` (10–72
   chars, at least one upper, lower, and digit) and a `crypto.randomInt`-based

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -1346,6 +1346,14 @@ to the default event type.
 
 ### Key decisions
 
+- **Shared event-filter builders** — `backend/src/utils/eventFilters.js` exports
+  `buildCalendarEventFilters(query)` (used by all three `calendar.js` event
+  endpoints: list / pdf / excel) and `buildPortalCalendarFilters(query, memberId)`
+  (used by both `portal.js` calendar endpoints: view / pdf). Each returns
+  `{ where, params }` and validates the query string with Zod, so a malformed
+  `from`/`to` returns 422 at the edge rather than 500-ing on the `::date` cast.
+  Note the PDF/Excel handlers still read `req.query.from`/`to` separately, purely
+  for the report's title label. Added in ImprovementPlan Chunk 6 (N1, N3).
 - **Non-group events** share the `group_events` table (nullable `group_id`) rather than a separate table
 - **Event types** are a single flexible system — no per-type privileges
 - **Calendar "Other" mode** embeds event management inline rather than a separate page

--- a/CLAUDE-STANDARDS.md
+++ b/CLAUDE-STANDARDS.md
@@ -261,6 +261,23 @@ Every item below applies to every new feature — no exceptions.
   from `backend/src/utils/audit.js` for create/update/delete operations. `logAudit`
   never throws, so no try/catch needed around it.
 
+- [ ] **Response shape and status codes** — adopt one convention consistently:
+
+  | Outcome | Status | Body |
+  |---------|--------|------|
+  | Resource created | **201** | the created resource object (e.g. `res.status(201).json(group)`) |
+  | Resource fetched / updated | **200** | the resource object (or an array for a list) |
+  | Action with no resource to return (delete, bulk op) | **200** | `{ message: '…' }` |
+  | Client error (validation, not found, forbidden) | 4xx | `{ error: '…' }` — always via `throw AppError(msg, status)` so the central `errorHandler` formats it |
+  | Zod body/query validation failure | 422 | `{ error: 'Validation error', issues: [...] }` (handled centrally) |
+
+  Use `{ error }` (singular) for **all** error bodies — never `{ message }` for an
+  error, and never a bare string. Reserve `{ message }` for *successful*
+  action-only responses. Never hand-roll an error status with `res.status(4xx)`
+  when `AppError` will do; the existing inline `res.status(400).json({ error })`
+  guards (e.g. "Nothing to update.") are acceptable but `AppError` is preferred
+  for new code.
+
 ## List pages
 
 - [ ] **Sortable columns** — use `useSortedData` hook + `SortableHeader` component.

--- a/CODEBASE-RECOMMENDATIONS.md
+++ b/CODEBASE-RECOMMENDATIONS.md
@@ -222,14 +222,15 @@ Implemented in v0.9.3 for the 6 low-risk routes (69 new tests):
 
 ## Other observations (not recommendations, informational)
 
-- **Audit logging inconsistency** — `groups.js` and `teams.js` don't call `logAudit()`
-  on create/update/delete, while `members.js` and `finance.js` do. Consider adding
-  audit logging to groups/teams operations.
-- **settings.js uses Prisma directly** while all other routes use raw SQL via
-  `tenantQuery`. Minor inconsistency but not urgent.
+- **Audit logging inconsistency** — ✅ Resolved (ImprovementPlan Chunk 6, 2026-06-12).
+  `groups.js` and `teams.js` now call `logAudit()` on entity create/update/delete,
+  matching `members.js` / `finance.js`.
+- **settings.js uses Prisma directly** — ✅ Reviewed, no change needed (Chunk 6).
+  The Prisma calls read the **public** schema (`sys_tenants.name`, `sys_settings`),
+  which `tenantQuery()` (tenant-schema only) cannot reach. The remaining settings
+  queries already use `tenantQuery`. Not an inconsistency to fix.
 - **Home.jsx** (16K), **Login.jsx** (11K), **ChangePassword.jsx** sit at the pages
   root rather than in a subdirectory. Could move to `pages/auth/` but low priority.
-- **`eventAttendance` missing from `FEATURE_DEPS`** — `FeatureConfig.jsx` shows it
-  depends on `events`, but it's not in the shared `FEATURE_DEPS` map. The backend
-  `requireFeature` middleware won't check the parent. May be intentional (if the
-  middleware is never called with `eventAttendance`) or a bug worth investigating.
+- **`eventAttendance` missing from `FEATURE_DEPS`** — ✅ Resolved. `eventAttendance: 'events'`
+  is present in `shared/constants.js` `FEATURE_DEPS` (verified Chunk 6, 2026-06-12);
+  the dependency is enforced by `requireFeature`.

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -51,65 +51,6 @@ These are catalogued and re-verified in `docs/ImprovementPlan.md` (Chunks 4–5)
 7. `[OPEN]` **Privilege-string format collisions** — `${resource}:${action}` with
    resources that may contain `:` (`finance:transactions:create`). Works
    today, fragile if a future resource code includes `:create`.
-8. `[OPEN]` **No targeted rate limit on portal endpoints** (`app.js:69-71`). Only
-   the global 300/15min/IP `generalLimiter` covers `/public/:slug/portal/*`;
-   `/auth/*` has a tighter `authLimiter`. Add a 20/15min/IP limiter per
-   portal-register/login/forgot/reset/verify-email route.
-9. `[OPEN]` **Portal JWT skips Redis session-invalidation check**
-   (`routes/portal.js:22`). Disabling a member's portal credentials does
-   not take effect until the 15-min access token expires.
-10. `[OPEN]` **Verification tokens still logged via `console.log`**
-    (`routes/public.js:804` portal register-verify, `routes/portal.js:699`
-    portal email-change verify). The forgot-password leak was fixed
-    2026-06-10; these two remain. Either wire SendGrid or refuse the
-    request when email is not configured — don't persist the token and
-    emit it to stdout.
-11. `[OPEN]` **Slug regex inconsistency** — `routes/public.js:24` allows
-    `[a-z0-9_-]` but `utils/db.js:27` only allows `[a-z0-9_]`. A slug
-    containing `-` 500s inside `tenantQuery` rather than 400-ing at the
-    edge. Unify both regexes.
-12. `[RESOLVED 2026-06-12]` **Photo upload doesn't validate magic bytes** —
-    `routes/portal.js`. Fixed in ImprovementPlan Chunk 5: both photo routes now
-    call `decodeAndValidateImage()` (`utils/uploads.js`), which sniffs the
-    leading bytes and rejects a payload whose content doesn't match its
-    declared jpeg/png/gif type. (See also #15.)
-13. `[OPEN]` **Portal login email-enumeration via differentiated responses** —
-    `routes/public.js:887,891`. 401 for unknown/wrong-password but 403
-    "Please verify your email" for known-unverified accounts reveals
-    which emails have a portal account.
-14. `[OPEN]` **`/portal/forgot-password` timing enumeration** —
-    `routes/public.js:922`. Bcrypt + DB write happen only on hit;
-    response time leaks account existence.
-15. `[RESOLVED 2026-06-12]` **No magic-byte validation on photo uploads**
-    (`routes/members.js`, `routes/portal.js`). Fixed in ImprovementPlan
-    Chunk 5 — see #12.
-16. `[RESOLVED 2026-06-12]` **Email-attachment `originalname` passed through
-    unsanitised** (`routes/email.js`). Fixed in Chunk 5: attachments are run
-    through `sanitizeAttachmentFilename()` (basename only, control/illegal
-    chars stripped, whitespace padding collapsed, length capped).
-17. `[RESOLVED 2026-06-12]` **`clearTenantData()` doesn't purge Redis
-    invalidation marks** (`routes/backup.js`). Fixed in Chunk 5: the restore
-    route calls `purgeTenantInvalidations(tenantSlug)` (`utils/redis.js`, SCAN
-    + DEL) after a successful restore, clearing stale
-    `invalidated:slug:userId` keys.
-18. `[RESOLVED 2026-06-12]` **Multer accepts any MIME type on `/system/restore`
-    and `/email/send`** (`routes/system.js`, `routes/email.js`). Fixed in
-    Chunk 5: both multer configs now use `mimeFileFilter()` (spreadsheet
-    whitelist for restore, safe-attachment whitelist for email) plus explicit
-    `files` count limits.
-19. `[RESOLVED 2026-06-12]` **`/email/send` `fromEmail` field is declared but
-    ignored** (`routes/email.js`). Fixed in Chunk 5: `fromEmail` and `replyTo`
-    are now validated against the user's own permitted addresses
-    (`getUserFromAddresses()`, the same source as `/email/from-addresses`);
-    a value outside that set is rejected with 403.
-20. `[RESOLVED 2026-06-12]` **`/email/send` `replyTo` is unconstrained**
-    (`routes/email.js`). Fixed in Chunk 5 — see #19.
-21. `[RESOLVED 2026-06-12]` **`/email/delivery/:batchId/refresh` issues one
-    SendGrid API call per recipient** (`routes/email.js`). Fixed in Chunk 5:
-    the per-click lookup count is capped at `MAX_REFRESH_LOOKUPS` (100).
-22. `[RESOLVED 2026-06-12]` **Hard-coded `FROM_ADDRESS`** (`routes/email.js`).
-    Fixed in Chunk 5: the broadcast sender now reads `EMAIL_FROM_ADDRESS`
-    (falling back to `RECOVERY_FROM_ADDRESS`, then the original default).
 8. `[FIXED]` **No targeted rate limit on portal endpoints**. A dedicated
    `portalAuthLimiter` (20/15 min/IP, env `PORTAL_AUTH_RATE_LIMIT_MAX`) now
    guards `register`, `login`, `forgot-password`, `reset-password`, and
@@ -125,10 +66,11 @@ These are catalogued and re-verified in `docs/ImprovementPlan.md` (Chunks 4–5)
 11. `[FIXED]` **Slug regex inconsistency**. `routes/public.js` `resolveTenant`
     now uses `[a-z0-9_]+`, identical to `utils/db.js`, so a `-`-containing slug
     400s at the edge instead of 500-ing in `tenantQuery`. (Chunk 4, 2026-06-12.)
-12. `[OPEN]` **Photo upload doesn't validate magic bytes** —
-    `routes/portal.js:726`. Mime-type is whitelisted to jpeg/png/gif and
-    Helmet's nosniff blocks browser sniffing, so no XSS — but mislabelled
-    payloads silently succeed and may break PDF rendering downstream.
+12. `[FIXED]` **Photo upload doesn't validate magic bytes** —
+    `routes/portal.js`. Fixed in ImprovementPlan Chunk 5: both photo routes now
+    call `decodeAndValidateImage()` (`utils/uploads.js`), which sniffs the
+    leading bytes and rejects a payload whose content doesn't match its
+    declared jpeg/png/gif type. (See also #15.)
 13. `[ACCEPTED]` **Portal login "verify your email" differentiated response** —
     `routes/public.js`. The 403 "Please verify your email" branch is only
     reachable *after* a correct password match, so it does not enable
@@ -142,33 +84,36 @@ These are catalogued and re-verified in `docs/ImprovementPlan.md` (Chunks 4–5)
     `routes/public.js`. The reset email is now fire-and-forget, so the
     matched-account response no longer waits on email delivery. (Chunk 4,
     2026-06-12.)
-15. `[OPEN]` **No magic-byte validation on photo uploads**
-    (`routes/members.js:1494`, `routes/portal.js:726`). Mime-type is
-    whitelisted; nosniff blocks browser XSS. But mislabelled payloads
-    silently succeed and break PDF rendering downstream — DoS vector.
-16. `[OPEN]` **Email-attachment `originalname` passed through unsanitised**
-    (`routes/email.js:267`). Recipients can be sent files with
-    attacker-crafted names (`Invoice.pdf .exe`, control-char headers).
-    Sanitise to a basename, strip control chars, cap length.
-17. `[OPEN]` **`clearTenantData()` doesn't purge Redis invalidation marks**
-    (`routes/backup.js:658`). After restore, stale `invalidated:slug:userId`
-    keys (31-day TTL) may make fresh sessions appear pre-revoked.
-18. `[OPEN]` **Multer accepts any MIME type on `/system/restore` and `/email/send`**
-    (`routes/system.js:201`, `routes/email.js:16`). FileSize caps the
-    only bound; per-request /email/send worst case ≈ 400 MB in memory.
-19. `[OPEN]` **`/email/send` `fromEmail` field is declared but ignored** —
-    `routes/email.js:205,293`. The SendGrid message hard-codes
-    `FROM_ADDRESS`. Either wire it up with an allow-list, or drop the
-    field from the schema.
-20. `[OPEN]` **`/email/send` `replyTo` is unconstrained** — anyone with
-    `email:send` can set it to any address (e.g. impersonating an
-    officer). Limit to the user's own member-email + offices they hold
-    (the same source as `/email/from-addresses`).
-21. `[OPEN]` **`/email/delivery/:batchId/refresh` issues one SendGrid API call
-    per recipient** — `routes/email.js:433`. Cap the per-click amplification.
-22. `[OPEN]` **Hard-coded `FROM_ADDRESS = 'noreply@u3abeacon.org.uk'`** —
-    `routes/email.js:23`. Make env-configurable so deployments under
-    other domains don't fail SPF/DKIM silently.
+15. `[FIXED]` **No magic-byte validation on photo uploads**
+    (`routes/members.js`, `routes/portal.js`). Fixed in ImprovementPlan
+    Chunk 5 — see #12.
+16. `[FIXED]` **Email-attachment `originalname` passed through
+    unsanitised** (`routes/email.js`). Fixed in Chunk 5: attachments are run
+    through `sanitizeAttachmentFilename()` (basename only, control/illegal
+    chars stripped, whitespace padding collapsed, length capped).
+17. `[FIXED]` **`clearTenantData()` doesn't purge Redis
+    invalidation marks** (`routes/backup.js`). Fixed in Chunk 5: the restore
+    route calls `purgeTenantInvalidations(tenantSlug)` (`utils/redis.js`, SCAN
+    + DEL) after a successful restore, clearing stale
+    `invalidated:slug:userId` keys.
+18. `[FIXED]` **Multer accepts any MIME type on `/system/restore`
+    and `/email/send`** (`routes/system.js`, `routes/email.js`). Fixed in
+    Chunk 5: both multer configs now use `mimeFileFilter()` (spreadsheet
+    whitelist for restore, safe-attachment whitelist for email) plus explicit
+    `files` count limits.
+19. `[FIXED]` **`/email/send` `fromEmail` field is declared but
+    ignored** (`routes/email.js`). Fixed in Chunk 5: `fromEmail` and `replyTo`
+    are now validated against the user's own permitted addresses
+    (`getUserFromAddresses()`, the same source as `/email/from-addresses`);
+    a value outside that set is rejected with 403.
+20. `[FIXED]` **`/email/send` `replyTo` is unconstrained**
+    (`routes/email.js`). Fixed in Chunk 5 — see #19.
+21. `[FIXED]` **`/email/delivery/:batchId/refresh` issues one
+    SendGrid API call per recipient** (`routes/email.js`). Fixed in Chunk 5:
+    the per-click lookup count is capped at `MAX_REFRESH_LOOKUPS` (100).
+22. `[FIXED]` **Hard-coded `FROM_ADDRESS`** (`routes/email.js`).
+    Fixed in Chunk 5: the broadcast sender now reads `EMAIL_FROM_ADDRESS`
+    (falling back to `RECOVERY_FROM_ADDRESS`, then the original default).
 23. `[OPEN]` **`routes/public.js` and `routes/portal.js` `resolveTokens` callers
     still use `body` for templated emails** — currently only `console.log`'d
     so latent, but when SendGrid is wired they should also use the new

--- a/backend/src/__tests__/eventFilters.test.js
+++ b/backend/src/__tests__/eventFilters.test.js
@@ -1,0 +1,106 @@
+// beacon2/backend/src/__tests__/eventFilters.test.js
+// Unit tests for the shared calendar/event WHERE-clause builders
+// (ImprovementPlan Chunk 6, N1 + N3). These replaced five duplicated inline
+// filter blocks across calendar.js and portal.js.
+
+import { describe, it, expect } from 'vitest';
+import { buildCalendarEventFilters, buildPortalCalendarFilters } from '../utils/eventFilters.js';
+
+describe('buildCalendarEventFilters', () => {
+  it('returns an empty WHERE clause and no params when nothing is supplied', () => {
+    const { where, params } = buildCalendarEventFilters({});
+    expect(where).toBe('');
+    expect(params).toEqual([]);
+  });
+
+  it('builds date-range conditions with ::date casts and sequential placeholders', () => {
+    const { where, params } = buildCalendarEventFilters({
+      from: '2026-01-01',
+      to: '2026-12-31',
+    });
+    expect(where).toBe('WHERE ge.event_date >= $1::date AND ge.event_date <= $2::date');
+    expect(params).toEqual(['2026-01-01', '2026-12-31']);
+  });
+
+  it('applies venue, group and event-type filters', () => {
+    const { where, params } = buildCalendarEventFilters({
+      venueId: 'v1',
+      groupId: 'g1',
+      eventTypeId: 'et1',
+    });
+    expect(where).toBe('WHERE ge.venue_id = $1 AND ge.group_id = $2 AND ge.event_type_id = $3');
+    expect(params).toEqual(['v1', 'g1', 'et1']);
+  });
+
+  it('uses groupsOnly only when no explicit groupId is given', () => {
+    const both = buildCalendarEventFilters({ groupId: 'g1', groupsOnly: 'true' });
+    expect(both.where).toBe('WHERE ge.group_id = $1');
+    expect(both.params).toEqual(['g1']);
+
+    const onlyFlag = buildCalendarEventFilters({ groupsOnly: 'true' });
+    expect(onlyFlag.where).toBe('WHERE ge.group_id IS NOT NULL');
+    expect(onlyFlag.params).toEqual([]);
+  });
+
+  it('scopes by member via the own-groups-or-open-meeting subquery', () => {
+    const { where, params } = buildCalendarEventFilters({ memberId: 'm1' });
+    expect(where).toContain('ge.group_id IS NULL OR ge.group_id IN');
+    expect(where).toContain('member_id = $1');
+    expect(params).toEqual(['m1']);
+  });
+
+  it('treats empty-string params as absent', () => {
+    const { where, params } = buildCalendarEventFilters({ from: '', to: '', venueId: '' });
+    expect(where).toBe('');
+    expect(params).toEqual([]);
+  });
+
+  it('rejects a malformed date so it 422s at the edge rather than 500-ing in SQL', () => {
+    expect(() => buildCalendarEventFilters({ from: '01/01/2026' })).toThrow();
+    expect(() => buildCalendarEventFilters({ to: 'not-a-date' })).toThrow();
+  });
+});
+
+describe('buildPortalCalendarFilters', () => {
+  it('returns an empty WHERE clause when no filters and filter=all', () => {
+    expect(buildPortalCalendarFilters({}, 'm1').where).toBe('');
+    expect(buildPortalCalendarFilters({ filter: 'all' }, 'm1').where).toBe('');
+  });
+
+  it('filter=own scopes to the member own groups plus open meetings', () => {
+    const { where, params } = buildPortalCalendarFilters({ filter: 'own' }, 'm1');
+    expect(where).toContain('ge.group_id IS NULL OR ge.group_id IN');
+    expect(params).toEqual(['m1']);
+  });
+
+  it('filter=other restricts to non-group events, optionally by event type', () => {
+    const noType = buildPortalCalendarFilters({ filter: 'other' }, 'm1');
+    expect(noType.where).toBe('WHERE ge.group_id IS NULL');
+    expect(noType.params).toEqual([]);
+
+    const withType = buildPortalCalendarFilters({ filter: 'other', eventTypeId: 'et1' }, 'm1');
+    expect(withType.where).toBe('WHERE ge.group_id IS NULL AND ge.event_type_id = $1');
+    expect(withType.params).toEqual(['et1']);
+  });
+
+  it('falls back to a plain groupId filter when no filter mode is set', () => {
+    const { where, params } = buildPortalCalendarFilters({ groupId: 'g1' }, 'm1');
+    expect(where).toBe('WHERE ge.group_id = $1');
+    expect(params).toEqual(['g1']);
+  });
+
+  it('combines a date range with the member scope', () => {
+    const { where, params } = buildPortalCalendarFilters(
+      { from: '2026-01-01', filter: 'own' },
+      'm1',
+    );
+    expect(where).toBe(
+      'WHERE ge.event_date >= $1::date AND (ge.group_id IS NULL OR ge.group_id IN (SELECT group_id FROM group_members WHERE member_id = $2))',
+    );
+    expect(params).toEqual(['2026-01-01', 'm1']);
+  });
+
+  it('rejects an unknown filter value', () => {
+    expect(() => buildPortalCalendarFilters({ filter: 'bogus' }, 'm1')).toThrow();
+  });
+});

--- a/backend/src/routes/calendar.js
+++ b/backend/src/routes/calendar.js
@@ -12,10 +12,15 @@ import { tenantQuery, escapeLike } from '../utils/db.js';
 import { sanitizeCell } from '../utils/spreadsheet.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logAudit } from '../utils/audit.js';
+import { buildCalendarEventFilters } from '../utils/eventFilters.js';
 
 const router = Router();
 router.use(requireAuth);
 router.use(requireFeature('events'));
+
+// Event-search (TransactionEditor event selector) result paging.
+const EVENT_SEARCH_DEFAULT_LIMIT = 20;
+const EVENT_SEARCH_MAX_LIMIT = 50;
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -42,42 +47,7 @@ function fmtTime(t) {
 router.get('/events', requirePrivilege('calendar', 'view'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
-    const { from, to, memberId, venueId, groupId, eventTypeId, groupsOnly } = req.query;
-
-    const conditions = [];
-    const params = [];
-    let i = 1;
-
-    if (from) {
-      conditions.push(`ge.event_date >= $${i++}::date`);
-      params.push(from);
-    }
-    if (to) {
-      conditions.push(`ge.event_date <= $${i++}::date`);
-      params.push(to);
-    }
-    if (venueId) {
-      conditions.push(`ge.venue_id = $${i++}`);
-      params.push(venueId);
-    }
-    if (groupId) {
-      conditions.push(`ge.group_id = $${i++}`);
-      params.push(groupId);
-    } else if (groupsOnly === 'true') {
-      conditions.push(`ge.group_id IS NOT NULL`);
-    }
-    if (eventTypeId) {
-      conditions.push(`ge.event_type_id = $${i++}`);
-      params.push(eventTypeId);
-    }
-    if (memberId) {
-      conditions.push(
-        `(ge.group_id IS NULL OR ge.group_id IN (SELECT group_id FROM group_members WHERE member_id = $${i++}))`,
-      );
-      params.push(memberId);
-    }
-
-    const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
+    const { where, params } = buildCalendarEventFilters(req.query);
 
     const events = await tenantQuery(
       slug,
@@ -106,42 +76,8 @@ router.get('/events', requirePrivilege('calendar', 'view'), async (req, res, nex
 router.get('/events/pdf', requirePrivilege('calendar', 'download'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
-    const { from, to, memberId, venueId, groupId, eventTypeId, groupsOnly } = req.query;
-
-    const conditions = [];
-    const params = [];
-    let i = 1;
-
-    if (from) {
-      conditions.push(`ge.event_date >= $${i++}::date`);
-      params.push(from);
-    }
-    if (to) {
-      conditions.push(`ge.event_date <= $${i++}::date`);
-      params.push(to);
-    }
-    if (venueId) {
-      conditions.push(`ge.venue_id = $${i++}`);
-      params.push(venueId);
-    }
-    if (groupId) {
-      conditions.push(`ge.group_id = $${i++}`);
-      params.push(groupId);
-    } else if (groupsOnly === 'true') {
-      conditions.push(`ge.group_id IS NOT NULL`);
-    }
-    if (eventTypeId) {
-      conditions.push(`ge.event_type_id = $${i++}`);
-      params.push(eventTypeId);
-    }
-    if (memberId) {
-      conditions.push(
-        `(ge.group_id IS NULL OR ge.group_id IN (SELECT group_id FROM group_members WHERE member_id = $${i++}))`,
-      );
-      params.push(memberId);
-    }
-
-    const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
+    const { from, to } = req.query; // retained for the PDF title label
+    const { where, params } = buildCalendarEventFilters(req.query);
 
     const events = await tenantQuery(
       slug,
@@ -251,42 +187,8 @@ router.get('/events/pdf', requirePrivilege('calendar', 'download'), async (req, 
 router.get('/events/excel', requirePrivilege('calendar', 'download'), async (req, res, next) => {
   try {
     const slug = req.user.tenantSlug;
-    const { from, to, memberId, venueId, groupId, eventTypeId, groupsOnly } = req.query;
-
-    const conditions = [];
-    const params = [];
-    let i = 1;
-
-    if (from) {
-      conditions.push(`ge.event_date >= $${i++}::date`);
-      params.push(from);
-    }
-    if (to) {
-      conditions.push(`ge.event_date <= $${i++}::date`);
-      params.push(to);
-    }
-    if (venueId) {
-      conditions.push(`ge.venue_id = $${i++}`);
-      params.push(venueId);
-    }
-    if (groupId) {
-      conditions.push(`ge.group_id = $${i++}`);
-      params.push(groupId);
-    } else if (groupsOnly === 'true') {
-      conditions.push(`ge.group_id IS NOT NULL`);
-    }
-    if (eventTypeId) {
-      conditions.push(`ge.event_type_id = $${i++}`);
-      params.push(eventTypeId);
-    }
-    if (memberId) {
-      conditions.push(
-        `(ge.group_id IS NULL OR ge.group_id IN (SELECT group_id FROM group_members WHERE member_id = $${i++}))`,
-      );
-      params.push(memberId);
-    }
-
-    const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
+    const { from, to } = req.query; // retained for the worksheet title label
+    const { where, params } = buildCalendarEventFilters(req.query);
 
     const events = await tenantQuery(
       slug,
@@ -615,7 +517,10 @@ router.get('/events/search', requirePrivilege('calendar', 'view'), async (req, r
   try {
     const slug = req.user.tenantSlug;
     const q = String(req.query.q || '').trim();
-    const limit = Math.min(parseInt(req.query.limit, 10) || 20, 50);
+    const limit = Math.min(
+      parseInt(req.query.limit, 10) || EVENT_SEARCH_DEFAULT_LIMIT,
+      EVENT_SEARCH_MAX_LIMIT,
+    );
     if (q.length < 2) return res.json([]);
 
     const rows = await tenantQuery(

--- a/backend/src/routes/giftAid.js
+++ b/backend/src/routes/giftAid.js
@@ -14,6 +14,9 @@ import { logAudit } from '../utils/audit.js';
 const router = Router();
 router.use(requireAuth);
 
+// Cap on rows returned by the Gift Aid consent-history audit query.
+const CONSENT_HISTORY_MAX_ROWS = 500;
+
 /** Compute financial year bounds from settings. */
 function computeYearBounds(yearNum, startMonth, startDay) {
   const m = String(startMonth).padStart(2, '0');
@@ -320,7 +323,7 @@ router.get(
         params.push(req.query.memberId);
       }
 
-      sql += `\n      ORDER BY created_at DESC LIMIT 500`;
+      sql += `\n      ORDER BY created_at DESC LIMIT ${CONSENT_HISTORY_MAX_ROWS}`;
 
       const rows = await tenantQuery(slug, sql, params);
 

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -10,6 +10,7 @@ import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { sanitizeCell } from '../utils/spreadsheet.js';
 import { AppError } from '../middleware/errorHandler.js';
+import { logAudit } from '../utils/audit.js';
 import {
   addMemberSchema,
   bulkAddMembersSchema,
@@ -324,6 +325,14 @@ router.post('/', requirePrivilege('group_records_all', 'create'), async (req, re
         data.showAddresses,
       ],
     );
+    logAudit(slug, {
+      userId: req.user.userId,
+      userName: req.user.name,
+      action: 'create',
+      entityType: 'group',
+      entityId: group.id,
+      entityName: group.name,
+    });
     res.status(201).json(group);
   } catch (err) {
     next(err);
@@ -400,6 +409,14 @@ router.patch('/:id', requirePrivilege('group_records_all', 'change'), async (req
       values,
     );
     if (!group) throw AppError('Group not found.', 404);
+    logAudit(slug, {
+      userId: req.user.userId,
+      userName: req.user.name,
+      action: 'update',
+      entityType: 'group',
+      entityId: group.id,
+      entityName: group.name,
+    });
     res.json(group);
   } catch (err) {
     next(err);
@@ -413,12 +430,20 @@ router.delete('/:id', requirePrivilege('group_records_all', 'delete'), async (re
     const slug = req.user.tenantSlug;
     const [existing] = await tenantQuery(
       slug,
-      `SELECT id FROM groups WHERE id = $1 AND type = 'group'`,
+      `SELECT id, name FROM groups WHERE id = $1 AND type = 'group'`,
       [req.params.id],
     );
     if (!existing) throw AppError('Group not found.', 404);
 
     await tenantQuery(slug, `DELETE FROM groups WHERE id = $1 AND type = 'group'`, [req.params.id]);
+    logAudit(slug, {
+      userId: req.user.userId,
+      userName: req.user.name,
+      action: 'delete',
+      entityType: 'group',
+      entityId: existing.id,
+      entityName: existing.name,
+    });
     res.json({ message: 'Group deleted.' });
   } catch (err) {
     next(err);

--- a/backend/src/routes/membershipCards.js
+++ b/backend/src/routes/membershipCards.js
@@ -11,6 +11,7 @@ import ExcelJS from 'exceljs';
 import PDFDocument from 'pdfkit';
 import bwipjs from 'bwip-js';
 import { sanitizeCell } from '../utils/spreadsheet.js';
+import { AppError } from '../middleware/errorHandler.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -634,7 +635,7 @@ router.get(
  */
 export async function generateSingleCardPdf(slug, memberId, advanceYear = false) {
   const members = await fetchMembersById(slug, [memberId]);
-  if (!members.length) throw new Error(`Member ${memberId} not found`);
+  if (!members.length) throw AppError(`Member ${memberId} not found`, 404);
 
   const member = members[0];
   const settings = await getCardSettings(slug);

--- a/backend/src/routes/portal.js
+++ b/backend/src/routes/portal.js
@@ -18,6 +18,7 @@ import { isFeatureEnabled } from '../middleware/requireFeature.js';
 import { logAudit } from '../utils/audit.js';
 import { generateSingleCardPdf } from './membershipCards.js';
 import { decodeAndValidateImage } from '../utils/uploads.js';
+import { buildPortalCalendarFilters } from '../utils/eventFilters.js';
 
 const router = Router({ mergeParams: true });
 
@@ -394,8 +395,6 @@ router.get('/calendar', async (req, res, next) => {
   try {
     const slug = req.portal.tenantSlug;
     const memberId = req.portal.memberId;
-    const { from, to, groupId, eventTypeId, filter } = req.query;
-    // filter: 'all' | 'own' | 'other'
 
     const [settings] = await tenantQuery(
       slug,
@@ -418,39 +417,7 @@ router.get('/calendar', async (req, res, next) => {
       ...(settings?.calendar_config ?? {}),
     };
 
-    const conditions = [];
-    const params = [];
-    let i = 1;
-
-    if (from) {
-      conditions.push(`ge.event_date >= $${i++}::date`);
-      params.push(from);
-    }
-    if (to) {
-      conditions.push(`ge.event_date <= $${i++}::date`);
-      params.push(to);
-    }
-
-    if (filter === 'own') {
-      // Own groups + general/open meetings
-      conditions.push(
-        `(ge.group_id IS NULL OR ge.group_id IN (SELECT group_id FROM group_members WHERE member_id = $${i++}))`,
-      );
-      params.push(memberId);
-    } else if (filter === 'other') {
-      // Non-group events only, optionally filtered by event type
-      conditions.push('ge.group_id IS NULL');
-      if (eventTypeId) {
-        conditions.push(`ge.event_type_id = $${i++}`);
-        params.push(eventTypeId);
-      }
-    } else if (groupId) {
-      conditions.push(`ge.group_id = $${i++}`);
-      params.push(groupId);
-    }
-    // 'all' = no group filter
-
-    const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
+    const { where, params } = buildPortalCalendarFilters(req.query, memberId);
 
     const events = await tenantQuery(
       slug,
@@ -519,7 +486,7 @@ router.get('/calendar/pdf', async (req, res, next) => {
   try {
     const slug = req.portal.tenantSlug;
     const memberId = req.portal.memberId;
-    const { from, to, groupId, eventTypeId, filter } = req.query;
+    const { from, to } = req.query; // retained for the PDF title label
 
     const [settings] = await tenantQuery(
       slug,
@@ -530,35 +497,7 @@ router.get('/calendar/pdf', async (req, res, next) => {
       return res.status(403).json({ error: 'Calendar download is not enabled.' });
     }
 
-    const conditions = [];
-    const params = [];
-    let i = 1;
-
-    if (from) {
-      conditions.push(`ge.event_date >= $${i++}::date`);
-      params.push(from);
-    }
-    if (to) {
-      conditions.push(`ge.event_date <= $${i++}::date`);
-      params.push(to);
-    }
-    if (filter === 'own') {
-      conditions.push(
-        `(ge.group_id IS NULL OR ge.group_id IN (SELECT group_id FROM group_members WHERE member_id = $${i++}))`,
-      );
-      params.push(memberId);
-    } else if (filter === 'other') {
-      conditions.push('ge.group_id IS NULL');
-      if (eventTypeId) {
-        conditions.push(`ge.event_type_id = $${i++}`);
-        params.push(eventTypeId);
-      }
-    } else if (groupId) {
-      conditions.push(`ge.group_id = $${i++}`);
-      params.push(groupId);
-    }
-
-    const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
+    const { where, params } = buildPortalCalendarFilters(req.query, memberId);
     const events = await tenantQuery(
       slug,
       `SELECT ge.event_date, ge.start_time, ge.end_time,

--- a/backend/src/routes/teams.js
+++ b/backend/src/routes/teams.js
@@ -12,6 +12,7 @@ import { requireFeature } from '../middleware/requireFeature.js';
 import { tenantQuery } from '../utils/db.js';
 import { sanitizeCell } from '../utils/spreadsheet.js';
 import { AppError } from '../middleware/errorHandler.js';
+import { logAudit } from '../utils/audit.js';
 import {
   addMemberSchema,
   bulkAddMembersSchema,
@@ -277,6 +278,14 @@ router.post('/', requirePrivilege('group_records_all', 'create'), async (req, re
         data.showAddresses,
       ],
     );
+    logAudit(slug, {
+      userId: req.user.userId,
+      userName: req.user.name,
+      action: 'create',
+      entityType: 'team',
+      entityId: team.id,
+      entityName: team.name,
+    });
     res.status(201).json(team);
   } catch (err) {
     next(err);
@@ -330,6 +339,14 @@ router.patch('/:id', requirePrivilege('group_records_all', 'change'), async (req
       values,
     );
     if (!team) throw AppError('Team not found.', 404);
+    logAudit(slug, {
+      userId: req.user.userId,
+      userName: req.user.name,
+      action: 'update',
+      entityType: 'team',
+      entityId: team.id,
+      entityName: team.name,
+    });
     res.json(team);
   } catch (err) {
     next(err);
@@ -342,12 +359,20 @@ router.delete('/:id', requirePrivilege('group_records_all', 'delete'), async (re
     const slug = req.user.tenantSlug;
     const [existing] = await tenantQuery(
       slug,
-      `SELECT id FROM groups WHERE id = $1 AND type = 'team'`,
+      `SELECT id, name FROM groups WHERE id = $1 AND type = 'team'`,
       [req.params.id],
     );
     if (!existing) throw AppError('Team not found.', 404);
 
     await tenantQuery(slug, `DELETE FROM groups WHERE id = $1 AND type = 'team'`, [req.params.id]);
+    logAudit(slug, {
+      userId: req.user.userId,
+      userName: req.user.name,
+      action: 'delete',
+      entityType: 'team',
+      entityId: existing.id,
+      entityName: existing.name,
+    });
     res.json({ message: 'Team deleted.' });
   } catch (err) {
     next(err);

--- a/backend/src/utils/eventFilters.js
+++ b/backend/src/utils/eventFilters.js
@@ -1,0 +1,138 @@
+// beacon2/backend/src/utils/eventFilters.js
+// Shared WHERE-clause builders for calendar / group-event queries.
+//
+// The same filter-building block was previously duplicated verbatim across the
+// three calendar.js endpoints (events / events/pdf / events/excel) and the two
+// portal.js calendar endpoints (calendar / calendar/pdf). These helpers are the
+// single source of truth for that logic, and they validate the incoming query
+// string with Zod so a malformed date 400s at the edge instead of 500-ing on
+// the `::date` cast inside Postgres.
+
+import { z } from 'zod';
+
+// Treat empty-string query params (e.g. `?from=&to=`) as absent rather than
+// failing validation, then enforce the YYYY-MM-DD shape on anything provided.
+const optDate = z.preprocess(
+  (v) => (v === '' ? undefined : v),
+  z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected a date in YYYY-MM-DD format')
+    .optional(),
+);
+
+const optStr = z.preprocess((v) => (v === '' ? undefined : v), z.string().optional());
+
+// ── Staff calendar (routes/calendar.js) ─────────────────────────────────────
+// Query: from, to, venueId, groupId, groupsOnly, eventTypeId, memberId
+
+const calendarSchema = z.object({
+  from: optDate,
+  to: optDate,
+  venueId: optStr,
+  groupId: optStr,
+  groupsOnly: optStr,
+  eventTypeId: optStr,
+  memberId: optStr,
+});
+
+/**
+ * Build the WHERE clause + params for the staff calendar event list.
+ * @param {object} query - req.query
+ * @returns {{ where: string, params: any[] }}
+ */
+export function buildCalendarEventFilters(query) {
+  const { from, to, venueId, groupId, groupsOnly, eventTypeId, memberId } =
+    calendarSchema.parse(query);
+
+  const conditions = [];
+  const params = [];
+  let i = 1;
+
+  if (from) {
+    conditions.push(`ge.event_date >= $${i++}::date`);
+    params.push(from);
+  }
+  if (to) {
+    conditions.push(`ge.event_date <= $${i++}::date`);
+    params.push(to);
+  }
+  if (venueId) {
+    conditions.push(`ge.venue_id = $${i++}`);
+    params.push(venueId);
+  }
+  if (groupId) {
+    conditions.push(`ge.group_id = $${i++}`);
+    params.push(groupId);
+  } else if (groupsOnly === 'true') {
+    conditions.push(`ge.group_id IS NOT NULL`);
+  }
+  if (eventTypeId) {
+    conditions.push(`ge.event_type_id = $${i++}`);
+    params.push(eventTypeId);
+  }
+  if (memberId) {
+    conditions.push(
+      `(ge.group_id IS NULL OR ge.group_id IN (SELECT group_id FROM group_members WHERE member_id = $${i++}))`,
+    );
+    params.push(memberId);
+  }
+
+  const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
+  return { where, params };
+}
+
+// ── Member portal calendar (routes/portal.js) ───────────────────────────────
+// Query: from, to, groupId, eventTypeId, filter ('all' | 'own' | 'other')
+
+const portalCalendarSchema = z.object({
+  from: optDate,
+  to: optDate,
+  groupId: optStr,
+  eventTypeId: optStr,
+  filter: z.enum(['all', 'own', 'other']).optional(),
+});
+
+/**
+ * Build the WHERE clause + params for the member-portal calendar.
+ * @param {object} query    - req.query
+ * @param {string} memberId - the authenticated portal member's id
+ * @returns {{ where: string, params: any[] }}
+ */
+export function buildPortalCalendarFilters(query, memberId) {
+  const { from, to, groupId, eventTypeId, filter } = portalCalendarSchema.parse(query);
+
+  const conditions = [];
+  const params = [];
+  let i = 1;
+
+  if (from) {
+    conditions.push(`ge.event_date >= $${i++}::date`);
+    params.push(from);
+  }
+  if (to) {
+    conditions.push(`ge.event_date <= $${i++}::date`);
+    params.push(to);
+  }
+
+  if (filter === 'own') {
+    // Own groups + general/open meetings
+    conditions.push(
+      `(ge.group_id IS NULL OR ge.group_id IN (SELECT group_id FROM group_members WHERE member_id = $${i++}))`,
+    );
+    params.push(memberId);
+  } else if (filter === 'other') {
+    // Non-group events only, optionally filtered by event type
+    conditions.push('ge.group_id IS NULL');
+    if (eventTypeId) {
+      conditions.push(`ge.event_type_id = $${i++}`);
+      params.push(eventTypeId);
+    }
+  } else if (groupId) {
+    conditions.push(`ge.group_id = $${i++}`);
+    params.push(groupId);
+  }
+  // 'all' = no group filter
+
+  const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
+  return { where, params };
+}

--- a/docs/ImprovementPlan.md
+++ b/docs/ImprovementPlan.md
@@ -238,13 +238,35 @@ those flows, so there is nothing to change yet. New unit tests:
 `__tests__/uploads.test.js`; magic-byte mismatch case added to
 `members.test.js`.
 
-### Chunk 6 — Backend consistency (N1–N3, N6, C5, C6)
+### Chunk 6 — Backend consistency (N1–N3, N6, C5, C6) ✅ Done (2026-06-12)
 - Extract the shared WHERE-builder helper used by calendar/members/
   addressExport/membershipCards/portal.
 - Adopt and document one response-shape convention; fix the stray bare `Error`;
   add Zod validation for query params on the routes that use them raw;
   hoist pagination limits to constants; add `logAudit()` to groups/teams
   mutations; resolve the `eventAttendance` FEATURE_DEPS question.
+
+**Notes:** N1 was scoped to the **event** filters only (owner decision) — the
+genuinely byte-identical duplication. New `backend/src/utils/eventFilters.js`
+holds `buildCalendarEventFilters()` (replacing 3 inline blocks in `calendar.js`)
+and `buildPortalCalendarFilters()` (replacing 2 in `portal.js`); both validate
+the query string with Zod, so a malformed `from`/`to` now 422s at the edge
+instead of 500-ing on the `::date` cast (N3). The member-filter helpers in
+`members.js` / `addressExport.js` / `membershipCards.js` were left as-is — they
+are already locally factored and not actually identical (membershipCards hard-codes
+`Current`; members.js adds search/custom-field/payment-method conditions).
+N2: response-shape + status-code convention documented in CLAUDE-STANDARDS
+(`{ error }` for all errors via `AppError`; `{ message }` only for action-only
+successes; 201 create / 200 fetch+update). N6: the bare `throw new Error` in
+`membershipCards.js` → `AppError(…, 404)`; pagination magic numbers hoisted to
+named constants (`EVENT_SEARCH_*` in calendar.js, `CONSENT_HISTORY_MAX_ROWS` in
+giftAid.js). The `settings.js` "Prisma vs tenantQuery" item was a **false
+positive** — its Prisma calls read the **public** schema (`sys_tenants`,
+`sys_settings`), which `tenantQuery()` cannot reach; left unchanged. C5: already
+resolved — `eventAttendance: 'events'` is present in `shared/constants.js`
+`FEATURE_DEPS` (fixed earlier; see CHANGELOG). C6: `logAudit()` added to the
+group and team create/update/delete handlers (entity-level CRUD).
+New unit tests: `__tests__/eventFilters.test.js`.
 
 ### Chunk 7 — Backend tests for untested routes (C1, M4 backend half, T4)
 - Shared mock-setup helper to replace the per-file boilerplate.


### PR DESCRIPTION
## Summary

Resolves the duplicated security findings in `KNOWN-ISSUES.md`, then implements **Chunk 6** of `docs/ImprovementPlan.md` (backend consistency: N1–N3, N6, C5, C6).

### KNOWN-ISSUES cleanup
The Chunk 4 and Chunk 5 edits had each appended their own copy of security findings #8–22, leaving **two contradictory blocks** (e.g. #8 read `[OPEN]` in one and `[FIXED]` in the other; #12 read `[RESOLVED]` vs `[OPEN]`). Consolidated back to a single consistent **1–26 list** with correct status tags, and normalised the non-standard `[RESOLVED]` tag to the documented `[FIXED]`.

### Chunk 6
- **N1 / N3** — New `backend/src/utils/eventFilters.js` with `buildCalendarEventFilters()` and `buildPortalCalendarFilters()`, replacing **five byte-identical inline WHERE-clause blocks** across `calendar.js` (events / pdf / excel) and `portal.js` (calendar / pdf). Both validate the query string with Zod, so a malformed `from`/`to` now returns **422** at the edge instead of **500**-ing on the Postgres `::date` cast. (N1 scoped to the event filters only — the genuinely identical duplication; the member-filter helpers are already locally factored and not actually identical.)
- **N2** — Documented one response-shape + status-code convention in `CLAUDE-STANDARDS.md`: `{ error }` for all error bodies via `AppError`; `{ message }` only for action-only successes; 201 create / 200 fetch+update.
- **N6** — Replaced the lone bare `throw new Error` in `membershipCards.js` with `AppError(…, 404)`; hoisted scattered pagination limits to named constants (`EVENT_SEARCH_*` in `calendar.js`, `CONSENT_HISTORY_MAX_ROWS` in `giftAid.js`). The `settings.js` "Prisma vs tenantQuery" item was a **false positive** — its Prisma calls read the public schema (`sys_tenants`, `sys_settings`), which `tenantQuery()` cannot reach — so it was verified and left unchanged.
- **C5** — `eventAttendance` is already present in the shared `FEATURE_DEPS` map; verified and updated the stale docs.
- **C6** — Added `logAudit()` to the group and team create/update/delete handlers, matching members/finance.

## Testing
- All **500** backend tests pass (487 baseline + 13 new in `__tests__/eventFilters.test.js`).
- Backend lint and `format:check` clean.
- No frontend code changed.

## Docs updated
`docs/ImprovementPlan.md` (Chunk 6 ✅), `KNOWN-ISSUES.md`, `CODEBASE-RECOMMENDATIONS.md`, `CLAUDE-STANDARDS.md`, `CLAUDE-REFERENCE.md`, `CHANGELOG.md`.

https://claude.ai/code/session_01QunJmjyrP5nRQfU8CG9mXM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QunJmjyrP5nRQfU8CG9mXM)_