### PR TITLE
Chunk 10: split remaining oversized frontend pages (M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,9 +174,31 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
     `calendar/calendarUtils.js`. The page still owns the filter form, the "other"
     event-management section, and the add-event form.
   - Frontend suite green (53 files, 140 tests), lint 0 errors, Prettier clean.
-    The remaining M2 pages (TransactionEditor, CreditBatches, MemberList,
-    FinanceLedger, SystemDashboard) are deferred to a follow-up session and
-    tracked in `KNOWN-ISSUES.md`.
+- **Split oversized frontend pages — remaining five (ImprovementPlan Chunk 10,
+  finding M2)** — extraction only, no behaviour change:
+  - `pages/finance/TransactionEditor.jsx` (1,097 → 792 lines).
+    `finance/transactionEditorUtils.js` (today/BLANK/PAYMENT_METHODS + INP/LBL
+    class strings); `TransactionAssociations.jsx` (member/group/team/event
+    pickers); `TransactionGiftAidSection.jsx`; `TransactionCategories.jsx`.
+  - `pages/finance/CreditBatches.jsx` (1,028 → 446 lines).
+    `finance/creditBatchesUtils.js` (style strings + fmtAmt/toISODate);
+    `CreditBatchPicker.jsx` (shared unbatched-transaction selection table,
+    deduplicating the near-identical create + add-to-batch tables);
+    `CreditBatchList.jsx`; `CreditBatchDetail.jsx`; `CreditBatchAddTxns.jsx`;
+    `CreditBatchCreate.jsx`.
+  - `pages/members/MemberList.jsx` (921 → 453 lines). `members/memberListConstants.js`
+    (DOWNLOAD_FIELDS, ALPHABET); `MemberListFilters.jsx`; `MemberListTable.jsx`
+    (select controls + sortable table); `MemberListBulkActions.jsx`.
+  - `pages/finance/FinanceLedger.jsx` (892 → 395 lines). `finance/financeLedgerUtils.js`
+    (VIEWS/VIEW_LABELS/YEARS + fmtDate/fmtAmount/isEligible); `FinanceLedgerControls.jsx`;
+    `FinanceLedgerTable.jsx`.
+  - `pages/system/SystemDashboard.jsx` (832 → 458 lines). `system/systemDashboardConstants.js`
+    (EMPTY_FORM, SECTIONS, getVal); `CreateTenantForm.jsx`; `RestoreBackupSection.jsx`;
+    `RestoreConfirmModal.jsx`; `FeatureConfigModal.jsx`.
+  - All extracted parts are presentation-only with state/handlers passed in from
+    the parent. Frontend suite green (53 files, 140 tests), lint 0 errors,
+    Prettier clean. This completes Chunk 10 — every M2 page originally flagged is
+    now split.
 
 ### Fixed
 - **Duplicated security findings in `KNOWN-ISSUES.md`** — the Chunk 4 and Chunk 5

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -189,18 +189,18 @@ These are catalogued and re-verified in `docs/ImprovementPlan.md` (Chunks 4–5)
 
 ## Oversized frontend pages (ImprovementPlan Chunk 10, finding M2)
 
-1. `[OPEN]` **Remaining oversized pages not yet split** — Chunk 10 split
+1. `[OPEN]` **A few pages still over the ~700-line guideline** — Chunk 10 split
+   all the originally-flagged M2 pages (extraction only, no behaviour change):
    `MemberEditor.jsx` (2,317 → 1,994), `EntityMembers.jsx` (722 → 583),
-   `GroupRecord.jsx` (1,128 → 152), `TeamRecord.jsx` (889 → 125) and
-   `Calendar.jsx` (1,125 → 861). These pages are still over the ~700-line
-   guideline and should be split the same way (extraction only, no behaviour
-   change) in a follow-up session: `TransactionEditor.jsx` (1,097),
-   `CreditBatches.jsx` (1,028), `MemberList.jsx` (921), `FinanceLedger.jsx`
-   (892), `SystemDashboard.jsx` (832). `Calendar.jsx` is still 861 — its filter
-   form and "other"-mode event management could be split further if revisited.
-   `MemberEditor.jsx` itself is still ~1,994 lines — the address/partner
-   section (the largest remaining block) is a candidate for a further pass but is
-   heavily intertwined with shared form state, so it was left for now.
+   `GroupRecord.jsx` (1,128 → 152), `TeamRecord.jsx` (889 → 125),
+   `Calendar.jsx` (1,125 → 861), and (2026-06-13 follow-up) `TransactionEditor.jsx`
+   (1,097 → 792), `CreditBatches.jsx` (1,028 → 446), `MemberList.jsx` (921 → 453),
+   `FinanceLedger.jsx` (892 → 395), `SystemDashboard.jsx` (832 → 458). Two parents
+   remain over the guideline and could take a further extraction pass if revisited:
+   `MemberEditor.jsx` (~1,994 — the address/partner block is the largest remaining
+   chunk but is heavily intertwined with shared form state) and `Calendar.jsx`
+   (~861 — its filter form and "other"-mode event management). `TransactionEditor.jsx`
+   (792) is close to the line and is mostly the flat top-level field grid.
 
 ---
 

--- a/docs/ImprovementPlan.md
+++ b/docs/ImprovementPlan.md
@@ -415,10 +415,26 @@ only, no behaviour change.
   the "other" event-management section, and the add-event form.
 - Pure extraction, no behaviour change. Frontend suite green (53 files, 140 tests);
   lint 0 errors, Prettier clean.
-- **Remaining M2 pages deferred:** `TransactionEditor.jsx` (1,097),
-  `CreditBatches.jsx` (1,028), `MemberList.jsx` (921), `FinanceLedger.jsx`
-  (892), `SystemDashboard.jsx` (832) are still oversized. Logged in
-  `KNOWN-ISSUES.md` for a follow-up session (same extraction-only approach).
+- **Remaining M2 pages (2026-06-13, follow-up session):** the five deferred pages
+  were split, same extraction-only approach:
+  - `TransactionEditor.jsx` (1,097 → 792) → `finance/transactionEditorUtils.js`
+    (today/BLANK/PAYMENT_METHODS + INP/LBL class strings), `TransactionAssociations.jsx`
+    (member/group/team/event pickers), `TransactionGiftAidSection.jsx`,
+    `TransactionCategories.jsx`.
+  - `CreditBatches.jsx` (1,028 → 446) → `finance/creditBatchesUtils.js`
+    (styles + fmtAmt/toISODate), `CreditBatchPicker.jsx` (shared selection table that
+    deduplicates the near-identical create + add-to-batch tables), `CreditBatchList.jsx`,
+    `CreditBatchDetail.jsx`, `CreditBatchAddTxns.jsx`, `CreditBatchCreate.jsx`.
+  - `MemberList.jsx` (921 → 453) → `members/memberListConstants.js` (DOWNLOAD_FIELDS,
+    ALPHABET), `MemberListFilters.jsx`, `MemberListTable.jsx` (select controls + sortable
+    table), `MemberListBulkActions.jsx`.
+  - `FinanceLedger.jsx` (892 → 395) → `finance/financeLedgerUtils.js` (VIEWS/VIEW_LABELS/
+    YEARS + fmtDate/fmtAmount/isEligible), `FinanceLedgerControls.jsx`, `FinanceLedgerTable.jsx`.
+  - `SystemDashboard.jsx` (832 → 458) → `system/systemDashboardConstants.js` (EMPTY_FORM,
+    SECTIONS, getVal), `CreateTenantForm.jsx`, `RestoreBackupSection.jsx`,
+    `RestoreConfirmModal.jsx`, `FeatureConfigModal.jsx`.
+  - All presentation-only with state/handlers passed in from the parent; frontend suite
+    green (53 files, 140 tests); lint 0 errors, Prettier clean. M2 is now fully addressed.
 
 ### Chunk 11 — Frontend test quality & accessibility (C2, O5, M4 frontend half)
 - Shared mock factories; interaction tests (form submit, validation error,

--- a/frontend/src/pages/finance/CreditBatchAddTxns.jsx
+++ b/frontend/src/pages/finance/CreditBatchAddTxns.jsx
@@ -1,0 +1,59 @@
+// beacon2/frontend/src/pages/finance/CreditBatchAddTxns.jsx
+//
+// "Add transactions to an existing batch" view of CreditBatches. Presentation
+// only: state and handlers are owned by the parent; the selection table is the
+// shared CreditBatchPicker.
+
+import { btnPrimary, btnSecondary } from './creditBatchesUtils.js';
+import CreditBatchPicker from './CreditBatchPicker.jsx';
+
+export default function CreditBatchAddTxns({
+  viewBatch,
+  setShowAddTxns,
+  loadingAddTxns,
+  addUnbatched,
+  selectedAdd,
+  setSelectedAdd,
+  toggleAdd,
+  addingTxns,
+  handleAddTxnsToBatch,
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-4 mb-4">
+        <button onClick={() => setShowAddTxns(false)} className={btnSecondary}>
+          &larr; Back to batch
+        </button>
+        <h2 className="text-lg font-bold">Add transactions to: {viewBatch.batch_ref}</h2>
+      </div>
+
+      {loadingAddTxns ? (
+        <p className="text-center text-slate-500 py-8">Loading unbatched transactions…</p>
+      ) : addUnbatched.length === 0 ? (
+        <p className="text-sm text-slate-500">No unbatched credit transactions available.</p>
+      ) : (
+        <>
+          <CreditBatchPicker
+            rows={addUnbatched}
+            selected={selectedAdd}
+            setSelected={setSelectedAdd}
+            toggle={toggleAdd}
+          />
+
+          <div className="flex gap-3">
+            <button
+              onClick={handleAddTxnsToBatch}
+              disabled={addingTxns || selectedAdd.size === 0}
+              className={btnPrimary}
+            >
+              {addingTxns ? 'Adding…' : `Add ${selectedAdd.size} to batch`}
+            </button>
+            <button onClick={() => setShowAddTxns(false)} className={btnSecondary}>
+              Cancel
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/finance/CreditBatchCreate.jsx
+++ b/frontend/src/pages/finance/CreditBatchCreate.jsx
@@ -1,0 +1,125 @@
+// beacon2/frontend/src/pages/finance/CreditBatchCreate.jsx
+//
+// "Create a new batch / add selection to an existing batch" view of
+// CreditBatches. Presentation only: state and handlers are owned by the parent;
+// the selection table is the shared CreditBatchPicker.
+
+import { inputCls, btnPrimary, btnSecondary, fmtAmt } from './creditBatchesUtils.js';
+import CreditBatchPicker from './CreditBatchPicker.jsx';
+
+export default function CreditBatchCreate({
+  setShowCreate,
+  loadingUnbatched,
+  unbatched,
+  selectedCreate,
+  setSelectedCreate,
+  toggleCreate,
+  batchRef,
+  setBatchRef,
+  batchDesc,
+  setBatchDesc,
+  creating,
+  handleCreateBatch,
+  unclearedBatches,
+  existingBatchId,
+  setExistingBatchId,
+  handleAddToExisting,
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-4 mb-4">
+        <button onClick={() => setShowCreate(false)} className={btnSecondary}>
+          &larr; Back
+        </button>
+        <h2 className="text-lg font-bold">Select transactions for batch</h2>
+      </div>
+
+      {loadingUnbatched ? (
+        <p className="text-sm text-slate-500">Loading unbatched transactions...</p>
+      ) : unbatched.length === 0 ? (
+        <p className="text-sm text-slate-500">No unbatched credit transactions available.</p>
+      ) : (
+        <>
+          <CreditBatchPicker
+            rows={unbatched}
+            selected={selectedCreate}
+            setSelected={setSelectedCreate}
+            toggle={toggleCreate}
+          />
+
+          {selectedCreate.size > 0 && (
+            <div className="bg-white/90 rounded-lg shadow-sm p-4 space-y-4">
+              {/* Create new batch */}
+              <div className="flex flex-wrap items-end gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">
+                    Batch Reference
+                  </label>
+                  <input
+                    type="text"
+                    name="batchRef"
+                    value={batchRef}
+                    onChange={(e) => setBatchRef(e.target.value)}
+                    placeholder="e.g. 12 Mar 2026"
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">
+                    Description
+                  </label>
+                  <input
+                    type="text"
+                    name="batchDesc"
+                    value={batchDesc}
+                    onChange={(e) => setBatchDesc(e.target.value)}
+                    placeholder="Optional description"
+                    className={inputCls}
+                  />
+                </div>
+                <button
+                  onClick={handleCreateBatch}
+                  disabled={creating || !batchRef.trim()}
+                  className={btnPrimary}
+                >
+                  {creating ? 'Creating...' : 'Create Batch'}
+                </button>
+              </div>
+
+              {/* Add to existing batch */}
+              {unclearedBatches.length > 0 && (
+                <div className="flex flex-wrap items-end gap-3 border-t border-slate-200 pt-4">
+                  <div>
+                    <label className="block text-sm font-medium text-slate-700 mb-1">
+                      Or add to existing batch
+                    </label>
+                    <select
+                      name="existingBatchId"
+                      value={existingBatchId}
+                      onChange={(e) => setExistingBatchId(e.target.value)}
+                      className={inputCls}
+                    >
+                      <option value="">— select batch —</option>
+                      {unclearedBatches.map((b) => (
+                        <option key={b.id} value={b.id}>
+                          {b.batch_ref} ({b.txn_count} txns, £{fmtAmt(b.total_amount)})
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <button
+                    onClick={handleAddToExisting}
+                    disabled={creating || !existingBatchId}
+                    className={btnPrimary}
+                  >
+                    Add to Existing
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/finance/CreditBatchDetail.jsx
+++ b/frontend/src/pages/finance/CreditBatchDetail.jsx
@@ -1,0 +1,239 @@
+// beacon2/frontend/src/pages/finance/CreditBatchDetail.jsx
+//
+// Batch detail/edit view of CreditBatches — editable header, the batch's
+// transaction table with optional "remove?" column, and the action buttons.
+// Presentation only: all state and handlers are owned by the parent.
+
+import { inputCls, btnPrimary, btnDanger, btnSecondary, fmtAmt } from './creditBatchesUtils.js';
+import { fmtDate } from '../../lib/dateFormatters.js';
+
+export default function CreditBatchDetail({
+  viewBatch,
+  setViewBatch,
+  canCreate,
+  canDelete,
+  editRef,
+  setEditRef,
+  editDate,
+  setEditDate,
+  editDesc,
+  setEditDesc,
+  saving,
+  handleSaveBatchDetails,
+  selectedRemove,
+  setSelectedRemove,
+  toggleRemove,
+  removing,
+  handleRemoveFromBatch,
+  openAddTxns,
+  handleDeleteBatch,
+  currentBatchTotal,
+  newBatchTotal,
+  hasRemovable,
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-4 mb-4">
+        <button onClick={() => setViewBatch(null)} className={btnSecondary}>
+          &larr; Back to list
+        </button>
+        <h2 className="text-lg font-bold">Edit Credit Batch</h2>
+      </div>
+
+      {/* Batch details */}
+      <div className="bg-white/90 rounded-lg shadow-sm p-4 mb-4 space-y-3">
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="text-sm text-slate-600">
+            <span className="font-medium">Batch Number:</span> {viewBatch.batch_number}
+          </div>
+        </div>
+        {canCreate ? (
+          <div className="flex flex-wrap items-end gap-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">
+                Batch Reference
+              </label>
+              <input
+                type="text"
+                name="editRef"
+                value={editRef}
+                onChange={(e) => setEditRef(e.target.value)}
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">Batch Date</label>
+              <input
+                type="date"
+                name="editDate"
+                value={editDate}
+                onChange={(e) => setEditDate(e.target.value)}
+                className={inputCls}
+              />
+            </div>
+            <div className="flex-1 min-w-[180px]">
+              <label className="block text-sm font-medium text-slate-700 mb-1">Description</label>
+              <input
+                type="text"
+                name="editDesc"
+                value={editDesc}
+                onChange={(e) => setEditDesc(e.target.value)}
+                placeholder="Optional"
+                className={`${inputCls} w-full`}
+              />
+            </div>
+            <button
+              onClick={handleSaveBatchDetails}
+              disabled={saving || !editRef.trim()}
+              className={btnPrimary}
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-6 text-sm text-slate-600">
+            <span>
+              <span className="font-medium">Reference:</span> {viewBatch.batch_ref}
+            </span>
+            <span>
+              <span className="font-medium">Date:</span> {fmtDate(viewBatch.batch_date)}
+            </span>
+            {viewBatch.description && (
+              <span>
+                <span className="font-medium">Description:</span> {viewBatch.description}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Batch transactions table */}
+      <div className="overflow-x-auto mb-4">
+        <table className="min-w-max w-full text-sm border border-slate-300">
+          <thead>
+            <tr className="bg-slate-50">
+              <th className="px-3 py-1 border-b border-slate-300 text-left">#</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">Date</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">Payment Ref</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">Payment Method</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">From/To</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">Detail</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-right">Amount (£)</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">Cleared</th>
+              {hasRemovable && canCreate && (
+                <th className="px-3 py-1 border-b border-slate-300 text-center">Remove?</th>
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {viewBatch.transactions.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={hasRemovable && canCreate ? 9 : 8}
+                  className="px-3 py-3 text-center text-slate-400"
+                >
+                  No transactions in this batch.
+                </td>
+              </tr>
+            ) : (
+              viewBatch.transactions.map((t, i) => (
+                <tr
+                  key={t.id}
+                  className={
+                    selectedRemove.has(t.id)
+                      ? 'bg-red-50'
+                      : i % 2 === 0
+                        ? 'bg-yellow-50'
+                        : 'bg-white'
+                  }
+                >
+                  <td className="px-3 py-1 border-b border-slate-200 font-mono text-xs text-slate-500">
+                    {t.transaction_number}
+                  </td>
+                  <td className="px-3 py-1 border-b border-slate-200">{fmtDate(t.date)}</td>
+                  <td className="px-3 py-1 border-b border-slate-200">{t.payment_ref ?? ''}</td>
+                  <td className="px-3 py-1 border-b border-slate-200">{t.payment_method ?? ''}</td>
+                  <td className="px-3 py-1 border-b border-slate-200">{t.from_to ?? ''}</td>
+                  <td className="px-3 py-1 border-b border-slate-200">{t.detail ?? ''}</td>
+                  <td className="px-3 py-1 border-b border-slate-200 text-right font-mono">
+                    {fmtAmt(t.amount)}
+                  </td>
+                  <td className="px-3 py-1 border-b border-slate-200">
+                    {t.cleared_at ? fmtDate(t.cleared_at) : ''}
+                  </td>
+                  {hasRemovable && canCreate && (
+                    <td className="px-2 py-1 border-b border-slate-200 text-center">
+                      {!t.cleared_at && (
+                        <input
+                          type="checkbox"
+                          checked={selectedRemove.has(t.id)}
+                          onChange={() => toggleRemove(t.id)}
+                        />
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))
+            )}
+          </tbody>
+          {viewBatch.transactions.length > 0 && (
+            <tfoot>
+              <tr className="bg-slate-100 border-t-2 border-slate-300">
+                <td colSpan={6} className="px-3 py-1.5 text-right font-medium text-sm">
+                  Current Batch Total:
+                </td>
+                <td className="px-3 py-1.5 text-right font-mono font-medium">
+                  £{fmtAmt(currentBatchTotal)}
+                </td>
+                <td colSpan={hasRemovable && canCreate ? 2 : 1} />
+              </tr>
+              {selectedRemove.size > 0 && (
+                <tr className="bg-slate-100">
+                  <td colSpan={6} className="px-3 py-1.5 text-right font-medium text-sm">
+                    New Batch Total:
+                  </td>
+                  <td className="px-3 py-1.5 text-right font-mono font-medium">
+                    £{fmtAmt(newBatchTotal)}
+                  </td>
+                  <td colSpan={hasRemovable && canCreate ? 2 : 1} />
+                </tr>
+              )}
+            </tfoot>
+          )}
+        </table>
+      </div>
+
+      {/* Action buttons below the table */}
+      <div className="flex flex-wrap gap-3">
+        {canCreate && hasRemovable && (
+          <>
+            <button
+              onClick={handleRemoveFromBatch}
+              disabled={removing || selectedRemove.size === 0}
+              className={btnPrimary}
+            >
+              {removing ? 'Removing…' : 'Update Transaction'}
+            </button>
+            <button
+              onClick={() => setSelectedRemove(new Set())}
+              disabled={removing || selectedRemove.size === 0}
+              className={btnSecondary}
+            >
+              Cancel
+            </button>
+          </>
+        )}
+        {canCreate && (
+          <button onClick={openAddTxns} className={btnPrimary}>
+            Add transactions
+          </button>
+        )}
+        {canDelete && viewBatch.transactions.length === 0 && (
+          <button onClick={() => handleDeleteBatch(viewBatch.id)} className={btnDanger}>
+            Delete batch
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/finance/CreditBatchList.jsx
+++ b/frontend/src/pages/finance/CreditBatchList.jsx
@@ -1,0 +1,142 @@
+// beacon2/frontend/src/pages/finance/CreditBatchList.jsx
+//
+// List view of CreditBatches — account/mode/date filter bar and the batch table.
+// Presentation only: filter state and handlers are owned by the parent.
+
+import { inputCls, fmtAmt } from './creditBatchesUtils.js';
+import { fmtDate } from '../../lib/dateFormatters.js';
+
+export default function CreditBatchList({
+  accounts,
+  accountId,
+  setAccountId,
+  mode,
+  setMode,
+  sinceDate,
+  setSinceDate,
+  loading,
+  batches,
+  canDelete,
+  openBatch,
+  handleDeleteBatch,
+}) {
+  return (
+    <>
+      {/* Account selector & filter */}
+      <div className="flex flex-wrap items-end gap-4 mb-4">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">Account</label>
+          <select
+            name="accountId"
+            value={accountId}
+            onChange={(e) => setAccountId(e.target.value)}
+            className={inputCls}
+          >
+            <option value="">— select —</option>
+            {accounts.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">Show</label>
+          <select
+            name="mode"
+            value={mode}
+            onChange={(e) => setMode(e.target.value)}
+            className={inputCls}
+          >
+            <option value="uncleared">Uncleared</option>
+            <option value="since">Since date</option>
+          </select>
+        </div>
+        {mode === 'since' && (
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Since</label>
+            <input
+              type="date"
+              name="sinceDate"
+              value={sinceDate}
+              onChange={(e) => setSinceDate(e.target.value)}
+              className={inputCls}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Batch list */}
+      {loading && <p className="text-center text-slate-500 py-8">Loading…</p>}
+
+      {!loading && batches.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="min-w-max w-full text-sm border border-slate-300">
+            <thead>
+              <tr className="bg-slate-50">
+                <th className="px-3 py-1 border-b border-slate-300 text-left">Batch Ref</th>
+                <th className="px-3 py-1 border-b border-slate-300 text-left">Batch Date</th>
+                <th className="px-3 py-1 border-b border-slate-300 text-right">Transactions</th>
+                <th className="px-3 py-1 border-b border-slate-300 text-right">Total (£)</th>
+                <th className="px-3 py-1 border-b border-slate-300 text-left">Status</th>
+                <th className="px-3 py-1 border-b border-slate-300" />
+              </tr>
+            </thead>
+            <tbody>
+              {batches.map((b, i) => {
+                const allCleared = b.cleared_count === b.txn_count && b.txn_count > 0;
+                const partCleared = b.cleared_count > 0 && b.cleared_count < b.txn_count;
+                return (
+                  <tr key={b.id} className={i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}>
+                    <td className="px-3 py-1 border-b border-slate-200">
+                      <button
+                        onClick={() => openBatch(b.id)}
+                        className="text-blue-700 hover:underline font-medium"
+                      >
+                        {b.batch_ref}
+                      </button>
+                    </td>
+                    <td className="px-3 py-1 border-b border-slate-200">{fmtDate(b.batch_date)}</td>
+                    <td className="px-3 py-1 border-b border-slate-200 text-right">
+                      {b.txn_count}
+                    </td>
+                    <td className="px-3 py-1 border-b border-slate-200 text-right font-mono">
+                      {fmtAmt(b.total_amount)}
+                    </td>
+                    <td className="px-3 py-1 border-b border-slate-200">
+                      {allCleared ? (
+                        <span className="text-xs text-green-700 bg-green-100 px-1.5 py-0.5 rounded">
+                          Cleared
+                        </span>
+                      ) : partCleared ? (
+                        <span className="text-xs text-amber-700 bg-amber-100 px-1.5 py-0.5 rounded">
+                          Part cleared
+                        </span>
+                      ) : (
+                        <span className="text-xs text-slate-500">Uncleared</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-1 border-b border-slate-200">
+                      {canDelete && b.txn_count === 0 && (
+                        <button
+                          onClick={() => handleDeleteBatch(b.id)}
+                          className="text-red-600 hover:underline text-xs"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loading && batches.length === 0 && accountId && (
+        <p className="text-sm text-slate-500">No batches found.</p>
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/finance/CreditBatchPicker.jsx
+++ b/frontend/src/pages/finance/CreditBatchPicker.jsx
@@ -1,0 +1,91 @@
+// beacon2/frontend/src/pages/finance/CreditBatchPicker.jsx
+//
+// Shared "select unbatched credit transactions" table, used both when creating a
+// new batch and when adding transactions to an existing one. Presentation only:
+// the row list and selection Set are owned by the parent.
+
+import { fmtAmt } from './creditBatchesUtils.js';
+import { fmtDate } from '../../lib/dateFormatters.js';
+
+export default function CreditBatchPicker({ rows, selected, setSelected, toggle }) {
+  const allSelected = selected.size === rows.length && rows.length > 0;
+  const selectAllOrNone = () =>
+    selected.size === rows.length
+      ? setSelected(new Set())
+      : setSelected(new Set(rows.map((t) => t.id)));
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-3 mb-3 items-center">
+        <button
+          onClick={() => setSelected(new Set(rows.map((t) => t.id)))}
+          className="text-blue-700 hover:underline text-sm"
+        >
+          Select All
+        </button>
+        <button
+          onClick={() => setSelected(new Set())}
+          className="text-blue-700 hover:underline text-sm"
+        >
+          Clear
+        </button>
+        <span className="text-sm text-slate-500">{selected.size} selected</span>
+      </div>
+
+      <div className="overflow-x-auto mb-4">
+        <table className="min-w-max w-full text-sm border border-slate-300">
+          <thead>
+            <tr className="bg-slate-50">
+              <th className="px-2 py-1 border-b border-slate-300 w-8">
+                <input type="checkbox" checked={allSelected} onChange={selectAllOrNone} />
+              </th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">#</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">Date</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">From/To</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">Detail</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">Method</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-left">Ref</th>
+              <th className="px-3 py-1 border-b border-slate-300 text-right">Amount (£)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((t, i) => (
+              <tr
+                key={t.id}
+                className={`cursor-pointer ${selected.has(t.id) ? 'bg-blue-50' : i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}`}
+                onClick={() => toggle(t.id)}
+              >
+                <td className="px-2 py-1 border-b border-slate-200 text-center">
+                  <input type="checkbox" checked={selected.has(t.id)} readOnly />
+                </td>
+                <td className="px-3 py-1 border-b border-slate-200 font-mono text-xs text-slate-500">
+                  {t.transaction_number}
+                </td>
+                <td className="px-3 py-1 border-b border-slate-200">{fmtDate(t.date)}</td>
+                <td className="px-3 py-1 border-b border-slate-200">{t.from_to ?? ''}</td>
+                <td className="px-3 py-1 border-b border-slate-200">{t.detail ?? ''}</td>
+                <td className="px-3 py-1 border-b border-slate-200">{t.payment_method ?? ''}</td>
+                <td className="px-3 py-1 border-b border-slate-200">{t.payment_ref ?? ''}</td>
+                <td className="px-3 py-1 border-b border-slate-200 text-right font-mono">
+                  {fmtAmt(t.amount)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          {selected.size > 0 && (
+            <tfoot>
+              <tr className="bg-slate-50 font-medium">
+                <td colSpan={7} className="px-3 py-1 border-t border-slate-300 text-right">
+                  Selected total:
+                </td>
+                <td className="px-3 py-1 border-t border-slate-300 text-right font-mono">
+                  {fmtAmt(rows.filter((t) => selected.has(t.id)).reduce((s, t) => s + t.amount, 0))}
+                </td>
+              </tr>
+            </tfoot>
+          )}
+        </table>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/finance/CreditBatches.jsx
+++ b/frontend/src/pages/finance/CreditBatches.jsx
@@ -7,24 +7,11 @@ import { finance as financeApi } from '../../lib/api.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
-import { fmtDate } from '../../lib/dateFormatters.js';
-
-const inputCls =
-  'border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
-const btnPrimary =
-  'bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium transition-colors';
-const btnDanger = 'border border-red-300 text-red-600 hover:bg-red-50 rounded px-5 py-2 text-sm';
-const btnSecondary =
-  'border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-4 py-1.5 text-sm transition-colors';
-
-function fmtAmt(n) {
-  return Number(n).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-}
-
-function toISODate(d) {
-  if (!d) return '';
-  return String(d).slice(0, 10);
-}
+import { toISODate } from './creditBatchesUtils.js';
+import CreditBatchList from './CreditBatchList.jsx';
+import CreditBatchDetail from './CreditBatchDetail.jsx';
+import CreditBatchAddTxns from './CreditBatchAddTxns.jsx';
+import CreditBatchCreate from './CreditBatchCreate.jsx';
 
 export default function CreditBatches() {
   const { can, tenant } = useAuth();
@@ -371,656 +358,87 @@ export default function CreditBatches() {
           </div>
         )}
 
-        {/* ─── Account selector & filter ───────────────────────────────── */}
+        {/* ─── List view (filter bar + batch table) ────────────────────── */}
         {!viewBatch && !showCreate && (
-          <div className="flex flex-wrap items-end gap-4 mb-4">
-            <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">Account</label>
-              <select
-                name="accountId"
-                value={accountId}
-                onChange={(e) => setAccountId(e.target.value)}
-                className={inputCls}
-              >
-                <option value="">— select —</option>
-                {accounts.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">Show</label>
-              <select
-                name="mode"
-                value={mode}
-                onChange={(e) => setMode(e.target.value)}
-                className={inputCls}
-              >
-                <option value="uncleared">Uncleared</option>
-                <option value="since">Since date</option>
-              </select>
-            </div>
-            {mode === 'since' && (
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Since</label>
-                <input
-                  type="date"
-                  name="sinceDate"
-                  value={sinceDate}
-                  onChange={(e) => setSinceDate(e.target.value)}
-                  className={inputCls}
-                />
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* ─── Batch list ──────────────────────────────────────────────── */}
-        {!viewBatch && !showCreate && loading && (
-          <p className="text-center text-slate-500 py-8">Loading…</p>
-        )}
-
-        {!viewBatch && !showCreate && !loading && batches.length > 0 && (
-          <div className="overflow-x-auto">
-            <table className="min-w-max w-full text-sm border border-slate-300">
-              <thead>
-                <tr className="bg-slate-50">
-                  <th className="px-3 py-1 border-b border-slate-300 text-left">Batch Ref</th>
-                  <th className="px-3 py-1 border-b border-slate-300 text-left">Batch Date</th>
-                  <th className="px-3 py-1 border-b border-slate-300 text-right">Transactions</th>
-                  <th className="px-3 py-1 border-b border-slate-300 text-right">Total (£)</th>
-                  <th className="px-3 py-1 border-b border-slate-300 text-left">Status</th>
-                  <th className="px-3 py-1 border-b border-slate-300" />
-                </tr>
-              </thead>
-              <tbody>
-                {batches.map((b, i) => {
-                  const allCleared = b.cleared_count === b.txn_count && b.txn_count > 0;
-                  const partCleared = b.cleared_count > 0 && b.cleared_count < b.txn_count;
-                  return (
-                    <tr key={b.id} className={i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}>
-                      <td className="px-3 py-1 border-b border-slate-200">
-                        <button
-                          onClick={() => openBatch(b.id)}
-                          className="text-blue-700 hover:underline font-medium"
-                        >
-                          {b.batch_ref}
-                        </button>
-                      </td>
-                      <td className="px-3 py-1 border-b border-slate-200">
-                        {fmtDate(b.batch_date)}
-                      </td>
-                      <td className="px-3 py-1 border-b border-slate-200 text-right">
-                        {b.txn_count}
-                      </td>
-                      <td className="px-3 py-1 border-b border-slate-200 text-right font-mono">
-                        {fmtAmt(b.total_amount)}
-                      </td>
-                      <td className="px-3 py-1 border-b border-slate-200">
-                        {allCleared ? (
-                          <span className="text-xs text-green-700 bg-green-100 px-1.5 py-0.5 rounded">
-                            Cleared
-                          </span>
-                        ) : partCleared ? (
-                          <span className="text-xs text-amber-700 bg-amber-100 px-1.5 py-0.5 rounded">
-                            Part cleared
-                          </span>
-                        ) : (
-                          <span className="text-xs text-slate-500">Uncleared</span>
-                        )}
-                      </td>
-                      <td className="px-3 py-1 border-b border-slate-200">
-                        {canDelete && b.txn_count === 0 && (
-                          <button
-                            onClick={() => handleDeleteBatch(b.id)}
-                            className="text-red-600 hover:underline text-xs"
-                          >
-                            Delete
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-
-        {!viewBatch && !showCreate && !loading && batches.length === 0 && accountId && (
-          <p className="text-sm text-slate-500">No batches found.</p>
+          <CreditBatchList
+            accounts={accounts}
+            accountId={accountId}
+            setAccountId={setAccountId}
+            mode={mode}
+            setMode={setMode}
+            sinceDate={sinceDate}
+            setSinceDate={setSinceDate}
+            loading={loading}
+            batches={batches}
+            canDelete={canDelete}
+            openBatch={openBatch}
+            handleDeleteBatch={handleDeleteBatch}
+          />
         )}
 
         {/* ─── Batch detail view ───────────────────────────────────────── */}
         {viewBatch && !showAddTxns && (
-          <div>
-            <div className="flex items-center gap-4 mb-4">
-              <button onClick={() => setViewBatch(null)} className={btnSecondary}>
-                &larr; Back to list
-              </button>
-              <h2 className="text-lg font-bold">Edit Credit Batch</h2>
-            </div>
-
-            {/* Batch details */}
-            <div className="bg-white/90 rounded-lg shadow-sm p-4 mb-4 space-y-3">
-              <div className="flex flex-wrap items-end gap-4">
-                <div className="text-sm text-slate-600">
-                  <span className="font-medium">Batch Number:</span> {viewBatch.batch_number}
-                </div>
-              </div>
-              {canCreate ? (
-                <div className="flex flex-wrap items-end gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 mb-1">
-                      Batch Reference
-                    </label>
-                    <input
-                      type="text"
-                      name="editRef"
-                      value={editRef}
-                      onChange={(e) => setEditRef(e.target.value)}
-                      className={inputCls}
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 mb-1">
-                      Batch Date
-                    </label>
-                    <input
-                      type="date"
-                      name="editDate"
-                      value={editDate}
-                      onChange={(e) => setEditDate(e.target.value)}
-                      className={inputCls}
-                    />
-                  </div>
-                  <div className="flex-1 min-w-[180px]">
-                    <label className="block text-sm font-medium text-slate-700 mb-1">
-                      Description
-                    </label>
-                    <input
-                      type="text"
-                      name="editDesc"
-                      value={editDesc}
-                      onChange={(e) => setEditDesc(e.target.value)}
-                      placeholder="Optional"
-                      className={`${inputCls} w-full`}
-                    />
-                  </div>
-                  <button
-                    onClick={handleSaveBatchDetails}
-                    disabled={saving || !editRef.trim()}
-                    className={btnPrimary}
-                  >
-                    {saving ? 'Saving…' : 'Save'}
-                  </button>
-                </div>
-              ) : (
-                <div className="flex flex-wrap gap-6 text-sm text-slate-600">
-                  <span>
-                    <span className="font-medium">Reference:</span> {viewBatch.batch_ref}
-                  </span>
-                  <span>
-                    <span className="font-medium">Date:</span> {fmtDate(viewBatch.batch_date)}
-                  </span>
-                  {viewBatch.description && (
-                    <span>
-                      <span className="font-medium">Description:</span> {viewBatch.description}
-                    </span>
-                  )}
-                </div>
-              )}
-            </div>
-
-            {/* Batch transactions table */}
-            <div className="overflow-x-auto mb-4">
-              <table className="min-w-max w-full text-sm border border-slate-300">
-                <thead>
-                  <tr className="bg-slate-50">
-                    <th className="px-3 py-1 border-b border-slate-300 text-left">#</th>
-                    <th className="px-3 py-1 border-b border-slate-300 text-left">Date</th>
-                    <th className="px-3 py-1 border-b border-slate-300 text-left">Payment Ref</th>
-                    <th className="px-3 py-1 border-b border-slate-300 text-left">
-                      Payment Method
-                    </th>
-                    <th className="px-3 py-1 border-b border-slate-300 text-left">From/To</th>
-                    <th className="px-3 py-1 border-b border-slate-300 text-left">Detail</th>
-                    <th className="px-3 py-1 border-b border-slate-300 text-right">Amount (£)</th>
-                    <th className="px-3 py-1 border-b border-slate-300 text-left">Cleared</th>
-                    {hasRemovable && canCreate && (
-                      <th className="px-3 py-1 border-b border-slate-300 text-center">Remove?</th>
-                    )}
-                  </tr>
-                </thead>
-                <tbody>
-                  {viewBatch.transactions.length === 0 ? (
-                    <tr>
-                      <td
-                        colSpan={hasRemovable && canCreate ? 9 : 8}
-                        className="px-3 py-3 text-center text-slate-400"
-                      >
-                        No transactions in this batch.
-                      </td>
-                    </tr>
-                  ) : (
-                    viewBatch.transactions.map((t, i) => (
-                      <tr
-                        key={t.id}
-                        className={
-                          selectedRemove.has(t.id)
-                            ? 'bg-red-50'
-                            : i % 2 === 0
-                              ? 'bg-yellow-50'
-                              : 'bg-white'
-                        }
-                      >
-                        <td className="px-3 py-1 border-b border-slate-200 font-mono text-xs text-slate-500">
-                          {t.transaction_number}
-                        </td>
-                        <td className="px-3 py-1 border-b border-slate-200">{fmtDate(t.date)}</td>
-                        <td className="px-3 py-1 border-b border-slate-200">
-                          {t.payment_ref ?? ''}
-                        </td>
-                        <td className="px-3 py-1 border-b border-slate-200">
-                          {t.payment_method ?? ''}
-                        </td>
-                        <td className="px-3 py-1 border-b border-slate-200">{t.from_to ?? ''}</td>
-                        <td className="px-3 py-1 border-b border-slate-200">{t.detail ?? ''}</td>
-                        <td className="px-3 py-1 border-b border-slate-200 text-right font-mono">
-                          {fmtAmt(t.amount)}
-                        </td>
-                        <td className="px-3 py-1 border-b border-slate-200">
-                          {t.cleared_at ? fmtDate(t.cleared_at) : ''}
-                        </td>
-                        {hasRemovable && canCreate && (
-                          <td className="px-2 py-1 border-b border-slate-200 text-center">
-                            {!t.cleared_at && (
-                              <input
-                                type="checkbox"
-                                checked={selectedRemove.has(t.id)}
-                                onChange={() => toggleRemove(t.id)}
-                              />
-                            )}
-                          </td>
-                        )}
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-                {viewBatch.transactions.length > 0 && (
-                  <tfoot>
-                    <tr className="bg-slate-100 border-t-2 border-slate-300">
-                      <td colSpan={6} className="px-3 py-1.5 text-right font-medium text-sm">
-                        Current Batch Total:
-                      </td>
-                      <td className="px-3 py-1.5 text-right font-mono font-medium">
-                        £{fmtAmt(currentBatchTotal)}
-                      </td>
-                      <td colSpan={hasRemovable && canCreate ? 2 : 1} />
-                    </tr>
-                    {selectedRemove.size > 0 && (
-                      <tr className="bg-slate-100">
-                        <td colSpan={6} className="px-3 py-1.5 text-right font-medium text-sm">
-                          New Batch Total:
-                        </td>
-                        <td className="px-3 py-1.5 text-right font-mono font-medium">
-                          £{fmtAmt(newBatchTotal)}
-                        </td>
-                        <td colSpan={hasRemovable && canCreate ? 2 : 1} />
-                      </tr>
-                    )}
-                  </tfoot>
-                )}
-              </table>
-            </div>
-
-            {/* Action buttons below the table */}
-            <div className="flex flex-wrap gap-3">
-              {canCreate && hasRemovable && (
-                <>
-                  <button
-                    onClick={handleRemoveFromBatch}
-                    disabled={removing || selectedRemove.size === 0}
-                    className={btnPrimary}
-                  >
-                    {removing ? 'Removing…' : 'Update Transaction'}
-                  </button>
-                  <button
-                    onClick={() => setSelectedRemove(new Set())}
-                    disabled={removing || selectedRemove.size === 0}
-                    className={btnSecondary}
-                  >
-                    Cancel
-                  </button>
-                </>
-              )}
-              {canCreate && (
-                <button onClick={openAddTxns} className={btnPrimary}>
-                  Add transactions
-                </button>
-              )}
-              {canDelete && viewBatch.transactions.length === 0 && (
-                <button onClick={() => handleDeleteBatch(viewBatch.id)} className={btnDanger}>
-                  Delete batch
-                </button>
-              )}
-            </div>
-          </div>
+          <CreditBatchDetail
+            viewBatch={viewBatch}
+            setViewBatch={setViewBatch}
+            canCreate={canCreate}
+            canDelete={canDelete}
+            editRef={editRef}
+            setEditRef={setEditRef}
+            editDate={editDate}
+            setEditDate={setEditDate}
+            editDesc={editDesc}
+            setEditDesc={setEditDesc}
+            saving={saving}
+            handleSaveBatchDetails={handleSaveBatchDetails}
+            selectedRemove={selectedRemove}
+            setSelectedRemove={setSelectedRemove}
+            toggleRemove={toggleRemove}
+            removing={removing}
+            handleRemoveFromBatch={handleRemoveFromBatch}
+            openAddTxns={openAddTxns}
+            handleDeleteBatch={handleDeleteBatch}
+            currentBatchTotal={currentBatchTotal}
+            newBatchTotal={newBatchTotal}
+            hasRemovable={hasRemovable}
+          />
         )}
 
         {/* ─── Add transactions to existing batch (from detail view) ──── */}
         {viewBatch && showAddTxns && (
-          <div>
-            <div className="flex items-center gap-4 mb-4">
-              <button onClick={() => setShowAddTxns(false)} className={btnSecondary}>
-                &larr; Back to batch
-              </button>
-              <h2 className="text-lg font-bold">Add transactions to: {viewBatch.batch_ref}</h2>
-            </div>
-
-            {loadingAddTxns ? (
-              <p className="text-center text-slate-500 py-8">Loading unbatched transactions…</p>
-            ) : addUnbatched.length === 0 ? (
-              <p className="text-sm text-slate-500">No unbatched credit transactions available.</p>
-            ) : (
-              <>
-                <div className="flex flex-wrap gap-3 mb-3 items-center">
-                  <button
-                    onClick={() => setSelectedAdd(new Set(addUnbatched.map((t) => t.id)))}
-                    className="text-blue-700 hover:underline text-sm"
-                  >
-                    Select All
-                  </button>
-                  <button
-                    onClick={() => setSelectedAdd(new Set())}
-                    className="text-blue-700 hover:underline text-sm"
-                  >
-                    Clear
-                  </button>
-                  <span className="text-sm text-slate-500">{selectedAdd.size} selected</span>
-                </div>
-
-                <div className="overflow-x-auto mb-4">
-                  <table className="min-w-max w-full text-sm border border-slate-300">
-                    <thead>
-                      <tr className="bg-slate-50">
-                        <th className="px-2 py-1 border-b border-slate-300 w-8">
-                          <input
-                            type="checkbox"
-                            checked={
-                              selectedAdd.size === addUnbatched.length && addUnbatched.length > 0
-                            }
-                            onChange={() =>
-                              selectedAdd.size === addUnbatched.length
-                                ? setSelectedAdd(new Set())
-                                : setSelectedAdd(new Set(addUnbatched.map((t) => t.id)))
-                            }
-                          />
-                        </th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">#</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">Date</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">From/To</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">Detail</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">Method</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">Ref</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-right">
-                          Amount (£)
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {addUnbatched.map((t, i) => (
-                        <tr
-                          key={t.id}
-                          className={`cursor-pointer ${selectedAdd.has(t.id) ? 'bg-blue-50' : i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}`}
-                          onClick={() => toggleAdd(t.id)}
-                        >
-                          <td className="px-2 py-1 border-b border-slate-200 text-center">
-                            <input type="checkbox" checked={selectedAdd.has(t.id)} readOnly />
-                          </td>
-                          <td className="px-3 py-1 border-b border-slate-200 font-mono text-xs text-slate-500">
-                            {t.transaction_number}
-                          </td>
-                          <td className="px-3 py-1 border-b border-slate-200">{fmtDate(t.date)}</td>
-                          <td className="px-3 py-1 border-b border-slate-200">{t.from_to ?? ''}</td>
-                          <td className="px-3 py-1 border-b border-slate-200">{t.detail ?? ''}</td>
-                          <td className="px-3 py-1 border-b border-slate-200">
-                            {t.payment_method ?? ''}
-                          </td>
-                          <td className="px-3 py-1 border-b border-slate-200">
-                            {t.payment_ref ?? ''}
-                          </td>
-                          <td className="px-3 py-1 border-b border-slate-200 text-right font-mono">
-                            {fmtAmt(t.amount)}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                    {selectedAdd.size > 0 && (
-                      <tfoot>
-                        <tr className="bg-slate-50 font-medium">
-                          <td
-                            colSpan={7}
-                            className="px-3 py-1 border-t border-slate-300 text-right"
-                          >
-                            Selected total:
-                          </td>
-                          <td className="px-3 py-1 border-t border-slate-300 text-right font-mono">
-                            {fmtAmt(
-                              addUnbatched
-                                .filter((t) => selectedAdd.has(t.id))
-                                .reduce((s, t) => s + t.amount, 0),
-                            )}
-                          </td>
-                        </tr>
-                      </tfoot>
-                    )}
-                  </table>
-                </div>
-
-                <div className="flex gap-3">
-                  <button
-                    onClick={handleAddTxnsToBatch}
-                    disabled={addingTxns || selectedAdd.size === 0}
-                    className={btnPrimary}
-                  >
-                    {addingTxns ? 'Adding…' : `Add ${selectedAdd.size} to batch`}
-                  </button>
-                  <button onClick={() => setShowAddTxns(false)} className={btnSecondary}>
-                    Cancel
-                  </button>
-                </div>
-              </>
-            )}
-          </div>
+          <CreditBatchAddTxns
+            viewBatch={viewBatch}
+            setShowAddTxns={setShowAddTxns}
+            loadingAddTxns={loadingAddTxns}
+            addUnbatched={addUnbatched}
+            selectedAdd={selectedAdd}
+            setSelectedAdd={setSelectedAdd}
+            toggleAdd={toggleAdd}
+            addingTxns={addingTxns}
+            handleAddTxnsToBatch={handleAddTxnsToBatch}
+          />
         )}
 
         {/* ─── Create new batch ────────────────────────────────────────── */}
         {showCreate && (
-          <div>
-            <div className="flex items-center gap-4 mb-4">
-              <button onClick={() => setShowCreate(false)} className={btnSecondary}>
-                &larr; Back
-              </button>
-              <h2 className="text-lg font-bold">Select transactions for batch</h2>
-            </div>
-
-            {loadingUnbatched ? (
-              <p className="text-sm text-slate-500">Loading unbatched transactions...</p>
-            ) : unbatched.length === 0 ? (
-              <p className="text-sm text-slate-500">No unbatched credit transactions available.</p>
-            ) : (
-              <>
-                <div className="flex flex-wrap gap-3 mb-3 items-center">
-                  <button
-                    onClick={() => setSelectedCreate(new Set(unbatched.map((t) => t.id)))}
-                    className="text-blue-700 hover:underline text-sm"
-                  >
-                    Select All
-                  </button>
-                  <button
-                    onClick={() => setSelectedCreate(new Set())}
-                    className="text-blue-700 hover:underline text-sm"
-                  >
-                    Clear
-                  </button>
-                  <span className="text-sm text-slate-500">{selectedCreate.size} selected</span>
-                </div>
-
-                <div className="overflow-x-auto mb-4">
-                  <table className="min-w-max w-full text-sm border border-slate-300">
-                    <thead>
-                      <tr className="bg-slate-50">
-                        <th className="px-2 py-1 border-b border-slate-300 w-8">
-                          <input
-                            type="checkbox"
-                            checked={
-                              selectedCreate.size === unbatched.length && unbatched.length > 0
-                            }
-                            onChange={() =>
-                              selectedCreate.size === unbatched.length
-                                ? setSelectedCreate(new Set())
-                                : setSelectedCreate(new Set(unbatched.map((t) => t.id)))
-                            }
-                          />
-                        </th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">#</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">Date</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">From/To</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">Detail</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">Method</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-left">Ref</th>
-                        <th className="px-3 py-1 border-b border-slate-300 text-right">
-                          Amount (£)
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {unbatched.map((t, i) => (
-                        <tr
-                          key={t.id}
-                          className={`cursor-pointer ${selectedCreate.has(t.id) ? 'bg-blue-50' : i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}`}
-                          onClick={() => toggleCreate(t.id)}
-                        >
-                          <td className="px-2 py-1 border-b border-slate-200 text-center">
-                            <input type="checkbox" checked={selectedCreate.has(t.id)} readOnly />
-                          </td>
-                          <td className="px-3 py-1 border-b border-slate-200 font-mono text-xs text-slate-500">
-                            {t.transaction_number}
-                          </td>
-                          <td className="px-3 py-1 border-b border-slate-200">{fmtDate(t.date)}</td>
-                          <td className="px-3 py-1 border-b border-slate-200">{t.from_to ?? ''}</td>
-                          <td className="px-3 py-1 border-b border-slate-200">{t.detail ?? ''}</td>
-                          <td className="px-3 py-1 border-b border-slate-200">
-                            {t.payment_method ?? ''}
-                          </td>
-                          <td className="px-3 py-1 border-b border-slate-200">
-                            {t.payment_ref ?? ''}
-                          </td>
-                          <td className="px-3 py-1 border-b border-slate-200 text-right font-mono">
-                            {fmtAmt(t.amount)}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                    {selectedCreate.size > 0 && (
-                      <tfoot>
-                        <tr className="bg-slate-50 font-medium">
-                          <td
-                            colSpan={7}
-                            className="px-3 py-1 border-t border-slate-300 text-right"
-                          >
-                            Selected total:
-                          </td>
-                          <td className="px-3 py-1 border-t border-slate-300 text-right font-mono">
-                            {fmtAmt(
-                              unbatched
-                                .filter((t) => selectedCreate.has(t.id))
-                                .reduce((s, t) => s + t.amount, 0),
-                            )}
-                          </td>
-                        </tr>
-                      </tfoot>
-                    )}
-                  </table>
-                </div>
-
-                {selectedCreate.size > 0 && (
-                  <div className="bg-white/90 rounded-lg shadow-sm p-4 space-y-4">
-                    {/* Create new batch */}
-                    <div className="flex flex-wrap items-end gap-3">
-                      <div>
-                        <label className="block text-sm font-medium text-slate-700 mb-1">
-                          Batch Reference
-                        </label>
-                        <input
-                          type="text"
-                          name="batchRef"
-                          value={batchRef}
-                          onChange={(e) => setBatchRef(e.target.value)}
-                          placeholder="e.g. 12 Mar 2026"
-                          className={inputCls}
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-slate-700 mb-1">
-                          Description
-                        </label>
-                        <input
-                          type="text"
-                          name="batchDesc"
-                          value={batchDesc}
-                          onChange={(e) => setBatchDesc(e.target.value)}
-                          placeholder="Optional description"
-                          className={inputCls}
-                        />
-                      </div>
-                      <button
-                        onClick={handleCreateBatch}
-                        disabled={creating || !batchRef.trim()}
-                        className={btnPrimary}
-                      >
-                        {creating ? 'Creating...' : 'Create Batch'}
-                      </button>
-                    </div>
-
-                    {/* Add to existing batch */}
-                    {unclearedBatches.length > 0 && (
-                      <div className="flex flex-wrap items-end gap-3 border-t border-slate-200 pt-4">
-                        <div>
-                          <label className="block text-sm font-medium text-slate-700 mb-1">
-                            Or add to existing batch
-                          </label>
-                          <select
-                            name="existingBatchId"
-                            value={existingBatchId}
-                            onChange={(e) => setExistingBatchId(e.target.value)}
-                            className={inputCls}
-                          >
-                            <option value="">— select batch —</option>
-                            {unclearedBatches.map((b) => (
-                              <option key={b.id} value={b.id}>
-                                {b.batch_ref} ({b.txn_count} txns, £{fmtAmt(b.total_amount)})
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <button
-                          onClick={handleAddToExisting}
-                          disabled={creating || !existingBatchId}
-                          className={btnPrimary}
-                        >
-                          Add to Existing
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
+          <CreditBatchCreate
+            setShowCreate={setShowCreate}
+            loadingUnbatched={loadingUnbatched}
+            unbatched={unbatched}
+            selectedCreate={selectedCreate}
+            setSelectedCreate={setSelectedCreate}
+            toggleCreate={toggleCreate}
+            batchRef={batchRef}
+            setBatchRef={setBatchRef}
+            batchDesc={batchDesc}
+            setBatchDesc={setBatchDesc}
+            creating={creating}
+            handleCreateBatch={handleCreateBatch}
+            unclearedBatches={unclearedBatches}
+            existingBatchId={existingBatchId}
+            setExistingBatchId={setExistingBatchId}
+            handleAddToExisting={handleAddToExisting}
+          />
         )}
       </div>
     </div>

--- a/frontend/src/pages/finance/FinanceLedger.jsx
+++ b/frontend/src/pages/finance/FinanceLedger.jsx
@@ -3,7 +3,7 @@
 // Implements Beacon doc 7.1.
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   finance as financeApi,
   groups as groupsApi,
@@ -13,22 +13,11 @@ import {
 import { useAuth } from '../../context/AuthContext.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
-import SortableHeader from '../../components/SortableHeader.jsx';
 import ScrollButtons from '../../components/ScrollButtons.jsx';
 import { useSortedData } from '../../hooks/useSortedData.js';
-
-const VIEWS = ['account', 'category', 'group', 'event'];
-const VIEW_LABELS = {
-  account: 'Account',
-  category: 'Category',
-  group: 'Group/Team',
-  event: 'Event',
-};
-const thisYear = new Date().getFullYear();
-const YEARS = Array.from({ length: 6 }, (_, i) => thisYear - i);
-
-const fmtDate = (d) => (d ? new Date(d).toLocaleDateString('en-GB') : '');
-const fmtAmount = (n) => (n != null ? `£${Number(n).toFixed(2)}` : '');
+import { VIEWS, thisYear, fmtAmount, isEligible } from './financeLedgerUtils.js';
+import FinanceLedgerControls from './FinanceLedgerControls.jsx';
+import FinanceLedgerTable from './FinanceLedgerTable.jsx';
 
 export default function FinanceLedger() {
   const { can, tenant } = useAuth();
@@ -219,9 +208,6 @@ export default function FinanceLedger() {
     return { in: inTotal, out: outTotal };
   }, [txns, view]);
 
-  // Bulk action eligibility: not cleared, not in a batch, not a transfer, in the current year
-  const isEligible = (t) => !t.cleared_at && !t.batch_id && !t.transfer_id;
-
   const eligibleIds = useMemo(() => {
     return new Set(txns.filter(isEligible).map((t) => t.id));
   }, [txns]);
@@ -275,10 +261,6 @@ export default function FinanceLedger() {
       : []),
   ];
 
-  const TH = 'px-2 py-2.5 font-normal';
-  // Columns before "In": (Account when not account view) + #, Date, Batch, From/To, Group/Team, Mem#, Detail, Category, PayRef, Method
-  const dataLeadingCols = (view !== 'account' ? 1 : 0) + 10;
-
   return (
     <div className="min-h-screen pb-10">
       <PageHeader tenant={tenant} />
@@ -288,157 +270,26 @@ export default function FinanceLedger() {
         <h1 className="text-xl font-bold text-center mb-4">Financial Ledger</h1>
 
         {/* Controls */}
-        <div className="bg-white/90 rounded-lg shadow-sm p-4 mb-4 flex flex-wrap gap-4 items-end">
-          {/* View selector */}
-          <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">View by</label>
-            <div className="flex gap-1">
-              {VIEWS.map((v) => (
-                <button
-                  key={v}
-                  onClick={() => {
-                    setView(v);
-                    setSearchParams({ view: v });
-                  }}
-                  className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
-                    view === v
-                      ? 'bg-blue-600 text-white'
-                      : 'border border-slate-300 text-slate-700 hover:bg-slate-50'
-                  }`}
-                >
-                  {VIEW_LABELS[v]}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* Selector */}
-          <div className="flex-1 min-w-[180px]">
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              {VIEW_LABELS[view]}
-            </label>
-            {view === 'group' && (
-              <input
-                type="text"
-                name="groupFilter"
-                value={groupFilter}
-                onChange={(e) => setGroupFilter(e.target.value)}
-                placeholder="Filter groups & teams…"
-                className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 mb-1"
-              />
-            )}
-            {view === 'event' ? (
-              selId ? (
-                <div className="flex items-center gap-2 border border-slate-300 rounded px-3 py-2 text-sm bg-slate-50">
-                  <span className="flex-1 text-slate-700">{eventLabel || 'Selected event'}</span>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSelId('');
-                      setEventLabel('');
-                      setEventSearch('');
-                      setEventResults([]);
-                    }}
-                    className="text-red-600 hover:underline text-xs"
-                  >
-                    Clear
-                  </button>
-                </div>
-              ) : (
-                <>
-                  <input
-                    type="text"
-                    name="eventSearch"
-                    value={eventSearch}
-                    onChange={(e) => setEventSearch(e.target.value)}
-                    placeholder="Search by topic, group name, or date…"
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                  {eventResults.length > 0 && (
-                    <ul className="border border-slate-200 rounded max-h-40 overflow-y-auto text-sm bg-white mt-1">
-                      {eventResults.map((ev) => {
-                        const lbl = ev.topic || ev.group_name || ev.event_type_name || 'Event';
-                        const d = ev.event_date ? String(ev.event_date).slice(0, 10) : '';
-                        return (
-                          <li key={ev.id}>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                setSelId(ev.id);
-                                setEventLabel(`${lbl}${d ? ` — ${d}` : ''}`);
-                                setEventSearch('');
-                                setEventResults([]);
-                              }}
-                              className="block w-full text-left px-2 py-1 hover:bg-blue-50"
-                            >
-                              {lbl}
-                              {d ? ` — ${d}` : ''}
-                            </button>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  )}
-                </>
-              )
-            ) : (
-              <select
-                name="selId"
-                value={selId}
-                onChange={(e) => setSelId(e.target.value)}
-                className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value="">— select —</option>
-                {view === 'account' &&
-                  accounts.map((a) => (
-                    <option key={a.id} value={a.id}>
-                      {a.name}
-                    </option>
-                  ))}
-                {view === 'category' &&
-                  categories.map((c) => (
-                    <option key={c.id} value={c.id}>
-                      {c.name}
-                    </option>
-                  ))}
-                {view === 'group' && (
-                  <>
-                    <option value="all">All groups &amp; teams</option>
-                    {filteredGroups.map((g) => (
-                      <option
-                        key={g.id}
-                        value={g.id}
-                        style={g.status === 'inactive' ? { color: '#dc2626' } : {}}
-                      >
-                        {g.short_name || g.name}
-                        {g.status === 'inactive' ? ' (inactive)' : ''}
-                      </option>
-                    ))}
-                  </>
-                )}
-              </select>
-            )}
-          </div>
-
-          {/* Year — not used in event view (all transactions for the event are shown) */}
-          {view !== 'event' && (
-            <div>
-              <label className="block text-xs font-medium text-slate-600 mb-1">Year</label>
-              <select
-                name="year"
-                value={year}
-                onChange={(e) => setYear(Number(e.target.value))}
-                className="border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                {YEARS.map((y) => (
-                  <option key={y} value={y}>
-                    {y}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-        </div>
+        <FinanceLedgerControls
+          view={view}
+          setView={setView}
+          setSearchParams={setSearchParams}
+          year={year}
+          setYear={setYear}
+          accounts={accounts}
+          categories={categories}
+          filteredGroups={filteredGroups}
+          selId={selId}
+          setSelId={setSelId}
+          groupFilter={groupFilter}
+          setGroupFilter={setGroupFilter}
+          eventSearch={eventSearch}
+          setEventSearch={setEventSearch}
+          eventResults={eventResults}
+          setEventResults={setEventResults}
+          eventLabel={eventLabel}
+          setEventLabel={setEventLabel}
+        />
 
         {loading && <p className="text-center text-slate-500 py-8">Loading…</p>}
         {error && <p className="text-center text-red-600 py-4">Error: {error}</p>}
@@ -460,372 +311,24 @@ export default function FinanceLedger() {
               </p>
             ) : (
               <>
-                <div className="overflow-x-auto rounded-lg shadow-sm" ref={tableRef}>
-                  <table className="w-full text-sm bg-white min-w-max">
-                    <thead>
-                      <tr className="bg-slate-50 border-b border-slate-200 text-left text-slate-600 italic font-normal">
-                        {showBulk && (
-                          <th className="px-2 py-2.5 w-8">
-                            <input
-                              type="checkbox"
-                              checked={eligibleIds.size > 0 && selected.size === eligibleIds.size}
-                              onChange={toggleAll}
-                              className="h-4 w-4 rounded border-slate-300"
-                              title="Select all eligible"
-                            />
-                          </th>
-                        )}
-                        {view !== 'account' && (
-                          <SortableHeader
-                            col="account_name"
-                            label="Account"
-                            sortKey={sortKey}
-                            sortDir={sortDir}
-                            onSort={onSort}
-                            className={TH}
-                          />
-                        )}
-                        <SortableHeader
-                          col="transaction_number"
-                          label="#"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <SortableHeader
-                          col="date"
-                          label="Date"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <SortableHeader
-                          col="batch_no"
-                          label="Batch"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <SortableHeader
-                          col="from_to"
-                          label="From/To"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <SortableHeader
-                          col="group_name"
-                          label="Group/Team"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <SortableHeader
-                          col="member_1_no"
-                          label="Mem#"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <SortableHeader
-                          col="detail"
-                          label="Detail"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <SortableHeader
-                          col="category_list"
-                          label="Category"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <SortableHeader
-                          col="payment_ref"
-                          label="Payment Ref"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <SortableHeader
-                          col="payment_method"
-                          label="Method"
-                          sortKey={sortKey}
-                          sortDir={sortDir}
-                          onSort={onSort}
-                          className={TH}
-                        />
-                        <th className={`${TH} text-right`}>In</th>
-                        <th className={`${TH} text-right`}>Out</th>
-                        <th className={`${TH} text-right`}>Balance</th>
-                        <th className={`${TH} text-center`}>Cleared</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {view === 'account' && (
-                        <tr className="bg-slate-100 border-b border-slate-200 italic text-slate-600">
-                          {showBulk && <td className="px-2 py-2"></td>}
-                          <td className="px-2 py-2" colSpan={dataLeadingCols}>
-                            Balance brought forward
-                          </td>
-                          <td className="px-2 py-2"></td>
-                          <td className="px-2 py-2"></td>
-                          <td className="px-2 py-2 text-right font-medium text-slate-700">
-                            {fmtAmount(openingBal)}
-                          </td>
-                          <td className="px-2 py-2"></td>
-                        </tr>
-                      )}
-                      {view === 'group' &&
-                        groupBf.length > 0 &&
-                        groupBf.map((bf) => (
-                          <tr
-                            key={`bf-${bf.group_id}`}
-                            className="bg-slate-100 border-b border-slate-200 italic text-slate-600"
-                          >
-                            <td className="px-2 py-2" colSpan={dataLeadingCols}>
-                              Balance b/f
-                              {bf.group_name ? ` — ${bf.group_short_name || bf.group_name}` : ''}
-                            </td>
-                            <td className="px-2 py-2 text-right text-green-700">
-                              {bf.balance >= 0 ? fmtAmount(bf.balance) : ''}
-                            </td>
-                            <td className="px-2 py-2 text-right text-red-700">
-                              {bf.balance < 0 ? fmtAmount(Math.abs(bf.balance)) : ''}
-                            </td>
-                            <td className="px-2 py-2"></td>
-                            <td className="px-2 py-2"></td>
-                          </tr>
-                        ))}
-                      {view === 'group' &&
-                        groupBf.length > 0 &&
-                        (() => {
-                          const totalBf = groupBf.reduce((s, bf) => s + bf.balance, 0);
-                          return (
-                            <tr className="bg-slate-200 border-b border-slate-300 font-bold text-slate-700">
-                              <td className="px-2 py-2" colSpan={dataLeadingCols}>
-                                Total Brought Forward
-                              </td>
-                              <td className="px-2 py-2 text-right text-green-700">
-                                {totalBf >= 0 ? fmtAmount(totalBf) : ''}
-                              </td>
-                              <td className="px-2 py-2 text-right text-red-700">
-                                {totalBf < 0 ? fmtAmount(Math.abs(totalBf)) : ''}
-                              </td>
-                              <td className="px-2 py-2"></td>
-                              <td className="px-2 py-2"></td>
-                            </tr>
-                          );
-                        })()}
-                      {withBalance.map((t, i) => (
-                        <tr
-                          key={t.id}
-                          className={`border-b border-slate-100 ${t.refund_of_id ? 'bg-red-50 text-red-700' : i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}`}
-                        >
-                          {showBulk && (
-                            <td className="px-2 py-2">
-                              {isEligible(t) && (
-                                <input
-                                  type="checkbox"
-                                  checked={selected.has(t.id)}
-                                  onChange={() => toggleSelect(t.id)}
-                                  className="h-4 w-4 rounded border-slate-300"
-                                />
-                              )}
-                            </td>
-                          )}
-                          {/* Account — hidden in account view (redundant) */}
-                          {view !== 'account' && (
-                            <td className="px-2 py-2 whitespace-nowrap">{t.account_name ?? ''}</td>
-                          )}
-                          {/* # — refund indicators ↩/↪ appear inline when a refund relationship exists */}
-                          <td className="px-2 py-2">
-                            <div className="flex items-center gap-1">
-                              {can('finance_transactions', 'view') ? (
-                                <button
-                                  onClick={() => navigate(`/finance/transactions/${t.id}`)}
-                                  className="text-blue-700 hover:underline font-mono"
-                                >
-                                  {t.transaction_number}
-                                </button>
-                              ) : (
-                                <span className="font-mono">{t.transaction_number}</span>
-                              )}
-                              {t.refund_of_id && (
-                                <button
-                                  onClick={() =>
-                                    navigate(`/finance/transactions/${t.refund_of_id}`)
-                                  }
-                                  className="text-red-500 hover:text-red-700 text-xs leading-none"
-                                  title={`Refund of #${t.refund_of_txn_number}`}
-                                >
-                                  ↩
-                                </button>
-                              )}
-                              {t.refunded_by_id && (
-                                <button
-                                  onClick={() =>
-                                    navigate(`/finance/transactions/${t.refunded_by_id}`)
-                                  }
-                                  className="text-blue-500 hover:text-blue-700 text-xs leading-none"
-                                  title={`Refunded by #${t.refunded_by_txn_number}`}
-                                >
-                                  ↪
-                                </button>
-                              )}
-                            </div>
-                          </td>
-                          {/* Date */}
-                          <td className="px-2 py-2 whitespace-nowrap">{fmtDate(t.date)}</td>
-                          {/* Batch — number as link; hover for description */}
-                          <td className="px-2 py-2">
-                            {t.batch_no && can('finance_batches', 'view') ? (
-                              <button
-                                onClick={() => navigate(`/finance/batches?batchId=${t.batch_id}`)}
-                                className="text-blue-700 hover:underline"
-                                title={
-                                  t.batch_description
-                                    ? `${t.batch_no}: ${t.batch_description}`
-                                    : t.batch_no
-                                }
-                              >
-                                {t.batch_no}
-                              </button>
-                            ) : (
-                              <span title={t.batch_description ?? ''}>{t.batch_no ?? ''}</span>
-                            )}
-                          </td>
-                          {/* From/To */}
-                          <td className="px-2 py-2 max-w-[140px] truncate" title={t.from_to}>
-                            {t.from_to}
-                          </td>
-                          {/* Group / Event */}
-                          <td
-                            className="px-2 py-2 max-w-[120px] truncate"
-                            title={t.group_name ?? ''}
-                          >
-                            {t.group_name && t.group_id ? (
-                              <Link
-                                to={`/${t.group_type === 'team' ? 'teams' : 'groups'}/${t.group_id}`}
-                                className="text-blue-700 hover:underline"
-                              >
-                                {t.group_short_name || t.group_name}
-                              </Link>
-                            ) : (
-                              t.group_short_name || t.group_name || ''
-                            )}
-                            {t.event_id && (
-                              <div className="text-xs">
-                                <Link
-                                  to={`/calendar/events/${t.event_id}`}
-                                  className="text-blue-600 hover:underline"
-                                >
-                                  {t.event_label || t.event_topic || 'Event'}
-                                </Link>
-                              </div>
-                            )}
-                          </td>
-                          {/* Mem# — 2nd member shown below when present */}
-                          <td className="px-2 py-2">
-                            {t.member_1_no && t.member_id_1 && (
-                              <Link
-                                to={`/members/${t.member_id_1}`}
-                                className="text-blue-700 hover:underline font-mono block"
-                                title={t.member_1_name}
-                              >
-                                {t.member_1_no}
-                              </Link>
-                            )}
-                            {t.member_2_no && t.member_id_2 && (
-                              <Link
-                                to={`/members/${t.member_id_2}`}
-                                className="text-blue-700 hover:underline font-mono text-xs block"
-                                title={t.member_2_name}
-                              >
-                                {t.member_2_no}
-                              </Link>
-                            )}
-                          </td>
-                          {/* Detail */}
-                          <td className="px-2 py-2 max-w-[180px] truncate" title={t.detail}>
-                            {t.detail}
-                          </td>
-                          {/* Category */}
-                          <td className="px-2 py-2 max-w-[140px] truncate" title={t.category_list}>
-                            {t.category_list}
-                          </td>
-                          {/* Payment Ref */}
-                          <td className="px-2 py-2">{t.payment_ref ?? ''}</td>
-                          {/* Method */}
-                          <td className="px-2 py-2">{t.payment_method}</td>
-                          {/* In */}
-                          <td className="px-2 py-2 text-right text-green-700">
-                            {t.type === 'in'
-                              ? fmtAmount(view === 'category' ? t.category_amount : t.amount)
-                              : ''}
-                          </td>
-                          {/* Out */}
-                          <td className="px-2 py-2 text-right text-red-700">
-                            {t.type === 'out'
-                              ? fmtAmount(view === 'category' ? t.category_amount : t.amount)
-                              : ''}
-                          </td>
-                          {/* Balance */}
-                          <td
-                            className={`px-2 py-2 text-right font-medium ${
-                              t.pending
-                                ? 'text-slate-400 italic'
-                                : t._balance >= 0
-                                  ? 'text-slate-700'
-                                  : 'text-red-600'
-                            }`}
-                          >
-                            {t.pending ? '' : fmtAmount(t._balance)}
-                          </td>
-                          {/* Cleared */}
-                          <td className="px-2 py-2 text-center text-xs text-slate-500">
-                            {t.pending ? (
-                              <span className="text-amber-600 font-medium">Pending</span>
-                            ) : t.cleared_at ? (
-                              fmtDate(t.cleared_at)
-                            ) : (
-                              ''
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                    <tfoot>
-                      <tr className="bg-slate-100 border-t-2 border-slate-300 font-medium text-sm">
-                        {showBulk && <td></td>}
-                        <td
-                          colSpan={dataLeadingCols}
-                          className="px-2 py-2 text-right text-slate-600"
-                        >
-                          Totals:
-                        </td>
-                        <td className="px-2 py-2 text-right text-green-700">
-                          {fmtAmount(totals.in)}
-                        </td>
-                        <td className="px-2 py-2 text-right text-red-700">
-                          {fmtAmount(totals.out)}
-                        </td>
-                        <td></td>
-                        <td></td>
-                      </tr>
-                    </tfoot>
-                  </table>
-                </div>
+                <FinanceLedgerTable
+                  view={view}
+                  showBulk={showBulk}
+                  eligibleIds={eligibleIds}
+                  selected={selected}
+                  toggleAll={toggleAll}
+                  toggleSelect={toggleSelect}
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onSort={onSort}
+                  withBalance={withBalance}
+                  openingBal={openingBal}
+                  groupBf={groupBf}
+                  totals={totals}
+                  tableRef={tableRef}
+                  can={can}
+                  navigate={navigate}
+                />
 
                 {/* Bulk actions bar — below the table per standard */}
                 {showBulk && eligibleIds.size > 0 && (

--- a/frontend/src/pages/finance/FinanceLedgerControls.jsx
+++ b/frontend/src/pages/finance/FinanceLedgerControls.jsx
@@ -1,0 +1,180 @@
+// beacon2/frontend/src/pages/finance/FinanceLedgerControls.jsx
+//
+// Controls bar of FinanceLedger — the view selector, the account/category/group/
+// event picker, and the year selector. Presentation only: all state and handlers
+// are owned by the parent.
+
+import { VIEWS, VIEW_LABELS, YEARS } from './financeLedgerUtils.js';
+
+export default function FinanceLedgerControls({
+  view,
+  setView,
+  setSearchParams,
+  year,
+  setYear,
+  accounts,
+  categories,
+  filteredGroups,
+  selId,
+  setSelId,
+  groupFilter,
+  setGroupFilter,
+  eventSearch,
+  setEventSearch,
+  eventResults,
+  setEventResults,
+  eventLabel,
+  setEventLabel,
+}) {
+  return (
+    <div className="bg-white/90 rounded-lg shadow-sm p-4 mb-4 flex flex-wrap gap-4 items-end">
+      {/* View selector */}
+      <div>
+        <label className="block text-xs font-medium text-slate-600 mb-1">View by</label>
+        <div className="flex gap-1">
+          {VIEWS.map((v) => (
+            <button
+              key={v}
+              onClick={() => {
+                setView(v);
+                setSearchParams({ view: v });
+              }}
+              className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
+                view === v
+                  ? 'bg-blue-600 text-white'
+                  : 'border border-slate-300 text-slate-700 hover:bg-slate-50'
+              }`}
+            >
+              {VIEW_LABELS[v]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Selector */}
+      <div className="flex-1 min-w-[180px]">
+        <label className="block text-xs font-medium text-slate-600 mb-1">{VIEW_LABELS[view]}</label>
+        {view === 'group' && (
+          <input
+            type="text"
+            name="groupFilter"
+            value={groupFilter}
+            onChange={(e) => setGroupFilter(e.target.value)}
+            placeholder="Filter groups & teams…"
+            className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 mb-1"
+          />
+        )}
+        {view === 'event' ? (
+          selId ? (
+            <div className="flex items-center gap-2 border border-slate-300 rounded px-3 py-2 text-sm bg-slate-50">
+              <span className="flex-1 text-slate-700">{eventLabel || 'Selected event'}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  setSelId('');
+                  setEventLabel('');
+                  setEventSearch('');
+                  setEventResults([]);
+                }}
+                className="text-red-600 hover:underline text-xs"
+              >
+                Clear
+              </button>
+            </div>
+          ) : (
+            <>
+              <input
+                type="text"
+                name="eventSearch"
+                value={eventSearch}
+                onChange={(e) => setEventSearch(e.target.value)}
+                placeholder="Search by topic, group name, or date…"
+                className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              {eventResults.length > 0 && (
+                <ul className="border border-slate-200 rounded max-h-40 overflow-y-auto text-sm bg-white mt-1">
+                  {eventResults.map((ev) => {
+                    const lbl = ev.topic || ev.group_name || ev.event_type_name || 'Event';
+                    const d = ev.event_date ? String(ev.event_date).slice(0, 10) : '';
+                    return (
+                      <li key={ev.id}>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSelId(ev.id);
+                            setEventLabel(`${lbl}${d ? ` — ${d}` : ''}`);
+                            setEventSearch('');
+                            setEventResults([]);
+                          }}
+                          className="block w-full text-left px-2 py-1 hover:bg-blue-50"
+                        >
+                          {lbl}
+                          {d ? ` — ${d}` : ''}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </>
+          )
+        ) : (
+          <select
+            name="selId"
+            value={selId}
+            onChange={(e) => setSelId(e.target.value)}
+            className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">— select —</option>
+            {view === 'account' &&
+              accounts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name}
+                </option>
+              ))}
+            {view === 'category' &&
+              categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            {view === 'group' && (
+              <>
+                <option value="all">All groups &amp; teams</option>
+                {filteredGroups.map((g) => (
+                  <option
+                    key={g.id}
+                    value={g.id}
+                    style={g.status === 'inactive' ? { color: '#dc2626' } : {}}
+                  >
+                    {g.short_name || g.name}
+                    {g.status === 'inactive' ? ' (inactive)' : ''}
+                  </option>
+                ))}
+              </>
+            )}
+          </select>
+        )}
+      </div>
+
+      {/* Year — not used in event view (all transactions for the event are shown) */}
+      {view !== 'event' && (
+        <div>
+          <label className="block text-xs font-medium text-slate-600 mb-1">Year</label>
+          <select
+            name="year"
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+            className="border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {YEARS.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/finance/FinanceLedgerTable.jsx
+++ b/frontend/src/pages/finance/FinanceLedgerTable.jsx
@@ -1,0 +1,388 @@
+// beacon2/frontend/src/pages/finance/FinanceLedgerTable.jsx
+//
+// The ledger transactions table of FinanceLedger — sortable header, balance-
+// brought-forward rows, transaction rows with running balance, and the totals
+// footer. Presentation only: sorting, selection, and data are owned by the
+// parent.
+
+import { Link } from 'react-router-dom';
+import SortableHeader from '../../components/SortableHeader.jsx';
+import { fmtDate, fmtAmount, isEligible } from './financeLedgerUtils.js';
+
+const TH = 'px-2 py-2.5 font-normal';
+
+export default function FinanceLedgerTable({
+  view,
+  showBulk,
+  eligibleIds,
+  selected,
+  toggleAll,
+  toggleSelect,
+  sortKey,
+  sortDir,
+  onSort,
+  withBalance,
+  openingBal,
+  groupBf,
+  totals,
+  tableRef,
+  can,
+  navigate,
+}) {
+  // Columns before "In": (Account when not account view) + #, Date, Batch,
+  // From/To, Group/Team, Mem#, Detail, Category, PayRef, Method
+  const dataLeadingCols = (view !== 'account' ? 1 : 0) + 10;
+
+  return (
+    <div className="overflow-x-auto rounded-lg shadow-sm" ref={tableRef}>
+      <table className="w-full text-sm bg-white min-w-max">
+        <thead>
+          <tr className="bg-slate-50 border-b border-slate-200 text-left text-slate-600 italic font-normal">
+            {showBulk && (
+              <th className="px-2 py-2.5 w-8">
+                <input
+                  type="checkbox"
+                  checked={eligibleIds.size > 0 && selected.size === eligibleIds.size}
+                  onChange={toggleAll}
+                  className="h-4 w-4 rounded border-slate-300"
+                  title="Select all eligible"
+                />
+              </th>
+            )}
+            {view !== 'account' && (
+              <SortableHeader
+                col="account_name"
+                label="Account"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSort={onSort}
+                className={TH}
+              />
+            )}
+            <SortableHeader
+              col="transaction_number"
+              label="#"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <SortableHeader
+              col="date"
+              label="Date"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <SortableHeader
+              col="batch_no"
+              label="Batch"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <SortableHeader
+              col="from_to"
+              label="From/To"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <SortableHeader
+              col="group_name"
+              label="Group/Team"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <SortableHeader
+              col="member_1_no"
+              label="Mem#"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <SortableHeader
+              col="detail"
+              label="Detail"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <SortableHeader
+              col="category_list"
+              label="Category"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <SortableHeader
+              col="payment_ref"
+              label="Payment Ref"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <SortableHeader
+              col="payment_method"
+              label="Method"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+              className={TH}
+            />
+            <th className={`${TH} text-right`}>In</th>
+            <th className={`${TH} text-right`}>Out</th>
+            <th className={`${TH} text-right`}>Balance</th>
+            <th className={`${TH} text-center`}>Cleared</th>
+          </tr>
+        </thead>
+        <tbody>
+          {view === 'account' && (
+            <tr className="bg-slate-100 border-b border-slate-200 italic text-slate-600">
+              {showBulk && <td className="px-2 py-2"></td>}
+              <td className="px-2 py-2" colSpan={dataLeadingCols}>
+                Balance brought forward
+              </td>
+              <td className="px-2 py-2"></td>
+              <td className="px-2 py-2"></td>
+              <td className="px-2 py-2 text-right font-medium text-slate-700">
+                {fmtAmount(openingBal)}
+              </td>
+              <td className="px-2 py-2"></td>
+            </tr>
+          )}
+          {view === 'group' &&
+            groupBf.length > 0 &&
+            groupBf.map((bf) => (
+              <tr
+                key={`bf-${bf.group_id}`}
+                className="bg-slate-100 border-b border-slate-200 italic text-slate-600"
+              >
+                <td className="px-2 py-2" colSpan={dataLeadingCols}>
+                  Balance b/f
+                  {bf.group_name ? ` — ${bf.group_short_name || bf.group_name}` : ''}
+                </td>
+                <td className="px-2 py-2 text-right text-green-700">
+                  {bf.balance >= 0 ? fmtAmount(bf.balance) : ''}
+                </td>
+                <td className="px-2 py-2 text-right text-red-700">
+                  {bf.balance < 0 ? fmtAmount(Math.abs(bf.balance)) : ''}
+                </td>
+                <td className="px-2 py-2"></td>
+                <td className="px-2 py-2"></td>
+              </tr>
+            ))}
+          {view === 'group' &&
+            groupBf.length > 0 &&
+            (() => {
+              const totalBf = groupBf.reduce((s, bf) => s + bf.balance, 0);
+              return (
+                <tr className="bg-slate-200 border-b border-slate-300 font-bold text-slate-700">
+                  <td className="px-2 py-2" colSpan={dataLeadingCols}>
+                    Total Brought Forward
+                  </td>
+                  <td className="px-2 py-2 text-right text-green-700">
+                    {totalBf >= 0 ? fmtAmount(totalBf) : ''}
+                  </td>
+                  <td className="px-2 py-2 text-right text-red-700">
+                    {totalBf < 0 ? fmtAmount(Math.abs(totalBf)) : ''}
+                  </td>
+                  <td className="px-2 py-2"></td>
+                  <td className="px-2 py-2"></td>
+                </tr>
+              );
+            })()}
+          {withBalance.map((t, i) => (
+            <tr
+              key={t.id}
+              className={`border-b border-slate-100 ${t.refund_of_id ? 'bg-red-50 text-red-700' : i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}`}
+            >
+              {showBulk && (
+                <td className="px-2 py-2">
+                  {isEligible(t) && (
+                    <input
+                      type="checkbox"
+                      checked={selected.has(t.id)}
+                      onChange={() => toggleSelect(t.id)}
+                      className="h-4 w-4 rounded border-slate-300"
+                    />
+                  )}
+                </td>
+              )}
+              {/* Account — hidden in account view (redundant) */}
+              {view !== 'account' && (
+                <td className="px-2 py-2 whitespace-nowrap">{t.account_name ?? ''}</td>
+              )}
+              {/* # — refund indicators ↩/↪ appear inline when a refund relationship exists */}
+              <td className="px-2 py-2">
+                <div className="flex items-center gap-1">
+                  {can('finance_transactions', 'view') ? (
+                    <button
+                      onClick={() => navigate(`/finance/transactions/${t.id}`)}
+                      className="text-blue-700 hover:underline font-mono"
+                    >
+                      {t.transaction_number}
+                    </button>
+                  ) : (
+                    <span className="font-mono">{t.transaction_number}</span>
+                  )}
+                  {t.refund_of_id && (
+                    <button
+                      onClick={() => navigate(`/finance/transactions/${t.refund_of_id}`)}
+                      className="text-red-500 hover:text-red-700 text-xs leading-none"
+                      title={`Refund of #${t.refund_of_txn_number}`}
+                    >
+                      ↩
+                    </button>
+                  )}
+                  {t.refunded_by_id && (
+                    <button
+                      onClick={() => navigate(`/finance/transactions/${t.refunded_by_id}`)}
+                      className="text-blue-500 hover:text-blue-700 text-xs leading-none"
+                      title={`Refunded by #${t.refunded_by_txn_number}`}
+                    >
+                      ↪
+                    </button>
+                  )}
+                </div>
+              </td>
+              {/* Date */}
+              <td className="px-2 py-2 whitespace-nowrap">{fmtDate(t.date)}</td>
+              {/* Batch — number as link; hover for description */}
+              <td className="px-2 py-2">
+                {t.batch_no && can('finance_batches', 'view') ? (
+                  <button
+                    onClick={() => navigate(`/finance/batches?batchId=${t.batch_id}`)}
+                    className="text-blue-700 hover:underline"
+                    title={
+                      t.batch_description ? `${t.batch_no}: ${t.batch_description}` : t.batch_no
+                    }
+                  >
+                    {t.batch_no}
+                  </button>
+                ) : (
+                  <span title={t.batch_description ?? ''}>{t.batch_no ?? ''}</span>
+                )}
+              </td>
+              {/* From/To */}
+              <td className="px-2 py-2 max-w-[140px] truncate" title={t.from_to}>
+                {t.from_to}
+              </td>
+              {/* Group / Event */}
+              <td className="px-2 py-2 max-w-[120px] truncate" title={t.group_name ?? ''}>
+                {t.group_name && t.group_id ? (
+                  <Link
+                    to={`/${t.group_type === 'team' ? 'teams' : 'groups'}/${t.group_id}`}
+                    className="text-blue-700 hover:underline"
+                  >
+                    {t.group_short_name || t.group_name}
+                  </Link>
+                ) : (
+                  t.group_short_name || t.group_name || ''
+                )}
+                {t.event_id && (
+                  <div className="text-xs">
+                    <Link
+                      to={`/calendar/events/${t.event_id}`}
+                      className="text-blue-600 hover:underline"
+                    >
+                      {t.event_label || t.event_topic || 'Event'}
+                    </Link>
+                  </div>
+                )}
+              </td>
+              {/* Mem# — 2nd member shown below when present */}
+              <td className="px-2 py-2">
+                {t.member_1_no && t.member_id_1 && (
+                  <Link
+                    to={`/members/${t.member_id_1}`}
+                    className="text-blue-700 hover:underline font-mono block"
+                    title={t.member_1_name}
+                  >
+                    {t.member_1_no}
+                  </Link>
+                )}
+                {t.member_2_no && t.member_id_2 && (
+                  <Link
+                    to={`/members/${t.member_id_2}`}
+                    className="text-blue-700 hover:underline font-mono text-xs block"
+                    title={t.member_2_name}
+                  >
+                    {t.member_2_no}
+                  </Link>
+                )}
+              </td>
+              {/* Detail */}
+              <td className="px-2 py-2 max-w-[180px] truncate" title={t.detail}>
+                {t.detail}
+              </td>
+              {/* Category */}
+              <td className="px-2 py-2 max-w-[140px] truncate" title={t.category_list}>
+                {t.category_list}
+              </td>
+              {/* Payment Ref */}
+              <td className="px-2 py-2">{t.payment_ref ?? ''}</td>
+              {/* Method */}
+              <td className="px-2 py-2">{t.payment_method}</td>
+              {/* In */}
+              <td className="px-2 py-2 text-right text-green-700">
+                {t.type === 'in'
+                  ? fmtAmount(view === 'category' ? t.category_amount : t.amount)
+                  : ''}
+              </td>
+              {/* Out */}
+              <td className="px-2 py-2 text-right text-red-700">
+                {t.type === 'out'
+                  ? fmtAmount(view === 'category' ? t.category_amount : t.amount)
+                  : ''}
+              </td>
+              {/* Balance */}
+              <td
+                className={`px-2 py-2 text-right font-medium ${
+                  t.pending
+                    ? 'text-slate-400 italic'
+                    : t._balance >= 0
+                      ? 'text-slate-700'
+                      : 'text-red-600'
+                }`}
+              >
+                {t.pending ? '' : fmtAmount(t._balance)}
+              </td>
+              {/* Cleared */}
+              <td className="px-2 py-2 text-center text-xs text-slate-500">
+                {t.pending ? (
+                  <span className="text-amber-600 font-medium">Pending</span>
+                ) : t.cleared_at ? (
+                  fmtDate(t.cleared_at)
+                ) : (
+                  ''
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr className="bg-slate-100 border-t-2 border-slate-300 font-medium text-sm">
+            {showBulk && <td></td>}
+            <td colSpan={dataLeadingCols} className="px-2 py-2 text-right text-slate-600">
+              Totals:
+            </td>
+            <td className="px-2 py-2 text-right text-green-700">{fmtAmount(totals.in)}</td>
+            <td className="px-2 py-2 text-right text-red-700">{fmtAmount(totals.out)}</td>
+            <td></td>
+            <td></td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/finance/TransactionAssociations.jsx
+++ b/frontend/src/pages/finance/TransactionAssociations.jsx
@@ -1,0 +1,221 @@
+// beacon2/frontend/src/pages/finance/TransactionAssociations.jsx
+//
+// "Associate transaction with" section of TransactionEditor — member 1/2,
+// group/team, and event pickers. Presentation only: all state and handlers
+// are passed in from the parent.
+
+import { INP_CLS as INP, LBL_CLS as LBL } from './transactionEditorUtils.js';
+
+export default function TransactionAssociations({
+  form,
+  set,
+  cleared,
+  m1Filter,
+  setM1Filter,
+  filteredM1,
+  m2Filter,
+  setM2Filter,
+  filteredM2,
+  groupFilter,
+  setGroupFilter,
+  filteredGroups,
+  filteredTeams,
+  eventLabel,
+  setEventLabel,
+  eventSearch,
+  setEventSearch,
+  eventResults,
+  setEventResults,
+}) {
+  return (
+    <div className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6 mb-4">
+      <h2 className="text-sm font-semibold text-slate-700 mb-3">Associate transaction with</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {/* Member 1 */}
+        <div>
+          <label htmlFor="txn-member1" className={LBL}>
+            Member 1
+          </label>
+          <input
+            id="txn-member1-filter"
+            type="text"
+            name="m1Filter"
+            value={m1Filter}
+            onChange={(e) => setM1Filter(e.target.value)}
+            disabled={cleared}
+            className={`${INP} mb-1`}
+            placeholder="Search name / number…"
+          />
+          <select
+            id="txn-member1"
+            name="member_id_1"
+            value={form.member_id_1}
+            onChange={(e) => set('member_id_1', e.target.value)}
+            disabled={cleared}
+            className={INP}
+            size={4}
+          >
+            <option value="">— none —</option>
+            {filteredM1.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.membership_number} {m.forenames} {m.surname}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Member 2 */}
+        <div>
+          <label htmlFor="txn-member2" className={LBL}>
+            Member 2
+          </label>
+          {!form.member_id_1 && (
+            <p className="text-xs text-slate-400 mb-1">Select Member 1 first</p>
+          )}
+          <input
+            id="txn-member2-filter"
+            type="text"
+            name="m2Filter"
+            value={m2Filter}
+            onChange={(e) => setM2Filter(e.target.value)}
+            disabled={cleared || !form.member_id_1}
+            className={`${INP} mb-1`}
+            placeholder="Search name / number…"
+          />
+          <select
+            id="txn-member2"
+            name="member_id_2"
+            value={form.member_id_2}
+            onChange={(e) => set('member_id_2', e.target.value)}
+            disabled={cleared || !form.member_id_1}
+            className={INP}
+            size={4}
+          >
+            <option value="">— none —</option>
+            {filteredM2.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.membership_number} {m.forenames} {m.surname}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Group / Team */}
+        <div>
+          <label htmlFor="txn-group-filter" className={LBL}>
+            Group / Team
+          </label>
+          <input
+            id="txn-group-filter"
+            type="text"
+            placeholder="Search name / abbreviation…"
+            value={groupFilter}
+            onChange={(e) => setGroupFilter(e.target.value)}
+            disabled={cleared}
+            className={`${INP} mb-1`}
+          />
+          <select
+            id="txn-group"
+            name="group_id"
+            value={form.group_id}
+            onChange={(e) => set('group_id', e.target.value)}
+            disabled={cleared}
+            className={INP}
+            size={5}
+          >
+            <option value="">— none —</option>
+            {filteredGroups.length > 0 && (
+              <optgroup label="Groups">
+                {filteredGroups.map((g) => (
+                  <option
+                    key={g.id}
+                    value={g.id}
+                    style={g.status === 'inactive' ? { color: '#dc2626' } : {}}
+                  >
+                    {g.short_name || g.name}
+                    {g.status === 'inactive' ? ' (inactive)' : ''}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+            {filteredTeams.length > 0 && (
+              <optgroup label="Teams">
+                {filteredTeams.map((t) => (
+                  <option
+                    key={t.id}
+                    value={t.id}
+                    style={t.status === 'inactive' ? { color: '#dc2626' } : {}}
+                  >
+                    {t.short_name || t.name}
+                    {t.status === 'inactive' ? ' (inactive)' : ''}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+          </select>
+        </div>
+
+        {/* Event */}
+        <div>
+          <label htmlFor="txn-event-search" className={LBL}>
+            Event
+          </label>
+          {form.event_id ? (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-slate-700">{eventLabel || form.event_id}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  set('event_id', '');
+                  setEventLabel('');
+                  setEventSearch('');
+                }}
+                disabled={cleared}
+                className="text-red-600 hover:underline text-xs"
+              >
+                Clear
+              </button>
+            </div>
+          ) : (
+            <>
+              <input
+                id="txn-event-search"
+                type="text"
+                placeholder="Search by topic, group name, or date…"
+                value={eventSearch}
+                onChange={(e) => setEventSearch(e.target.value)}
+                disabled={cleared}
+                className={`${INP} mb-1`}
+              />
+              {eventResults.length > 0 && (
+                <ul className="border border-slate-200 rounded max-h-40 overflow-y-auto text-sm">
+                  {eventResults.map((ev) => {
+                    const lbl = ev.topic || ev.group_name || ev.event_type_name || 'Event';
+                    const d = ev.event_date ? String(ev.event_date).slice(0, 10) : '';
+                    return (
+                      <li key={ev.id}>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            set('event_id', ev.id);
+                            setEventLabel(`${lbl} (${d})`);
+                            setEventSearch('');
+                            setEventResults([]);
+                          }}
+                          className="block w-full text-left px-2 py-1 hover:bg-blue-50"
+                        >
+                          {lbl}
+                          {d ? ` — ${d}` : ''}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/finance/TransactionCategories.jsx
+++ b/frontend/src/pages/finance/TransactionCategories.jsx
@@ -1,0 +1,77 @@
+// beacon2/frontend/src/pages/finance/TransactionCategories.jsx
+//
+// Category-allocation section of TransactionEditor. Presentation only: the
+// running total/validation and category amounts are computed by the parent and
+// passed in.
+
+import RequiredMark from '../../components/RequiredMark.jsx';
+
+export default function TransactionCategories({
+  categories,
+  catAmounts,
+  setCatAmounts,
+  markDirty,
+  readOnly,
+  amountOk,
+  catOk,
+  catTotal,
+  amountNum,
+}) {
+  return (
+    <div className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6 mb-4">
+      <h2 className="text-sm font-semibold text-slate-700 mb-1">
+        Category allocation <RequiredMark />
+      </h2>
+      <p className="text-xs text-slate-500 mb-3">
+        Amounts must add up to the transaction amount.
+        {amountOk && (
+          <span className={catOk ? ' text-green-700 font-medium' : ' text-red-600 font-medium'}>
+            {' '}
+            Total: £{catTotal.toFixed(2)} / £{amountNum.toFixed(2)}
+            {!catOk && ` — difference £${Math.abs(catTotal - amountNum).toFixed(2)}`}
+          </span>
+        )}
+      </p>
+
+      {categories.length === 0 ? (
+        <p className="text-sm text-slate-400">
+          No active categories. Add categories in Finance set-up.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-slate-600">
+                <th className="py-1.5 pr-4 font-medium">Category</th>
+                <th className="py-1.5 w-36 font-medium">Amount (£)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {categories.map((cat) => (
+                <tr key={cat.id} className="border-b border-slate-100">
+                  <td className="py-1.5 pr-4">{cat.name}</td>
+                  <td className="py-1.5">
+                    <input
+                      type="number"
+                      name="categoryAmount"
+                      min="0"
+                      step="0.01"
+                      value={catAmounts[cat.id] ?? ''}
+                      onChange={(e) => {
+                        markDirty();
+                        setCatAmounts((prev) => ({ ...prev, [cat.id]: e.target.value }));
+                      }}
+                      disabled={readOnly}
+                      className="border border-slate-300 rounded px-2 py-1 text-sm w-32 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      placeholder="0.00"
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/finance/TransactionEditor.jsx
+++ b/frontend/src/pages/finance/TransactionEditor.jsx
@@ -18,30 +18,10 @@ import PageHeader from '../../components/PageHeader.jsx';
 import DateInput from '../../components/DateInput.jsx';
 import { useUnsavedChanges } from '../../hooks/useUnsavedChanges.js';
 import { scrollToFormError } from '../../lib/scrollToError.js';
-import { FINANCE_PAYMENT_METHODS } from '../../lib/constants.js';
-
-const PAYMENT_METHODS = ['', ...FINANCE_PAYMENT_METHODS];
-
-const today = () => new Date().toISOString().slice(0, 10);
-
-const BLANK = {
-  account_id: '',
-  date: today(),
-  type: 'in',
-  from_to: '',
-  amount: '',
-  payment_method: '',
-  payment_ref: '',
-  detail: '',
-  remarks: '',
-  member_id_1: '',
-  member_id_2: '',
-  group_id: '',
-  event_id: '',
-  pending: false,
-  gift_aid_amount: '',
-  gift_aid_amount_2: '',
-};
+import { PAYMENT_METHODS, today, BLANK, INP_CLS, LBL_CLS } from './transactionEditorUtils.js';
+import TransactionAssociations from './TransactionAssociations.jsx';
+import TransactionGiftAidSection from './TransactionGiftAidSection.jsx';
+import TransactionCategories from './TransactionCategories.jsx';
 
 export default function TransactionEditor() {
   const { id } = useParams();
@@ -420,9 +400,8 @@ export default function TransactionEditor() {
       : []),
   ];
 
-  const INP =
-    'border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 w-full';
-  const LBL = 'block text-sm font-medium text-slate-700 mb-1';
+  const INP = INP_CLS;
+  const LBL = LBL_CLS;
 
   if (loading) {
     return (
@@ -689,342 +668,52 @@ export default function TransactionEditor() {
             </div>
           </div>
 
-          {/* Associate with members / group */}
-          <div className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6 mb-4">
-            <h2 className="text-sm font-semibold text-slate-700 mb-3">
-              Associate transaction with
-            </h2>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-              {/* Member 1 */}
-              <div>
-                <label htmlFor="txn-member1" className={LBL}>
-                  Member 1
-                </label>
-                <input
-                  id="txn-member1-filter"
-                  type="text"
-                  name="m1Filter"
-                  value={m1Filter}
-                  onChange={(e) => setM1Filter(e.target.value)}
-                  disabled={cleared}
-                  className={`${INP} mb-1`}
-                  placeholder="Search name / number…"
-                />
-                <select
-                  id="txn-member1"
-                  name="member_id_1"
-                  value={form.member_id_1}
-                  onChange={(e) => set('member_id_1', e.target.value)}
-                  disabled={cleared}
-                  className={INP}
-                  size={4}
-                >
-                  <option value="">— none —</option>
-                  {filteredM1.map((m) => (
-                    <option key={m.id} value={m.id}>
-                      {m.membership_number} {m.forenames} {m.surname}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Member 2 */}
-              <div>
-                <label htmlFor="txn-member2" className={LBL}>
-                  Member 2
-                </label>
-                {!form.member_id_1 && (
-                  <p className="text-xs text-slate-400 mb-1">Select Member 1 first</p>
-                )}
-                <input
-                  id="txn-member2-filter"
-                  type="text"
-                  name="m2Filter"
-                  value={m2Filter}
-                  onChange={(e) => setM2Filter(e.target.value)}
-                  disabled={cleared || !form.member_id_1}
-                  className={`${INP} mb-1`}
-                  placeholder="Search name / number…"
-                />
-                <select
-                  id="txn-member2"
-                  name="member_id_2"
-                  value={form.member_id_2}
-                  onChange={(e) => set('member_id_2', e.target.value)}
-                  disabled={cleared || !form.member_id_1}
-                  className={INP}
-                  size={4}
-                >
-                  <option value="">— none —</option>
-                  {filteredM2.map((m) => (
-                    <option key={m.id} value={m.id}>
-                      {m.membership_number} {m.forenames} {m.surname}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Group / Team */}
-              <div>
-                <label htmlFor="txn-group-filter" className={LBL}>
-                  Group / Team
-                </label>
-                <input
-                  id="txn-group-filter"
-                  type="text"
-                  placeholder="Search name / abbreviation…"
-                  value={groupFilter}
-                  onChange={(e) => setGroupFilter(e.target.value)}
-                  disabled={cleared}
-                  className={`${INP} mb-1`}
-                />
-                <select
-                  id="txn-group"
-                  name="group_id"
-                  value={form.group_id}
-                  onChange={(e) => set('group_id', e.target.value)}
-                  disabled={cleared}
-                  className={INP}
-                  size={5}
-                >
-                  <option value="">— none —</option>
-                  {filteredGroups.length > 0 && (
-                    <optgroup label="Groups">
-                      {filteredGroups.map((g) => (
-                        <option
-                          key={g.id}
-                          value={g.id}
-                          style={g.status === 'inactive' ? { color: '#dc2626' } : {}}
-                        >
-                          {g.short_name || g.name}
-                          {g.status === 'inactive' ? ' (inactive)' : ''}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                  {filteredTeams.length > 0 && (
-                    <optgroup label="Teams">
-                      {filteredTeams.map((t) => (
-                        <option
-                          key={t.id}
-                          value={t.id}
-                          style={t.status === 'inactive' ? { color: '#dc2626' } : {}}
-                        >
-                          {t.short_name || t.name}
-                          {t.status === 'inactive' ? ' (inactive)' : ''}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                </select>
-              </div>
-
-              {/* Event */}
-              <div>
-                <label htmlFor="txn-event-search" className={LBL}>
-                  Event
-                </label>
-                {form.event_id ? (
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm text-slate-700">{eventLabel || form.event_id}</span>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        set('event_id', '');
-                        setEventLabel('');
-                        setEventSearch('');
-                      }}
-                      disabled={cleared}
-                      className="text-red-600 hover:underline text-xs"
-                    >
-                      Clear
-                    </button>
-                  </div>
-                ) : (
-                  <>
-                    <input
-                      id="txn-event-search"
-                      type="text"
-                      placeholder="Search by topic, group name, or date…"
-                      value={eventSearch}
-                      onChange={(e) => setEventSearch(e.target.value)}
-                      disabled={cleared}
-                      className={`${INP} mb-1`}
-                    />
-                    {eventResults.length > 0 && (
-                      <ul className="border border-slate-200 rounded max-h-40 overflow-y-auto text-sm">
-                        {eventResults.map((ev) => {
-                          const lbl = ev.topic || ev.group_name || ev.event_type_name || 'Event';
-                          const d = ev.event_date ? String(ev.event_date).slice(0, 10) : '';
-                          return (
-                            <li key={ev.id}>
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  set('event_id', ev.id);
-                                  setEventLabel(`${lbl} (${d})`);
-                                  setEventSearch('');
-                                  setEventResults([]);
-                                }}
-                                className="block w-full text-left px-2 py-1 hover:bg-blue-50"
-                              >
-                                {lbl}
-                                {d ? ` — ${d}` : ''}
-                              </button>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    )}
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
+          {/* Associate with members / group / event */}
+          <TransactionAssociations
+            form={form}
+            set={set}
+            cleared={cleared}
+            m1Filter={m1Filter}
+            setM1Filter={setM1Filter}
+            filteredM1={filteredM1}
+            m2Filter={m2Filter}
+            setM2Filter={setM2Filter}
+            filteredM2={filteredM2}
+            groupFilter={groupFilter}
+            setGroupFilter={setGroupFilter}
+            filteredGroups={filteredGroups}
+            filteredTeams={filteredTeams}
+            eventLabel={eventLabel}
+            setEventLabel={setEventLabel}
+            eventSearch={eventSearch}
+            setEventSearch={setEventSearch}
+            eventResults={eventResults}
+            setEventResults={setEventResults}
+          />
 
           {/* Gift Aid */}
           {form.type === 'in' && (form.member_id_1 || form.member_id_2) && (
-            <div className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6 mb-4">
-              <h2 className="text-sm font-semibold text-slate-700 mb-3">Gift Aid</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {form.member_id_1 && (
-                  <div>
-                    <label htmlFor="txn-ga-amount1" className={LBL}>
-                      Gift aid eligible (Member 1)
-                    </label>
-                    <div className="flex items-center gap-1">
-                      <span className="text-slate-400 text-sm">£</span>
-                      <input
-                        id="txn-ga-amount1"
-                        type="number"
-                        name="gift_aid_amount"
-                        min="0"
-                        step="0.01"
-                        value={form.gift_aid_amount}
-                        onChange={(e) => set('gift_aid_amount', e.target.value)}
-                        disabled={readOnly || !!giftAidClaimedAt}
-                        className="border border-slate-300 rounded px-2 py-1 text-sm w-32 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        placeholder="0.00"
-                        title="Enter the amount (if any) that is eligible for Gift Aid"
-                      />
-                    </div>
-                    {giftAidClaimedAt && (
-                      <div className="mt-2">
-                        <label htmlFor="txn-ga-claimed1" className={LBL}>
-                          Gift aid claimed
-                        </label>
-                        <input
-                          id="txn-ga-claimed1"
-                          type="text"
-                          value={new Date(giftAidClaimedAt).toLocaleDateString('en-GB')}
-                          readOnly
-                          className="border border-slate-200 bg-slate-50 rounded px-2 py-1 text-sm w-32 text-slate-600"
-                          title="The date on which Gift Aid was claimed. This field is normally entered automatically."
-                        />
-                      </div>
-                    )}
-                  </div>
-                )}
-                {form.member_id_2 && (
-                  <div>
-                    <label htmlFor="txn-ga-amount2" className={LBL}>
-                      Gift aid eligible (Member 2)
-                    </label>
-                    <div className="flex items-center gap-1">
-                      <span className="text-slate-400 text-sm">£</span>
-                      <input
-                        id="txn-ga-amount2"
-                        type="number"
-                        name="gift_aid_amount_2"
-                        min="0"
-                        step="0.01"
-                        value={form.gift_aid_amount_2}
-                        onChange={(e) => set('gift_aid_amount_2', e.target.value)}
-                        disabled={readOnly || !!giftAidClaimedAt2}
-                        className="border border-slate-300 rounded px-2 py-1 text-sm w-32 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        placeholder="0.00"
-                        title="Enter the amount (if any) that is eligible for Gift Aid"
-                      />
-                    </div>
-                    {giftAidClaimedAt2 && (
-                      <div className="mt-2">
-                        <label htmlFor="txn-ga-claimed2" className={LBL}>
-                          Gift aid claimed
-                        </label>
-                        <input
-                          id="txn-ga-claimed2"
-                          type="text"
-                          value={new Date(giftAidClaimedAt2).toLocaleDateString('en-GB')}
-                          readOnly
-                          className="border border-slate-200 bg-slate-50 rounded px-2 py-1 text-sm w-32 text-slate-600"
-                          title="The date on which Gift Aid was claimed. This field is normally entered automatically."
-                        />
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
+            <TransactionGiftAidSection
+              form={form}
+              set={set}
+              readOnly={readOnly}
+              giftAidClaimedAt={giftAidClaimedAt}
+              giftAidClaimedAt2={giftAidClaimedAt2}
+            />
           )}
 
           {/* Categories */}
-          <div className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6 mb-4">
-            <h2 className="text-sm font-semibold text-slate-700 mb-1">
-              Category allocation <RequiredMark />
-            </h2>
-            <p className="text-xs text-slate-500 mb-3">
-              Amounts must add up to the transaction amount.
-              {amountOk && (
-                <span
-                  className={catOk ? ' text-green-700 font-medium' : ' text-red-600 font-medium'}
-                >
-                  {' '}
-                  Total: £{catTotal.toFixed(2)} / £{amountNum.toFixed(2)}
-                  {!catOk && ` — difference £${Math.abs(catTotal - amountNum).toFixed(2)}`}
-                </span>
-              )}
-            </p>
-
-            {categories.length === 0 ? (
-              <p className="text-sm text-slate-400">
-                No active categories. Add categories in Finance set-up.
-              </p>
-            ) : (
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-slate-200 text-left text-slate-600">
-                      <th className="py-1.5 pr-4 font-medium">Category</th>
-                      <th className="py-1.5 w-36 font-medium">Amount (£)</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {categories.map((cat) => (
-                      <tr key={cat.id} className="border-b border-slate-100">
-                        <td className="py-1.5 pr-4">{cat.name}</td>
-                        <td className="py-1.5">
-                          <input
-                            type="number"
-                            name="categoryAmount"
-                            min="0"
-                            step="0.01"
-                            value={catAmounts[cat.id] ?? ''}
-                            onChange={(e) => {
-                              markDirty();
-                              setCatAmounts((prev) => ({ ...prev, [cat.id]: e.target.value }));
-                            }}
-                            disabled={readOnly}
-                            className="border border-slate-300 rounded px-2 py-1 text-sm w-32 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                            placeholder="0.00"
-                          />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
+          <TransactionCategories
+            categories={categories}
+            catAmounts={catAmounts}
+            setCatAmounts={setCatAmounts}
+            markDirty={markDirty}
+            readOnly={readOnly}
+            amountOk={amountOk}
+            catOk={catOk}
+            catTotal={catTotal}
+            amountNum={amountNum}
+          />
 
           {/* Credit Batch membership */}
           {!isNew && batchId && (

--- a/frontend/src/pages/finance/TransactionGiftAidSection.jsx
+++ b/frontend/src/pages/finance/TransactionGiftAidSection.jsx
@@ -1,0 +1,100 @@
+// beacon2/frontend/src/pages/finance/TransactionGiftAidSection.jsx
+//
+// Gift Aid section of TransactionEditor — per-member eligible amounts and the
+// read-only "claimed" dates. Presentation only: state and handlers are passed
+// in from the parent. The parent decides whether to render this at all (only
+// for incoming transactions with at least one member).
+
+import { LBL_CLS as LBL } from './transactionEditorUtils.js';
+
+export default function TransactionGiftAidSection({
+  form,
+  set,
+  readOnly,
+  giftAidClaimedAt,
+  giftAidClaimedAt2,
+}) {
+  return (
+    <div className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6 mb-4">
+      <h2 className="text-sm font-semibold text-slate-700 mb-3">Gift Aid</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {form.member_id_1 && (
+          <div>
+            <label htmlFor="txn-ga-amount1" className={LBL}>
+              Gift aid eligible (Member 1)
+            </label>
+            <div className="flex items-center gap-1">
+              <span className="text-slate-400 text-sm">£</span>
+              <input
+                id="txn-ga-amount1"
+                type="number"
+                name="gift_aid_amount"
+                min="0"
+                step="0.01"
+                value={form.gift_aid_amount}
+                onChange={(e) => set('gift_aid_amount', e.target.value)}
+                disabled={readOnly || !!giftAidClaimedAt}
+                className="border border-slate-300 rounded px-2 py-1 text-sm w-32 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="0.00"
+                title="Enter the amount (if any) that is eligible for Gift Aid"
+              />
+            </div>
+            {giftAidClaimedAt && (
+              <div className="mt-2">
+                <label htmlFor="txn-ga-claimed1" className={LBL}>
+                  Gift aid claimed
+                </label>
+                <input
+                  id="txn-ga-claimed1"
+                  type="text"
+                  value={new Date(giftAidClaimedAt).toLocaleDateString('en-GB')}
+                  readOnly
+                  className="border border-slate-200 bg-slate-50 rounded px-2 py-1 text-sm w-32 text-slate-600"
+                  title="The date on which Gift Aid was claimed. This field is normally entered automatically."
+                />
+              </div>
+            )}
+          </div>
+        )}
+        {form.member_id_2 && (
+          <div>
+            <label htmlFor="txn-ga-amount2" className={LBL}>
+              Gift aid eligible (Member 2)
+            </label>
+            <div className="flex items-center gap-1">
+              <span className="text-slate-400 text-sm">£</span>
+              <input
+                id="txn-ga-amount2"
+                type="number"
+                name="gift_aid_amount_2"
+                min="0"
+                step="0.01"
+                value={form.gift_aid_amount_2}
+                onChange={(e) => set('gift_aid_amount_2', e.target.value)}
+                disabled={readOnly || !!giftAidClaimedAt2}
+                className="border border-slate-300 rounded px-2 py-1 text-sm w-32 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="0.00"
+                title="Enter the amount (if any) that is eligible for Gift Aid"
+              />
+            </div>
+            {giftAidClaimedAt2 && (
+              <div className="mt-2">
+                <label htmlFor="txn-ga-claimed2" className={LBL}>
+                  Gift aid claimed
+                </label>
+                <input
+                  id="txn-ga-claimed2"
+                  type="text"
+                  value={new Date(giftAidClaimedAt2).toLocaleDateString('en-GB')}
+                  readOnly
+                  className="border border-slate-200 bg-slate-50 rounded px-2 py-1 text-sm w-32 text-slate-600"
+                  title="The date on which Gift Aid was claimed. This field is normally entered automatically."
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/finance/creditBatchesUtils.js
+++ b/frontend/src/pages/finance/creditBatchesUtils.js
@@ -1,0 +1,22 @@
+// beacon2/frontend/src/pages/finance/creditBatchesUtils.js
+//
+// Pure helpers and shared Tailwind class strings used by CreditBatches and its
+// extracted sub-views.
+
+export const inputCls =
+  'border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
+export const btnPrimary =
+  'bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium transition-colors';
+export const btnDanger =
+  'border border-red-300 text-red-600 hover:bg-red-50 rounded px-5 py-2 text-sm';
+export const btnSecondary =
+  'border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-4 py-1.5 text-sm transition-colors';
+
+export function fmtAmt(n) {
+  return Number(n).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+export function toISODate(d) {
+  if (!d) return '';
+  return String(d).slice(0, 10);
+}

--- a/frontend/src/pages/finance/financeLedgerUtils.js
+++ b/frontend/src/pages/finance/financeLedgerUtils.js
@@ -1,0 +1,22 @@
+// beacon2/frontend/src/pages/finance/financeLedgerUtils.js
+//
+// Pure helpers and constants shared by FinanceLedger and its extracted sections.
+
+export const VIEWS = ['account', 'category', 'group', 'event'];
+
+export const VIEW_LABELS = {
+  account: 'Account',
+  category: 'Category',
+  group: 'Group/Team',
+  event: 'Event',
+};
+
+const thisYear = new Date().getFullYear();
+export { thisYear };
+export const YEARS = Array.from({ length: 6 }, (_, i) => thisYear - i);
+
+export const fmtDate = (d) => (d ? new Date(d).toLocaleDateString('en-GB') : '');
+export const fmtAmount = (n) => (n != null ? `£${Number(n).toFixed(2)}` : '');
+
+// Bulk-action eligibility: not cleared, not in a batch, not a transfer.
+export const isEligible = (t) => !t.cleared_at && !t.batch_id && !t.transfer_id;

--- a/frontend/src/pages/finance/transactionEditorUtils.js
+++ b/frontend/src/pages/finance/transactionEditorUtils.js
@@ -1,0 +1,33 @@
+// beacon2/frontend/src/pages/finance/transactionEditorUtils.js
+//
+// Pure helpers, constants, and shared Tailwind class strings used by
+// TransactionEditor and its extracted sections.
+
+import { FINANCE_PAYMENT_METHODS } from '../../lib/constants.js';
+
+export const PAYMENT_METHODS = ['', ...FINANCE_PAYMENT_METHODS];
+
+export const today = () => new Date().toISOString().slice(0, 10);
+
+export const BLANK = {
+  account_id: '',
+  date: today(),
+  type: 'in',
+  from_to: '',
+  amount: '',
+  payment_method: '',
+  payment_ref: '',
+  detail: '',
+  remarks: '',
+  member_id_1: '',
+  member_id_2: '',
+  group_id: '',
+  event_id: '',
+  pending: false,
+  gift_aid_amount: '',
+  gift_aid_amount_2: '',
+};
+
+export const INP_CLS =
+  'border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 w-full';
+export const LBL_CLS = 'block text-sm font-medium text-slate-700 mb-1';

--- a/frontend/src/pages/members/MemberList.jsx
+++ b/frontend/src/pages/members/MemberList.jsx
@@ -16,42 +16,15 @@ import {
   SS_LETTER_COMPOSE_MEMBER_IDS,
 } from '../../lib/storageKeys.js';
 import { ROUTES } from '../../lib/routes.js';
-
-const DOWNLOAD_FIELDS = [
-  { key: 'membership_number', label: 'Membership No', default: true },
-  { key: 'title', label: 'Title', default: false },
-  { key: 'forenames', label: 'Forenames', default: true },
-  { key: 'known_as', label: 'Known As', default: false },
-  { key: 'surname', label: 'Surname', default: true },
-  { key: 'email', label: 'Email', default: true },
-  { key: 'mobile', label: 'Mobile', default: true },
-  { key: 'telephone', label: 'Telephone', default: false },
-  { key: 'address', label: 'Address', default: false },
-  { key: 'town', label: 'Town', default: true },
-  { key: 'county', label: 'County', default: false },
-  { key: 'postcode', label: 'Postcode', default: true },
-  { key: 'country', label: 'Country', default: false },
-  { key: 'status', label: 'Status', default: true },
-  { key: 'class', label: 'Class', default: true },
-  { key: 'joined_on', label: 'Joined', default: false },
-  { key: 'next_renewal', label: 'Next Renewal', default: false },
-  { key: 'custom_field_1', label: 'Custom Field 1', default: false },
-  { key: 'custom_field_2', label: 'Custom Field 2', default: false },
-  { key: 'custom_field_3', label: 'Custom Field 3', default: false },
-  { key: 'custom_field_4', label: 'Custom Field 4', default: false },
-];
 import { useAuth } from '../../context/AuthContext.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
-import SortableHeader from '../../components/SortableHeader.jsx';
 import ScrollButtons from '../../components/ScrollButtons.jsx';
 import { useSortedData } from '../../hooks/useSortedData.js';
-import { formatShortAddress, isSubscriptionOverdue } from '../../lib/memberFormatters.js';
-import { formatMemberName } from '../../hooks/usePreferences.js';
-import NoEmailIcon from '../../components/NoEmailIcon.jsx';
-import { ALL_PAYMENT_METHODS as PAYMENT_METHODS } from '../../lib/constants.js';
-
-const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+import { DOWNLOAD_FIELDS, ALPHABET } from './memberListConstants.js';
+import MemberListFilters from './MemberListFilters.jsx';
+import MemberListTable from './MemberListTable.jsx';
+import MemberListBulkActions from './MemberListBulkActions.jsx';
 
 export default function MemberList() {
   const { can, tenant, hasFeature } = useAuth();
@@ -351,165 +324,34 @@ export default function MemberList() {
         <h1 className="text-xl font-bold text-center mb-3">Members</h1>
 
         {/* ── Filters ──────────────────────────────────────────────── */}
-        <div className="bg-white/90 rounded-lg shadow-sm p-3 mb-3 space-y-3">
-          {/* Status checkboxes */}
-          <div className="flex flex-wrap gap-3 items-center">
-            <span className="text-sm font-medium text-slate-700 mr-1">Status:</span>
-            <label className="flex items-center gap-1.5 text-sm cursor-pointer">
-              <input
-                type="checkbox"
-                checked={selectedStatuses.length === 0}
-                onChange={() => setSelectedStatuses([])}
-                className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-              />
-              All
-            </label>
-            {statuses.map((s) => (
-              <label key={s.id} className="flex items-center gap-1.5 text-sm cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={selectedStatuses.includes(s.id)}
-                  onChange={() => toggleStatus(s.id)}
-                  className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                />
-                {s.name}
-              </label>
-            ))}
-          </div>
-
-          {/* Class + Poll + search row */}
-          <div className="flex flex-wrap gap-3 items-end">
-            <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">Class</label>
-              <select
-                name="selectedClass"
-                value={selectedClass}
-                onChange={(e) => setSelectedClass(e.target.value)}
-                className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value="">All classes</option>
-                {classes.map((c) => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {polls.length > 0 && (
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Poll</label>
-                <div className="flex gap-2 items-center">
-                  <select
-                    name="selectedPoll"
-                    value={selectedPoll}
-                    onChange={(e) => setSelectedPoll(e.target.value)}
-                    className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  >
-                    <option value="">All members</option>
-                    {polls.map((p) => (
-                      <option key={p.id} value={p.id}>
-                        {p.name}
-                      </option>
-                    ))}
-                  </select>
-                  {selectedPoll && (
-                    <label className="flex items-center gap-1.5 text-sm cursor-pointer whitespace-nowrap">
-                      <input
-                        type="checkbox"
-                        checked={negatePoll}
-                        onChange={(e) => setNegatePoll(e.target.checked)}
-                        className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                      />
-                      Negate poll
-                    </label>
-                  )}
-                </div>
-              </div>
-            )}
-
-            <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
-                Payment method
-              </label>
-              <select
-                name="selectedPaymentMethod"
-                value={selectedPaymentMethod}
-                onChange={(e) => setSelectedPaymentMethod(e.target.value)}
-                className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value="">- any -</option>
-                {PAYMENT_METHODS.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <form onSubmit={handleSearch} className="flex gap-2 items-end">
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Quick Find</label>
-                <input
-                  type="text"
-                  name="search"
-                  value={searchInput}
-                  onChange={(e) => setSearchInput(e.target.value)}
-                  placeholder="Name, address, postcode, no…"
-                  className="border border-slate-300 rounded px-3 py-1.5 text-sm w-56 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-              </div>
-              <button
-                type="submit"
-                className="bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-1.5 text-sm font-medium"
-              >
-                Search
-              </button>
-              {activeSearch && (
-                <button
-                  type="button"
-                  onClick={handleCancelSearch}
-                  className="border border-slate-300 rounded px-4 py-1.5 text-sm text-slate-600 hover:bg-slate-50"
-                >
-                  Cancel Search
-                </button>
-              )}
-            </form>
-
-            {hasCfLabels && (
-              <form onSubmit={handleCfSearch} className="flex gap-2 items-end">
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">
-                    Custom Fields
-                  </label>
-                  <input
-                    type="text"
-                    name="customFieldSearch"
-                    value={cfInput}
-                    onChange={(e) => setCfInput(e.target.value)}
-                    placeholder={cfLabelNames}
-                    className="border border-slate-300 rounded px-3 py-1.5 text-sm w-56 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                </div>
-                <button
-                  type="submit"
-                  className="bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-1.5 text-sm font-medium"
-                >
-                  Search
-                </button>
-                {activeCf && (
-                  <button
-                    type="button"
-                    onClick={handleCancelCf}
-                    className="border border-slate-300 rounded px-4 py-1.5 text-sm text-slate-600 hover:bg-slate-50"
-                  >
-                    Clear
-                  </button>
-                )}
-              </form>
-            )}
-          </div>
-        </div>
+        <MemberListFilters
+          statuses={statuses}
+          selectedStatuses={selectedStatuses}
+          setSelectedStatuses={setSelectedStatuses}
+          toggleStatus={toggleStatus}
+          classes={classes}
+          selectedClass={selectedClass}
+          setSelectedClass={setSelectedClass}
+          polls={polls}
+          selectedPoll={selectedPoll}
+          setSelectedPoll={setSelectedPoll}
+          negatePoll={negatePoll}
+          setNegatePoll={setNegatePoll}
+          selectedPaymentMethod={selectedPaymentMethod}
+          setSelectedPaymentMethod={setSelectedPaymentMethod}
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+          activeSearch={activeSearch}
+          handleSearch={handleSearch}
+          handleCancelSearch={handleCancelSearch}
+          hasCfLabels={hasCfLabels}
+          cfLabelNames={cfLabelNames}
+          cfInput={cfInput}
+          setCfInput={setCfInput}
+          activeCf={activeCf}
+          handleCfSearch={handleCfSearch}
+          handleCancelCf={handleCancelCf}
+        />
 
         {/* ── Info text ────────────────────────────────────────────── */}
         <p className="text-sm text-slate-500 italic mb-3">
@@ -546,369 +388,59 @@ export default function MemberList() {
             <p className="text-center text-slate-500 py-6">No members found.</p>
           ) : (
             <>
-              {/* Select controls */}
-              <div className="flex flex-wrap gap-2 items-center mb-2">
-                <span className="text-sm text-slate-500">
-                  {memberList.length} member{memberList.length !== 1 ? 's' : ''}
-                </span>
-                <span className="text-slate-300">|</span>
-                <span className="text-sm font-medium text-slate-600">Select:</span>
-                <button onClick={selectAll} className="text-sm text-blue-700 hover:underline">
-                  All
-                </button>
-                <button onClick={clearAll} className="text-sm text-blue-700 hover:underline">
-                  Clear All
-                </button>
-                <button onClick={selectEmail} className="text-sm text-blue-700 hover:underline">
-                  Email only
-                </button>
-                <button onClick={selectNoEmail} className="text-sm text-blue-700 hover:underline">
-                  Without email
-                </button>
-                <button
-                  onClick={selectPortalPassword}
-                  className="text-sm text-blue-700 hover:underline"
-                >
-                  Portal password set
-                </button>
-                <button
-                  onClick={selectNoPortalPassword}
-                  className="text-sm text-blue-700 hover:underline"
-                >
-                  Without portal password
-                </button>
-                <button
-                  onClick={selectEmailNotConfirmed}
-                  className="text-sm text-blue-700 hover:underline"
-                >
-                  Email not confirmed
-                </button>
-                {selected.size > 0 && (
-                  <span className="text-sm font-medium text-blue-700 ml-2">
-                    {selected.size} selected
-                  </span>
-                )}
-              </div>
-
-              <div ref={tableRef} className="overflow-x-auto rounded-lg shadow-sm mb-3">
-                <table className="w-full text-sm bg-white min-w-max">
-                  <thead>
-                    <tr className="bg-slate-50 border-b border-slate-200 text-left text-slate-600 italic font-normal">
-                      <th className="px-2 py-2"></th>
-                      <SortableHeader
-                        col="membership_number"
-                        label="No"
-                        sortKey={sortKey}
-                        sortDir={sortDir}
-                        onSort={onSort}
-                        className="px-3 py-2 font-normal"
-                      />
-                      <th className="px-3 py-2 font-normal">
-                        <span
-                          className="cursor-pointer select-none"
-                          onClick={() => onSort('forenames')}
-                        >
-                          Name
-                          <span
-                            className={`ml-1 text-xs ${sortKey === 'forenames' ? 'text-blue-600' : 'text-slate-300'}`}
-                          >
-                            {sortKey === 'forenames' ? (sortDir === 'asc' ? '▲' : '▼') : '⇅'}
-                          </span>
-                        </span>
-                        <span className="text-slate-300 mx-1">|</span>
-                        <span
-                          className="cursor-pointer select-none text-xs not-italic"
-                          onClick={() => onSort(SORT_SURNAME)}
-                        >
-                          by surname
-                          <span
-                            className={`ml-1 text-xs ${Array.isArray(sortKey) && sortKey[0] === 'surname' ? 'text-blue-600' : 'text-slate-300'}`}
-                          >
-                            {Array.isArray(sortKey) && sortKey[0] === 'surname'
-                              ? sortDir === 'asc'
-                                ? '▲'
-                                : '▼'
-                              : '⇅'}
-                          </span>
-                        </span>
-                      </th>
-                      <SortableHeader
-                        col="house_no"
-                        label="Address"
-                        sortKey={sortKey}
-                        sortDir={sortDir}
-                        onSort={onSort}
-                        className="px-3 py-2 font-normal"
-                      />
-                      <SortableHeader
-                        col="telephone"
-                        label="Telephone"
-                        sortKey={sortKey}
-                        sortDir={sortDir}
-                        onSort={onSort}
-                        className="px-3 py-2 font-normal"
-                      />
-                      <SortableHeader
-                        col="mobile"
-                        label="Mobile"
-                        sortKey={sortKey}
-                        sortDir={sortDir}
-                        onSort={onSort}
-                        className="px-3 py-2 font-normal"
-                      />
-                      <SortableHeader
-                        col="class"
-                        label="Class"
-                        sortKey={sortKey}
-                        sortDir={sortDir}
-                        onSort={onSort}
-                        className="px-3 py-2 font-normal"
-                      />
-                      <SortableHeader
-                        col="status"
-                        label="Status"
-                        sortKey={sortKey}
-                        sortDir={sortDir}
-                        onSort={onSort}
-                        className="px-3 py-2 font-normal"
-                      />
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sorted.map((m, i) => (
-                      <tr
-                        key={m.id}
-                        ref={(el) => {
-                          if (el) rowRefs.current[m.surname?.[0]?.toUpperCase()] = el;
-                        }}
-                        className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'} ${selected.has(m.id) ? 'outline outline-2 outline-blue-400' : ''}`}
-                      >
-                        <td className="px-2 py-2">
-                          <input
-                            type="checkbox"
-                            checked={selected.has(m.id)}
-                            onChange={() => toggleSelect(m.id)}
-                            className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                          />
-                          {!m.email && <NoEmailIcon className="ml-1" />}
-                        </td>
-                        <td
-                          className={`px-3 py-2 tabular-nums ${isSubscriptionOverdue(m) ? 'text-red-600' : ''}`}
-                        >
-                          {can('member_record', 'view') ? (
-                            <a
-                              href="#view"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                navigate(`/members/${m.id}`);
-                              }}
-                              className={`hover:underline ${isSubscriptionOverdue(m) ? 'text-red-600' : 'text-blue-700'}`}
-                            >
-                              {m.membership_number}
-                            </a>
-                          ) : (
-                            m.membership_number
-                          )}
-                        </td>
-                        <td
-                          className={`px-3 py-2 font-medium ${isSubscriptionOverdue(m) ? 'text-red-600' : ''}`}
-                        >
-                          {can('member_record', 'view') ? (
-                            <a
-                              href="#view"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                navigate(`/members/${m.id}`);
-                              }}
-                              className={`hover:underline ${isSubscriptionOverdue(m) ? 'text-red-600' : 'text-blue-700'}`}
-                            >
-                              {formatMemberName(m)}
-                            </a>
-                          ) : (
-                            formatMemberName(m)
-                          )}
-                        </td>
-                        <td className="px-3 py-2">{formatShortAddress(m)}</td>
-                        <td className="px-3 py-2">{m.telephone ?? ''}</td>
-                        <td className="px-3 py-2">{m.mobile ?? ''}</td>
-                        <td className="px-3 py-2">{m.class ?? ''}</td>
-                        <td className="px-3 py-2">{m.status ?? ''}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              <MemberListTable
+                memberList={memberList}
+                sorted={sorted}
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSort={onSort}
+                sortSurname={SORT_SURNAME}
+                selected={selected}
+                toggleSelect={toggleSelect}
+                selectAll={selectAll}
+                clearAll={clearAll}
+                selectEmail={selectEmail}
+                selectNoEmail={selectNoEmail}
+                selectPortalPassword={selectPortalPassword}
+                selectNoPortalPassword={selectNoPortalPassword}
+                selectEmailNotConfirmed={selectEmailNotConfirmed}
+                rowRefs={rowRefs}
+                tableRef={tableRef}
+                can={can}
+                navigate={navigate}
+              />
 
               {/* ── Bulk actions ──────────────────────────────────────── */}
               {selected.size > 0 && (
-                <div className="bg-white/90 rounded-lg shadow-sm p-3 space-y-3">
-                  <div className="flex flex-wrap gap-3 items-end">
-                    <div>
-                      <label className="block text-sm font-medium text-slate-700 mb-1">
-                        Do with {selected.size} selected member{selected.size !== 1 ? 's' : ''}
-                      </label>
-                      <select
-                        name="bulkAction"
-                        value={bulkAction}
-                        onChange={(e) => {
-                          setBulkAction(e.target.value);
-                          setBulkResult(null);
-                          setDlError(null);
-                        }}
-                        className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                      >
-                        <option value="">— choose action —</option>
-                        {can('email', 'send') && hasFeature('email') && (
-                          <option value="send_email">Send email</option>
-                        )}
-                        {can('letters', 'view') && hasFeature('letters') && (
-                          <option value="send_letter">Send letter</option>
-                        )}
-                        {hasBulkPolls && <option value="add_to_poll">Add to poll</option>}
-                        {hasBulkGroups && <option value="add_to_group">Add to group</option>}
-                        {hasBulkTeams && <option value="add_to_team">Add to team</option>}
-                        <option value="download_excel">Download Excel</option>
-                        <option value="download_pdf">Download PDF</option>
-                        <option value="download_emails">Download email addresses</option>
-                      </select>
-                    </div>
-
-                    {bulkAction === 'add_to_poll' && (
-                      <div>
-                        <label className="block text-sm font-medium text-slate-700 mb-1">
-                          Poll
-                        </label>
-                        <select
-                          name="addToPollId"
-                          value={addToPollId}
-                          onChange={(e) => setAddToPollId(e.target.value)}
-                          className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        >
-                          <option value="">— select poll —</option>
-                          {polls.map((p) => (
-                            <option key={p.id} value={p.id}>
-                              {p.name}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    )}
-
-                    {bulkAction === 'add_to_group' && (
-                      <div>
-                        <label className="block text-sm font-medium text-slate-700 mb-1">
-                          Group
-                        </label>
-                        <select
-                          name="addToGroupId"
-                          value={addToGroupId}
-                          onChange={(e) => setAddToGroupId(e.target.value)}
-                          className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        >
-                          <option value="">— select group —</option>
-                          {allGroups.map((g) => (
-                            <option key={g.id} value={g.id}>
-                              {g.name}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    )}
-
-                    {bulkAction === 'add_to_team' && (
-                      <div>
-                        <label className="block text-sm font-medium text-slate-700 mb-1">
-                          Team
-                        </label>
-                        <select
-                          name="addToTeamId"
-                          value={addToTeamId}
-                          onChange={(e) => setAddToTeamId(e.target.value)}
-                          className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        >
-                          <option value="">— select team —</option>
-                          {allTeams.map((t) => (
-                            <option key={t.id} value={t.id}>
-                              {t.name}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    )}
-
-                    {(bulkAction === 'send_email' ||
-                      bulkAction === 'send_letter' ||
-                      bulkAction === 'add_to_poll' ||
-                      bulkAction === 'add_to_group' ||
-                      bulkAction === 'add_to_team') && (
-                      <button
-                        onClick={handleBulkDo}
-                        disabled={
-                          bulkWorking ||
-                          (bulkAction === 'add_to_poll' && !addToPollId) ||
-                          (bulkAction === 'add_to_group' && !addToGroupId) ||
-                          (bulkAction === 'add_to_team' && !addToTeamId)
-                        }
-                        className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-4 py-1.5 text-sm font-medium transition-colors"
-                      >
-                        {bulkWorking ? 'Working…' : 'Do with selected'}
-                      </button>
-                    )}
-
-                    {bulkAction === 'download_emails' && (
-                      <button
-                        onClick={() => handleDownload('email-csv')}
-                        disabled={downloading}
-                        className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-4 py-1.5 text-sm font-medium transition-colors"
-                      >
-                        {downloading ? 'Downloading…' : 'Download'}
-                      </button>
-                    )}
-
-                    {bulkResult && (
-                      <p
-                        className={`text-sm font-medium ${bulkResult.type === 'success' ? 'text-green-700' : 'text-red-600'}`}
-                      >
-                        {bulkResult.msg}
-                      </p>
-                    )}
-                    {dlError && <p className="text-sm text-red-600 font-medium">{dlError}</p>}
-                  </div>
-
-                  {/* Field picker for Excel / PDF downloads */}
-                  {(bulkAction === 'download_excel' || bulkAction === 'download_pdf') && (
-                    <div className="border border-slate-200 rounded p-3 bg-slate-50">
-                      <p className="text-sm font-medium text-slate-700 mb-2">Fields to include:</p>
-                      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-x-4 gap-y-1 mb-3">
-                        {DOWNLOAD_FIELDS.map((f) => (
-                          <label
-                            key={f.key}
-                            className="flex items-center gap-1.5 text-sm cursor-pointer"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={dlFields.has(f.key)}
-                              onChange={() => toggleDlField(f.key)}
-                              className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                            />
-                            {f.label}
-                          </label>
-                        ))}
-                      </div>
-                      <button
-                        onClick={() =>
-                          handleDownload(bulkAction === 'download_excel' ? 'excel' : 'pdf')
-                        }
-                        disabled={downloading || dlFields.size === 0}
-                        className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-4 py-1.5 text-sm font-medium transition-colors"
-                      >
-                        {downloading
-                          ? 'Downloading…'
-                          : `Download ${bulkAction === 'download_excel' ? 'Excel' : 'PDF'}`}
-                      </button>
-                    </div>
-                  )}
-                </div>
+                <MemberListBulkActions
+                  selected={selected}
+                  bulkAction={bulkAction}
+                  setBulkAction={setBulkAction}
+                  setBulkResult={setBulkResult}
+                  setDlError={setDlError}
+                  can={can}
+                  hasFeature={hasFeature}
+                  hasBulkPolls={hasBulkPolls}
+                  hasBulkGroups={hasBulkGroups}
+                  hasBulkTeams={hasBulkTeams}
+                  polls={polls}
+                  addToPollId={addToPollId}
+                  setAddToPollId={setAddToPollId}
+                  allGroups={allGroups}
+                  addToGroupId={addToGroupId}
+                  setAddToGroupId={setAddToGroupId}
+                  allTeams={allTeams}
+                  addToTeamId={addToTeamId}
+                  setAddToTeamId={setAddToTeamId}
+                  handleBulkDo={handleBulkDo}
+                  bulkWorking={bulkWorking}
+                  bulkResult={bulkResult}
+                  handleDownload={handleDownload}
+                  downloading={downloading}
+                  dlError={dlError}
+                  dlFields={dlFields}
+                  toggleDlField={toggleDlField}
+                />
               )}
             </>
           ))}

--- a/frontend/src/pages/members/MemberListBulkActions.jsx
+++ b/frontend/src/pages/members/MemberListBulkActions.jsx
@@ -1,0 +1,197 @@
+// beacon2/frontend/src/pages/members/MemberListBulkActions.jsx
+//
+// "Do with selected members" panel of MemberList — action picker, the
+// poll/group/team target selectors, and the download field picker. Presentation
+// only: all state and handlers are owned by the parent.
+
+import { DOWNLOAD_FIELDS } from './memberListConstants.js';
+
+export default function MemberListBulkActions({
+  selected,
+  bulkAction,
+  setBulkAction,
+  setBulkResult,
+  setDlError,
+  can,
+  hasFeature,
+  hasBulkPolls,
+  hasBulkGroups,
+  hasBulkTeams,
+  polls,
+  addToPollId,
+  setAddToPollId,
+  allGroups,
+  addToGroupId,
+  setAddToGroupId,
+  allTeams,
+  addToTeamId,
+  setAddToTeamId,
+  handleBulkDo,
+  bulkWorking,
+  bulkResult,
+  handleDownload,
+  downloading,
+  dlError,
+  dlFields,
+  toggleDlField,
+}) {
+  return (
+    <div className="bg-white/90 rounded-lg shadow-sm p-3 space-y-3">
+      <div className="flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">
+            Do with {selected.size} selected member{selected.size !== 1 ? 's' : ''}
+          </label>
+          <select
+            name="bulkAction"
+            value={bulkAction}
+            onChange={(e) => {
+              setBulkAction(e.target.value);
+              setBulkResult(null);
+              setDlError(null);
+            }}
+            className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">— choose action —</option>
+            {can('email', 'send') && hasFeature('email') && (
+              <option value="send_email">Send email</option>
+            )}
+            {can('letters', 'view') && hasFeature('letters') && (
+              <option value="send_letter">Send letter</option>
+            )}
+            {hasBulkPolls && <option value="add_to_poll">Add to poll</option>}
+            {hasBulkGroups && <option value="add_to_group">Add to group</option>}
+            {hasBulkTeams && <option value="add_to_team">Add to team</option>}
+            <option value="download_excel">Download Excel</option>
+            <option value="download_pdf">Download PDF</option>
+            <option value="download_emails">Download email addresses</option>
+          </select>
+        </div>
+
+        {bulkAction === 'add_to_poll' && (
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Poll</label>
+            <select
+              name="addToPollId"
+              value={addToPollId}
+              onChange={(e) => setAddToPollId(e.target.value)}
+              className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">— select poll —</option>
+              {polls.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {bulkAction === 'add_to_group' && (
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Group</label>
+            <select
+              name="addToGroupId"
+              value={addToGroupId}
+              onChange={(e) => setAddToGroupId(e.target.value)}
+              className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">— select group —</option>
+              {allGroups.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {bulkAction === 'add_to_team' && (
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Team</label>
+            <select
+              name="addToTeamId"
+              value={addToTeamId}
+              onChange={(e) => setAddToTeamId(e.target.value)}
+              className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">— select team —</option>
+              {allTeams.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {(bulkAction === 'send_email' ||
+          bulkAction === 'send_letter' ||
+          bulkAction === 'add_to_poll' ||
+          bulkAction === 'add_to_group' ||
+          bulkAction === 'add_to_team') && (
+          <button
+            onClick={handleBulkDo}
+            disabled={
+              bulkWorking ||
+              (bulkAction === 'add_to_poll' && !addToPollId) ||
+              (bulkAction === 'add_to_group' && !addToGroupId) ||
+              (bulkAction === 'add_to_team' && !addToTeamId)
+            }
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-4 py-1.5 text-sm font-medium transition-colors"
+          >
+            {bulkWorking ? 'Working…' : 'Do with selected'}
+          </button>
+        )}
+
+        {bulkAction === 'download_emails' && (
+          <button
+            onClick={() => handleDownload('email-csv')}
+            disabled={downloading}
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-4 py-1.5 text-sm font-medium transition-colors"
+          >
+            {downloading ? 'Downloading…' : 'Download'}
+          </button>
+        )}
+
+        {bulkResult && (
+          <p
+            className={`text-sm font-medium ${bulkResult.type === 'success' ? 'text-green-700' : 'text-red-600'}`}
+          >
+            {bulkResult.msg}
+          </p>
+        )}
+        {dlError && <p className="text-sm text-red-600 font-medium">{dlError}</p>}
+      </div>
+
+      {/* Field picker for Excel / PDF downloads */}
+      {(bulkAction === 'download_excel' || bulkAction === 'download_pdf') && (
+        <div className="border border-slate-200 rounded p-3 bg-slate-50">
+          <p className="text-sm font-medium text-slate-700 mb-2">Fields to include:</p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-x-4 gap-y-1 mb-3">
+            {DOWNLOAD_FIELDS.map((f) => (
+              <label key={f.key} className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={dlFields.has(f.key)}
+                  onChange={() => toggleDlField(f.key)}
+                  className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                />
+                {f.label}
+              </label>
+            ))}
+          </div>
+          <button
+            onClick={() => handleDownload(bulkAction === 'download_excel' ? 'excel' : 'pdf')}
+            disabled={downloading || dlFields.size === 0}
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-4 py-1.5 text-sm font-medium transition-colors"
+          >
+            {downloading
+              ? 'Downloading…'
+              : `Download ${bulkAction === 'download_excel' ? 'Excel' : 'PDF'}`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/members/MemberListFilters.jsx
+++ b/frontend/src/pages/members/MemberListFilters.jsx
@@ -1,0 +1,194 @@
+// beacon2/frontend/src/pages/members/MemberListFilters.jsx
+//
+// Filter panel for MemberList — status checkboxes, class/poll/payment-method
+// selectors, and the Quick Find / custom-field search forms. Presentation only:
+// all filter state and handlers are owned by the parent.
+
+import { ALL_PAYMENT_METHODS as PAYMENT_METHODS } from '../../lib/constants.js';
+
+export default function MemberListFilters({
+  statuses,
+  selectedStatuses,
+  setSelectedStatuses,
+  toggleStatus,
+  classes,
+  selectedClass,
+  setSelectedClass,
+  polls,
+  selectedPoll,
+  setSelectedPoll,
+  negatePoll,
+  setNegatePoll,
+  selectedPaymentMethod,
+  setSelectedPaymentMethod,
+  searchInput,
+  setSearchInput,
+  activeSearch,
+  handleSearch,
+  handleCancelSearch,
+  hasCfLabels,
+  cfLabelNames,
+  cfInput,
+  setCfInput,
+  activeCf,
+  handleCfSearch,
+  handleCancelCf,
+}) {
+  return (
+    <div className="bg-white/90 rounded-lg shadow-sm p-3 mb-3 space-y-3">
+      {/* Status checkboxes */}
+      <div className="flex flex-wrap gap-3 items-center">
+        <span className="text-sm font-medium text-slate-700 mr-1">Status:</span>
+        <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={selectedStatuses.length === 0}
+            onChange={() => setSelectedStatuses([])}
+            className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+          />
+          All
+        </label>
+        {statuses.map((s) => (
+          <label key={s.id} className="flex items-center gap-1.5 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={selectedStatuses.includes(s.id)}
+              onChange={() => toggleStatus(s.id)}
+              className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+            />
+            {s.name}
+          </label>
+        ))}
+      </div>
+
+      {/* Class + Poll + search row */}
+      <div className="flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">Class</label>
+          <select
+            name="selectedClass"
+            value={selectedClass}
+            onChange={(e) => setSelectedClass(e.target.value)}
+            className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">All classes</option>
+            {classes.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {polls.length > 0 && (
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Poll</label>
+            <div className="flex gap-2 items-center">
+              <select
+                name="selectedPoll"
+                value={selectedPoll}
+                onChange={(e) => setSelectedPoll(e.target.value)}
+                className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">All members</option>
+                {polls.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+              {selectedPoll && (
+                <label className="flex items-center gap-1.5 text-sm cursor-pointer whitespace-nowrap">
+                  <input
+                    type="checkbox"
+                    checked={negatePoll}
+                    onChange={(e) => setNegatePoll(e.target.checked)}
+                    className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  Negate poll
+                </label>
+              )}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">Payment method</label>
+          <select
+            name="selectedPaymentMethod"
+            value={selectedPaymentMethod}
+            onChange={(e) => setSelectedPaymentMethod(e.target.value)}
+            className="border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">- any -</option>
+            {PAYMENT_METHODS.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <form onSubmit={handleSearch} className="flex gap-2 items-end">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Quick Find</label>
+            <input
+              type="text"
+              name="search"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              placeholder="Name, address, postcode, no…"
+              className="border border-slate-300 rounded px-3 py-1.5 text-sm w-56 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <button
+            type="submit"
+            className="bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-1.5 text-sm font-medium"
+          >
+            Search
+          </button>
+          {activeSearch && (
+            <button
+              type="button"
+              onClick={handleCancelSearch}
+              className="border border-slate-300 rounded px-4 py-1.5 text-sm text-slate-600 hover:bg-slate-50"
+            >
+              Cancel Search
+            </button>
+          )}
+        </form>
+
+        {hasCfLabels && (
+          <form onSubmit={handleCfSearch} className="flex gap-2 items-end">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">Custom Fields</label>
+              <input
+                type="text"
+                name="customFieldSearch"
+                value={cfInput}
+                onChange={(e) => setCfInput(e.target.value)}
+                placeholder={cfLabelNames}
+                className="border border-slate-300 rounded px-3 py-1.5 text-sm w-56 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <button
+              type="submit"
+              className="bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-1.5 text-sm font-medium"
+            >
+              Search
+            </button>
+            {activeCf && (
+              <button
+                type="button"
+                onClick={handleCancelCf}
+                className="border border-slate-300 rounded px-4 py-1.5 text-sm text-slate-600 hover:bg-slate-50"
+              >
+                Clear
+              </button>
+            )}
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/members/MemberListTable.jsx
+++ b/frontend/src/pages/members/MemberListTable.jsx
@@ -1,0 +1,215 @@
+// beacon2/frontend/src/pages/members/MemberListTable.jsx
+//
+// Results section of MemberList — the "Select:" quick-select controls and the
+// sortable member table. Presentation only: sorting, selection, and navigation
+// are owned by the parent.
+
+import SortableHeader from '../../components/SortableHeader.jsx';
+import NoEmailIcon from '../../components/NoEmailIcon.jsx';
+import { formatShortAddress, isSubscriptionOverdue } from '../../lib/memberFormatters.js';
+import { formatMemberName } from '../../hooks/usePreferences.js';
+
+export default function MemberListTable({
+  memberList,
+  sorted,
+  sortKey,
+  sortDir,
+  onSort,
+  sortSurname,
+  selected,
+  toggleSelect,
+  selectAll,
+  clearAll,
+  selectEmail,
+  selectNoEmail,
+  selectPortalPassword,
+  selectNoPortalPassword,
+  selectEmailNotConfirmed,
+  rowRefs,
+  tableRef,
+  can,
+  navigate,
+}) {
+  return (
+    <>
+      {/* Select controls */}
+      <div className="flex flex-wrap gap-2 items-center mb-2">
+        <span className="text-sm text-slate-500">
+          {memberList.length} member{memberList.length !== 1 ? 's' : ''}
+        </span>
+        <span className="text-slate-300">|</span>
+        <span className="text-sm font-medium text-slate-600">Select:</span>
+        <button onClick={selectAll} className="text-sm text-blue-700 hover:underline">
+          All
+        </button>
+        <button onClick={clearAll} className="text-sm text-blue-700 hover:underline">
+          Clear All
+        </button>
+        <button onClick={selectEmail} className="text-sm text-blue-700 hover:underline">
+          Email only
+        </button>
+        <button onClick={selectNoEmail} className="text-sm text-blue-700 hover:underline">
+          Without email
+        </button>
+        <button onClick={selectPortalPassword} className="text-sm text-blue-700 hover:underline">
+          Portal password set
+        </button>
+        <button onClick={selectNoPortalPassword} className="text-sm text-blue-700 hover:underline">
+          Without portal password
+        </button>
+        <button onClick={selectEmailNotConfirmed} className="text-sm text-blue-700 hover:underline">
+          Email not confirmed
+        </button>
+        {selected.size > 0 && (
+          <span className="text-sm font-medium text-blue-700 ml-2">{selected.size} selected</span>
+        )}
+      </div>
+
+      <div ref={tableRef} className="overflow-x-auto rounded-lg shadow-sm mb-3">
+        <table className="w-full text-sm bg-white min-w-max">
+          <thead>
+            <tr className="bg-slate-50 border-b border-slate-200 text-left text-slate-600 italic font-normal">
+              <th className="px-2 py-2"></th>
+              <SortableHeader
+                col="membership_number"
+                label="No"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSort={onSort}
+                className="px-3 py-2 font-normal"
+              />
+              <th className="px-3 py-2 font-normal">
+                <span className="cursor-pointer select-none" onClick={() => onSort('forenames')}>
+                  Name
+                  <span
+                    className={`ml-1 text-xs ${sortKey === 'forenames' ? 'text-blue-600' : 'text-slate-300'}`}
+                  >
+                    {sortKey === 'forenames' ? (sortDir === 'asc' ? '▲' : '▼') : '⇅'}
+                  </span>
+                </span>
+                <span className="text-slate-300 mx-1">|</span>
+                <span
+                  className="cursor-pointer select-none text-xs not-italic"
+                  onClick={() => onSort(sortSurname)}
+                >
+                  by surname
+                  <span
+                    className={`ml-1 text-xs ${Array.isArray(sortKey) && sortKey[0] === 'surname' ? 'text-blue-600' : 'text-slate-300'}`}
+                  >
+                    {Array.isArray(sortKey) && sortKey[0] === 'surname'
+                      ? sortDir === 'asc'
+                        ? '▲'
+                        : '▼'
+                      : '⇅'}
+                  </span>
+                </span>
+              </th>
+              <SortableHeader
+                col="house_no"
+                label="Address"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSort={onSort}
+                className="px-3 py-2 font-normal"
+              />
+              <SortableHeader
+                col="telephone"
+                label="Telephone"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSort={onSort}
+                className="px-3 py-2 font-normal"
+              />
+              <SortableHeader
+                col="mobile"
+                label="Mobile"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSort={onSort}
+                className="px-3 py-2 font-normal"
+              />
+              <SortableHeader
+                col="class"
+                label="Class"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSort={onSort}
+                className="px-3 py-2 font-normal"
+              />
+              <SortableHeader
+                col="status"
+                label="Status"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSort={onSort}
+                className="px-3 py-2 font-normal"
+              />
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((m, i) => (
+              <tr
+                key={m.id}
+                ref={(el) => {
+                  if (el) rowRefs.current[m.surname?.[0]?.toUpperCase()] = el;
+                }}
+                className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'} ${selected.has(m.id) ? 'outline outline-2 outline-blue-400' : ''}`}
+              >
+                <td className="px-2 py-2">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(m.id)}
+                    onChange={() => toggleSelect(m.id)}
+                    className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  {!m.email && <NoEmailIcon className="ml-1" />}
+                </td>
+                <td
+                  className={`px-3 py-2 tabular-nums ${isSubscriptionOverdue(m) ? 'text-red-600' : ''}`}
+                >
+                  {can('member_record', 'view') ? (
+                    <a
+                      href="#view"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        navigate(`/members/${m.id}`);
+                      }}
+                      className={`hover:underline ${isSubscriptionOverdue(m) ? 'text-red-600' : 'text-blue-700'}`}
+                    >
+                      {m.membership_number}
+                    </a>
+                  ) : (
+                    m.membership_number
+                  )}
+                </td>
+                <td
+                  className={`px-3 py-2 font-medium ${isSubscriptionOverdue(m) ? 'text-red-600' : ''}`}
+                >
+                  {can('member_record', 'view') ? (
+                    <a
+                      href="#view"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        navigate(`/members/${m.id}`);
+                      }}
+                      className={`hover:underline ${isSubscriptionOverdue(m) ? 'text-red-600' : 'text-blue-700'}`}
+                    >
+                      {formatMemberName(m)}
+                    </a>
+                  ) : (
+                    formatMemberName(m)
+                  )}
+                </td>
+                <td className="px-3 py-2">{formatShortAddress(m)}</td>
+                <td className="px-3 py-2">{m.telephone ?? ''}</td>
+                <td className="px-3 py-2">{m.mobile ?? ''}</td>
+                <td className="px-3 py-2">{m.class ?? ''}</td>
+                <td className="px-3 py-2">{m.status ?? ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/members/memberListConstants.js
+++ b/frontend/src/pages/members/memberListConstants.js
@@ -1,0 +1,29 @@
+// beacon2/frontend/src/pages/members/memberListConstants.js
+//
+// Static constants shared by MemberList and its extracted sections.
+
+export const DOWNLOAD_FIELDS = [
+  { key: 'membership_number', label: 'Membership No', default: true },
+  { key: 'title', label: 'Title', default: false },
+  { key: 'forenames', label: 'Forenames', default: true },
+  { key: 'known_as', label: 'Known As', default: false },
+  { key: 'surname', label: 'Surname', default: true },
+  { key: 'email', label: 'Email', default: true },
+  { key: 'mobile', label: 'Mobile', default: true },
+  { key: 'telephone', label: 'Telephone', default: false },
+  { key: 'address', label: 'Address', default: false },
+  { key: 'town', label: 'Town', default: true },
+  { key: 'county', label: 'County', default: false },
+  { key: 'postcode', label: 'Postcode', default: true },
+  { key: 'country', label: 'Country', default: false },
+  { key: 'status', label: 'Status', default: true },
+  { key: 'class', label: 'Class', default: true },
+  { key: 'joined_on', label: 'Joined', default: false },
+  { key: 'next_renewal', label: 'Next Renewal', default: false },
+  { key: 'custom_field_1', label: 'Custom Field 1', default: false },
+  { key: 'custom_field_2', label: 'Custom Field 2', default: false },
+  { key: 'custom_field_3', label: 'Custom Field 3', default: false },
+  { key: 'custom_field_4', label: 'Custom Field 4', default: false },
+];
+
+export const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');

--- a/frontend/src/pages/system/CreateTenantForm.jsx
+++ b/frontend/src/pages/system/CreateTenantForm.jsx
@@ -1,0 +1,131 @@
+// beacon2/frontend/src/pages/system/CreateTenantForm.jsx
+//
+// "Create new tenant" form section of SystemDashboard. Presentation only: form
+// state and handlers are owned by the parent.
+
+import PasswordInput from '../../components/PasswordInput.jsx';
+
+export default function CreateTenantForm({
+  form,
+  setForm,
+  handleChange,
+  handleCreate,
+  saving,
+  formErr,
+}) {
+  return (
+    <section className="bg-white rounded-xl shadow-sm p-6">
+      <h2 className="text-lg font-semibold text-slate-700 mb-4">Create new tenant</h2>
+
+      {formErr && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+          {formErr}
+        </div>
+      )}
+
+      <form onSubmit={handleCreate} className="space-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">u3a name</label>
+            <input
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              required
+              placeholder="e.g. Oxfordshire u3a"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Slug</label>
+            <input
+              name="slug"
+              value={form.slug}
+              onChange={handleChange}
+              required
+              placeholder="e.g. oxfordshire"
+              pattern="[a-z0-9_]+"
+              title="Lowercase letters, numbers and underscores only"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p className="text-xs text-slate-400 mt-1">
+              Lowercase, no spaces. Users will type this at login.
+            </p>
+          </div>
+        </div>
+
+        <hr className="border-slate-100" />
+        <p className="text-sm font-medium text-slate-600">First admin user</p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Name</label>
+            <input
+              name="adminName"
+              value={form.adminName}
+              onChange={handleChange}
+              required
+              placeholder="e.g. Jane Smith"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Email</label>
+            <input
+              name="adminEmail"
+              type="email"
+              value={form.adminEmail}
+              onChange={handleChange}
+              required
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">Username</label>
+          <input
+            name="adminUsername"
+            value={form.adminUsername}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                adminUsername: e.target.value.toLowerCase().replace(/[^a-z0-9]/g, ''),
+              }))
+            }
+            required
+            pattern="[a-z0-9]+"
+            title="Lowercase letters and numbers only"
+            placeholder="e.g. jsmith"
+            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="text-xs text-slate-400 mt-1">
+            Used to log in. Lowercase letters and numbers only.
+          </p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">Password</label>
+          <PasswordInput
+            name="adminPassword"
+            value={form.adminPassword}
+            onChange={handleChange}
+            required
+            minLength={8}
+            autoComplete="new-password"
+            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="text-xs text-slate-400 mt-1">At least 8 characters.</p>
+        </div>
+
+        <button
+          type="submit"
+          disabled={saving}
+          className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white font-medium py-2 rounded-lg text-sm transition-colors"
+        >
+          {saving ? 'Creating…' : 'Create tenant'}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/pages/system/FeatureConfigModal.jsx
+++ b/frontend/src/pages/system/FeatureConfigModal.jsx
@@ -1,0 +1,124 @@
+// beacon2/frontend/src/pages/system/FeatureConfigModal.jsx
+//
+// Per-tenant feature-toggle modal of SystemDashboard. Presentation only: the
+// config map, dirty/saving state and handlers are owned by the parent.
+
+import { SECTIONS, getVal } from './systemDashboardConstants.js';
+
+export default function FeatureConfigModal({
+  fcTenant,
+  fcConfig,
+  fcLoading,
+  fcSaving,
+  fcError,
+  fcSuccess,
+  fcDirty,
+  handleFcChange,
+  handleFcSave,
+  setFcTenant,
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-lg shadow-xl max-w-lg mx-4 w-full max-h-[85vh] flex flex-col">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-slate-200">
+          <h3 className="text-lg font-bold text-slate-800">Feature Configuration</h3>
+          <p className="text-sm text-slate-500">
+            {fcTenant.name} ({fcTenant.slug})
+          </p>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+          {fcLoading && <p className="text-center text-slate-500 py-4">Loading...</p>}
+
+          {fcError && (
+            <p className="rounded-md bg-red-50 border border-red-300 px-3 py-2 text-red-700 text-sm">
+              {fcError}
+            </p>
+          )}
+
+          {fcSuccess && (
+            <p className="rounded-md bg-green-50 border border-green-300 px-3 py-2 text-green-700 text-sm font-medium">
+              Feature configuration saved.
+            </p>
+          )}
+
+          {!fcLoading &&
+            SECTIONS.map((section) => {
+              const masterOn = section.master
+                ? getVal(fcConfig, section.master.key, section.master.defaultValue)
+                : true;
+              return (
+                <div
+                  key={section.title}
+                  className="border border-slate-200 rounded-lg overflow-hidden"
+                >
+                  <div className="bg-gradient-to-r from-amber-50 to-amber-100 px-4 py-2 font-semibold text-sm text-slate-800">
+                    {section.title}
+                  </div>
+                  <div className="px-4 py-2 space-y-1">
+                    {section.master && (
+                      <label className="flex items-center gap-3 py-1 text-sm cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={masterOn}
+                          onChange={(e) => handleFcChange(section.master.key, e.target.checked)}
+                          className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                        />
+                        <span className="font-medium text-slate-700">{section.master.label}</span>
+                      </label>
+                    )}
+                    {section.toggles.length > 0 && (
+                      <div className="pl-6 space-y-1">
+                        {section.toggles.map((t) => {
+                          const parentOff = t.dependsOn && !getVal(fcConfig, t.dependsOn, true);
+                          const checked = parentOff
+                            ? false
+                            : getVal(fcConfig, t.key, t.defaultValue);
+                          return (
+                            <label
+                              key={t.key}
+                              className={`flex items-center gap-3 py-0.5 text-sm ${parentOff ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}`}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                disabled={parentOff}
+                                onChange={(e) => handleFcChange(t.key, e.target.checked)}
+                                className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                              />
+                              <span className="text-slate-700">{t.label}</span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-slate-200 flex justify-end gap-3">
+          <button
+            onClick={() => setFcTenant(null)}
+            className="border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-5 py-2 text-sm"
+          >
+            {fcDirty ? 'Cancel' : 'Close'}
+          </button>
+          {fcDirty && (
+            <button
+              onClick={handleFcSave}
+              disabled={fcSaving}
+              className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium"
+            >
+              {fcSaving ? 'Saving...' : 'Save'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/system/RestoreBackupSection.jsx
+++ b/frontend/src/pages/system/RestoreBackupSection.jsx
@@ -1,0 +1,106 @@
+// beacon2/frontend/src/pages/system/RestoreBackupSection.jsx
+//
+// "Restore from Backup" section of SystemDashboard. Presentation only: restore
+// state and handlers are owned by the parent.
+
+export default function RestoreBackupSection({
+  tenants,
+  restoreFileRef,
+  restoreTenant,
+  setRestoreTenant,
+  restoreFile,
+  restoring,
+  restoreResult,
+  setRestoreResult,
+  restoreError,
+  setRestoreError,
+  handleRestoreFileChange,
+  handleRestoreClick,
+}) {
+  return (
+    <section className="bg-white rounded-xl shadow-sm p-6">
+      <h2 className="text-lg font-semibold text-slate-700 mb-1">Restore from Backup</h2>
+      <p className="text-sm text-slate-500 mb-4">
+        Upload a Beacon2 backup or a legacy Beacon export file to restore a tenant&apos;s data. The
+        format is detected automatically. User accounts and roles are included in the restore.
+      </p>
+
+      <div className="rounded-md bg-amber-50 border border-amber-300 px-4 py-3 text-amber-800 text-sm mb-5">
+        <strong>Warning:</strong> Restoring will{' '}
+        <strong>permanently delete all current data</strong> for the selected tenant and replace it
+        with the contents of the uploaded file. This cannot be undone.
+      </div>
+
+      {restoreError && (
+        <div className="mb-4 rounded-md bg-red-50 border border-red-300 px-4 py-3 text-red-700 text-sm font-medium">
+          {restoreError}
+        </div>
+      )}
+
+      {restoreResult && (
+        <div className="mb-4 rounded-md bg-green-50 border border-green-300 px-4 py-3 text-green-800 text-sm font-medium whitespace-pre-line">
+          ✓ {restoreResult.message}
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">Select tenant</label>
+          <select
+            name="restoreTenant"
+            value={restoreTenant}
+            onChange={(e) => {
+              setRestoreTenant(e.target.value);
+              setRestoreResult(null);
+              setRestoreError('');
+            }}
+            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">— choose a tenant —</option>
+            {tenants.map((t) => (
+              <option key={t.id} value={t.slug}>
+                {t.name} ({t.slug})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">
+            Select backup file (.xlsx)
+          </label>
+          <input
+            ref={restoreFileRef}
+            type="file"
+            accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            onChange={handleRestoreFileChange}
+            className="block text-sm text-slate-600
+              file:mr-3 file:py-2 file:px-4 file:rounded file:border-0
+              file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700
+              hover:file:bg-blue-100"
+          />
+          {restoreFile && (
+            <p className="text-xs text-slate-500 mt-1">
+              {restoreFile.name} ({(restoreFile.size / 1024).toFixed(0)} KB)
+            </p>
+          )}
+        </div>
+
+        <button
+          onClick={handleRestoreClick}
+          disabled={!restoreTenant || !restoreFile || restoring}
+          className="inline-flex items-center gap-2 rounded px-4 py-2 text-sm font-medium transition-colors bg-red-600 hover:bg-red-700 text-white disabled:bg-red-300 disabled:cursor-not-allowed"
+        >
+          {restoring ? (
+            <>
+              <span className="animate-spin inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
+              Restoring…
+            </>
+          ) : (
+            'Restore from this file'
+          )}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/system/RestoreConfirmModal.jsx
+++ b/frontend/src/pages/system/RestoreConfirmModal.jsx
@@ -1,0 +1,44 @@
+// beacon2/frontend/src/pages/system/RestoreConfirmModal.jsx
+//
+// Confirmation modal for the destructive restore action in SystemDashboard.
+// Presentation only: state and handlers are owned by the parent.
+
+export default function RestoreConfirmModal({
+  restoreTenant,
+  restoreFile,
+  setConfirmOpen,
+  handleConfirmRestore,
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-lg shadow-xl p-6 max-w-md mx-4">
+        <h3 className="text-lg font-bold text-slate-800 mb-3">Confirm restore</h3>
+        <p className="text-sm text-slate-600 mb-1">
+          Tenant: <strong>{restoreTenant}</strong>
+        </p>
+        <p className="text-sm text-slate-600 mb-2">File:</p>
+        <p className="text-sm font-medium text-slate-800 bg-slate-100 rounded px-3 py-2 mb-4 break-all">
+          {restoreFile?.name}
+        </p>
+        <p className="text-sm text-red-700 font-medium mb-5">
+          All current data for this tenant will be permanently deleted and replaced. This cannot be
+          undone.
+        </p>
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={() => setConfirmOpen(false)}
+            className="border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-5 py-2 text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirmRestore}
+            className="bg-red-600 hover:bg-red-700 text-white rounded px-5 py-2 text-sm font-medium"
+          >
+            Yes, restore now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/system/SystemDashboard.jsx
+++ b/frontend/src/pages/system/SystemDashboard.jsx
@@ -5,94 +5,12 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { system, getSysToken, clearSysToken } from '../../lib/api.js';
 import SortableHeader from '../../components/SortableHeader.jsx';
-import PasswordInput from '../../components/PasswordInput.jsx';
 import { useSortedData } from '../../hooks/useSortedData.js';
-
-const EMPTY_FORM = {
-  name: '',
-  slug: '',
-  adminEmail: '',
-  adminName: '',
-  adminPassword: '',
-  adminUsername: '',
-};
-
-// ─── Feature toggle definitions (same structure as FeatureConfig.jsx) ────────
-const SECTIONS = [
-  {
-    title: 'Membership',
-    master: null,
-    toggles: [
-      { key: 'membershipCards', label: 'Membership Cards', defaultValue: true },
-      { key: 'membershipRenewals', label: 'Membership Renewals', defaultValue: true },
-      { key: 'addressesExport', label: 'Addresses Export', defaultValue: true },
-      { key: 'giftAid', label: 'Gift Aid', defaultValue: false },
-      { key: 'customFields', label: 'Custom Fields', defaultValue: true },
-      { key: 'polls', label: 'Polls', defaultValue: true },
-      { key: 'statistics', label: 'Membership Statistics', defaultValue: true },
-    ],
-  },
-  {
-    title: 'Groups',
-    master: { key: 'groups', label: 'Groups module', defaultValue: true },
-    toggles: [
-      { key: 'teams', label: 'Teams', defaultValue: true, dependsOn: 'groups' },
-      { key: 'venues', label: 'Venues', defaultValue: true, dependsOn: 'groups' },
-      { key: 'faculties', label: 'Faculties', defaultValue: true, dependsOn: 'groups' },
-      { key: 'groupLedger', label: 'Group Ledger', defaultValue: false, dependsOn: 'groups' },
-      { key: 'siteworks', label: 'SiteWorks', defaultValue: false, dependsOn: 'groups' },
-    ],
-  },
-  {
-    title: 'Events & Calendar',
-    master: { key: 'events', label: 'Events & Calendar module', defaultValue: true },
-    toggles: [
-      { key: 'calendar', label: 'Calendar', defaultValue: true, dependsOn: 'events' },
-      { key: 'eventTypes', label: 'Event Types', defaultValue: true, dependsOn: 'events' },
-    ],
-  },
-  {
-    title: 'Finance',
-    master: { key: 'finance', label: 'Finance module', defaultValue: true },
-    toggles: [
-      { key: 'creditBatches', label: 'Credit Batches', defaultValue: true, dependsOn: 'finance' },
-      { key: 'reconciliation', label: 'Reconciliation', defaultValue: true, dependsOn: 'finance' },
-      {
-        key: 'financialStatement',
-        label: 'Financial Statement',
-        defaultValue: true,
-        dependsOn: 'finance',
-      },
-      {
-        key: 'groupsStatement',
-        label: 'Groups Statement',
-        defaultValue: true,
-        dependsOn: 'finance',
-      },
-      { key: 'transferMoney', label: 'Transfer Money', defaultValue: true, dependsOn: 'finance' },
-    ],
-  },
-  {
-    title: 'Email & Letters',
-    master: { key: 'email', label: 'Email & Letters module', defaultValue: true },
-    toggles: [],
-  },
-  {
-    title: 'Members Portal',
-    master: { key: 'portal', label: 'Members Portal', defaultValue: true },
-    toggles: [],
-  },
-  {
-    title: 'Online Joining',
-    master: { key: 'onlineJoining', label: 'Online Joining', defaultValue: true },
-    toggles: [],
-  },
-];
-
-function getVal(config, key, defaultValue) {
-  if (key in config) return config[key];
-  return defaultValue;
-}
+import { EMPTY_FORM, SECTIONS } from './systemDashboardConstants.js';
+import CreateTenantForm from './CreateTenantForm.jsx';
+import RestoreBackupSection from './RestoreBackupSection.jsx';
+import RestoreConfirmModal from './RestoreConfirmModal.jsx';
+import FeatureConfigModal from './FeatureConfigModal.jsx';
 
 export default function SystemDashboard() {
   const navigate = useNavigate();
@@ -457,119 +375,14 @@ export default function SystemDashboard() {
 
         {/* Create tenant form */}
         {showForm && (
-          <section className="bg-white rounded-xl shadow-sm p-6">
-            <h2 className="text-lg font-semibold text-slate-700 mb-4">Create new tenant</h2>
-
-            {formErr && (
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
-                {formErr}
-              </div>
-            )}
-
-            <form onSubmit={handleCreate} className="space-y-4">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">u3a name</label>
-                  <input
-                    name="name"
-                    value={form.name}
-                    onChange={handleChange}
-                    required
-                    placeholder="e.g. Oxfordshire u3a"
-                    className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">Slug</label>
-                  <input
-                    name="slug"
-                    value={form.slug}
-                    onChange={handleChange}
-                    required
-                    placeholder="e.g. oxfordshire"
-                    pattern="[a-z0-9_]+"
-                    title="Lowercase letters, numbers and underscores only"
-                    className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                  <p className="text-xs text-slate-400 mt-1">
-                    Lowercase, no spaces. Users will type this at login.
-                  </p>
-                </div>
-              </div>
-
-              <hr className="border-slate-100" />
-              <p className="text-sm font-medium text-slate-600">First admin user</p>
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">Name</label>
-                  <input
-                    name="adminName"
-                    value={form.adminName}
-                    onChange={handleChange}
-                    required
-                    placeholder="e.g. Jane Smith"
-                    className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">Email</label>
-                  <input
-                    name="adminEmail"
-                    type="email"
-                    value={form.adminEmail}
-                    onChange={handleChange}
-                    required
-                    className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Username</label>
-                <input
-                  name="adminUsername"
-                  value={form.adminUsername}
-                  onChange={(e) =>
-                    setForm((f) => ({
-                      ...f,
-                      adminUsername: e.target.value.toLowerCase().replace(/[^a-z0-9]/g, ''),
-                    }))
-                  }
-                  required
-                  pattern="[a-z0-9]+"
-                  title="Lowercase letters and numbers only"
-                  placeholder="e.g. jsmith"
-                  className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-                <p className="text-xs text-slate-400 mt-1">
-                  Used to log in. Lowercase letters and numbers only.
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Password</label>
-                <PasswordInput
-                  name="adminPassword"
-                  value={form.adminPassword}
-                  onChange={handleChange}
-                  required
-                  minLength={8}
-                  autoComplete="new-password"
-                  className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-                <p className="text-xs text-slate-400 mt-1">At least 8 characters.</p>
-              </div>
-
-              <button
-                type="submit"
-                disabled={saving}
-                className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white font-medium py-2 rounded-lg text-sm transition-colors"
-              >
-                {saving ? 'Creating…' : 'Create tenant'}
-              </button>
-            </form>
-          </section>
+          <CreateTenantForm
+            form={form}
+            setForm={setForm}
+            handleChange={handleChange}
+            handleCreate={handleCreate}
+            saving={saving}
+            formErr={formErr}
+          />
         )}
 
         {/* System Message */}
@@ -599,233 +412,46 @@ export default function SystemDashboard() {
         </section>
 
         {/* Restore from Backup */}
-        <section className="bg-white rounded-xl shadow-sm p-6">
-          <h2 className="text-lg font-semibold text-slate-700 mb-1">Restore from Backup</h2>
-          <p className="text-sm text-slate-500 mb-4">
-            Upload a Beacon2 backup or a legacy Beacon export file to restore a tenant&apos;s data.
-            The format is detected automatically. User accounts and roles are included in the
-            restore.
-          </p>
-
-          <div className="rounded-md bg-amber-50 border border-amber-300 px-4 py-3 text-amber-800 text-sm mb-5">
-            <strong>Warning:</strong> Restoring will{' '}
-            <strong>permanently delete all current data</strong> for the selected tenant and replace
-            it with the contents of the uploaded file. This cannot be undone.
-          </div>
-
-          {restoreError && (
-            <div className="mb-4 rounded-md bg-red-50 border border-red-300 px-4 py-3 text-red-700 text-sm font-medium">
-              {restoreError}
-            </div>
-          )}
-
-          {restoreResult && (
-            <div className="mb-4 rounded-md bg-green-50 border border-green-300 px-4 py-3 text-green-800 text-sm font-medium whitespace-pre-line">
-              ✓ {restoreResult.message}
-            </div>
-          )}
-
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">Select tenant</label>
-              <select
-                name="restoreTenant"
-                value={restoreTenant}
-                onChange={(e) => {
-                  setRestoreTenant(e.target.value);
-                  setRestoreResult(null);
-                  setRestoreError('');
-                }}
-                className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value="">— choose a tenant —</option>
-                {tenants.map((t) => (
-                  <option key={t.id} value={t.slug}>
-                    {t.name} ({t.slug})
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
-                Select backup file (.xlsx)
-              </label>
-              <input
-                ref={restoreFileRef}
-                type="file"
-                accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-                onChange={handleRestoreFileChange}
-                className="block text-sm text-slate-600
-                  file:mr-3 file:py-2 file:px-4 file:rounded file:border-0
-                  file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700
-                  hover:file:bg-blue-100"
-              />
-              {restoreFile && (
-                <p className="text-xs text-slate-500 mt-1">
-                  {restoreFile.name} ({(restoreFile.size / 1024).toFixed(0)} KB)
-                </p>
-              )}
-            </div>
-
-            <button
-              onClick={handleRestoreClick}
-              disabled={!restoreTenant || !restoreFile || restoring}
-              className="inline-flex items-center gap-2 rounded px-4 py-2 text-sm font-medium transition-colors bg-red-600 hover:bg-red-700 text-white disabled:bg-red-300 disabled:cursor-not-allowed"
-            >
-              {restoring ? (
-                <>
-                  <span className="animate-spin inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
-                  Restoring…
-                </>
-              ) : (
-                'Restore from this file'
-              )}
-            </button>
-          </div>
-        </section>
+        <RestoreBackupSection
+          tenants={tenants}
+          restoreFileRef={restoreFileRef}
+          restoreTenant={restoreTenant}
+          setRestoreTenant={setRestoreTenant}
+          restoreFile={restoreFile}
+          restoring={restoring}
+          restoreResult={restoreResult}
+          setRestoreResult={setRestoreResult}
+          restoreError={restoreError}
+          setRestoreError={setRestoreError}
+          handleRestoreFileChange={handleRestoreFileChange}
+          handleRestoreClick={handleRestoreClick}
+        />
       </main>
 
       {/* Restore confirmation modal */}
       {confirmOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-white rounded-lg shadow-xl p-6 max-w-md mx-4">
-            <h3 className="text-lg font-bold text-slate-800 mb-3">Confirm restore</h3>
-            <p className="text-sm text-slate-600 mb-1">
-              Tenant: <strong>{restoreTenant}</strong>
-            </p>
-            <p className="text-sm text-slate-600 mb-2">File:</p>
-            <p className="text-sm font-medium text-slate-800 bg-slate-100 rounded px-3 py-2 mb-4 break-all">
-              {restoreFile?.name}
-            </p>
-            <p className="text-sm text-red-700 font-medium mb-5">
-              All current data for this tenant will be permanently deleted and replaced. This cannot
-              be undone.
-            </p>
-            <div className="flex gap-3 justify-end">
-              <button
-                onClick={() => setConfirmOpen(false)}
-                className="border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-5 py-2 text-sm"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleConfirmRestore}
-                className="bg-red-600 hover:bg-red-700 text-white rounded px-5 py-2 text-sm font-medium"
-              >
-                Yes, restore now
-              </button>
-            </div>
-          </div>
-        </div>
+        <RestoreConfirmModal
+          restoreTenant={restoreTenant}
+          restoreFile={restoreFile}
+          setConfirmOpen={setConfirmOpen}
+          handleConfirmRestore={handleConfirmRestore}
+        />
       )}
 
       {/* Feature config modal */}
       {fcTenant && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-white rounded-lg shadow-xl max-w-lg mx-4 w-full max-h-[85vh] flex flex-col">
-            {/* Header */}
-            <div className="px-6 py-4 border-b border-slate-200">
-              <h3 className="text-lg font-bold text-slate-800">Feature Configuration</h3>
-              <p className="text-sm text-slate-500">
-                {fcTenant.name} ({fcTenant.slug})
-              </p>
-            </div>
-
-            {/* Scrollable content */}
-            <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
-              {fcLoading && <p className="text-center text-slate-500 py-4">Loading...</p>}
-
-              {fcError && (
-                <p className="rounded-md bg-red-50 border border-red-300 px-3 py-2 text-red-700 text-sm">
-                  {fcError}
-                </p>
-              )}
-
-              {fcSuccess && (
-                <p className="rounded-md bg-green-50 border border-green-300 px-3 py-2 text-green-700 text-sm font-medium">
-                  Feature configuration saved.
-                </p>
-              )}
-
-              {!fcLoading &&
-                SECTIONS.map((section) => {
-                  const masterOn = section.master
-                    ? getVal(fcConfig, section.master.key, section.master.defaultValue)
-                    : true;
-                  return (
-                    <div
-                      key={section.title}
-                      className="border border-slate-200 rounded-lg overflow-hidden"
-                    >
-                      <div className="bg-gradient-to-r from-amber-50 to-amber-100 px-4 py-2 font-semibold text-sm text-slate-800">
-                        {section.title}
-                      </div>
-                      <div className="px-4 py-2 space-y-1">
-                        {section.master && (
-                          <label className="flex items-center gap-3 py-1 text-sm cursor-pointer">
-                            <input
-                              type="checkbox"
-                              checked={masterOn}
-                              onChange={(e) => handleFcChange(section.master.key, e.target.checked)}
-                              className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                            />
-                            <span className="font-medium text-slate-700">
-                              {section.master.label}
-                            </span>
-                          </label>
-                        )}
-                        {section.toggles.length > 0 && (
-                          <div className="pl-6 space-y-1">
-                            {section.toggles.map((t) => {
-                              const parentOff = t.dependsOn && !getVal(fcConfig, t.dependsOn, true);
-                              const checked = parentOff
-                                ? false
-                                : getVal(fcConfig, t.key, t.defaultValue);
-                              return (
-                                <label
-                                  key={t.key}
-                                  className={`flex items-center gap-3 py-0.5 text-sm ${parentOff ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}`}
-                                >
-                                  <input
-                                    type="checkbox"
-                                    checked={checked}
-                                    disabled={parentOff}
-                                    onChange={(e) => handleFcChange(t.key, e.target.checked)}
-                                    className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                                  />
-                                  <span className="text-slate-700">{t.label}</span>
-                                </label>
-                              );
-                            })}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-            </div>
-
-            {/* Footer */}
-            <div className="px-6 py-4 border-t border-slate-200 flex justify-end gap-3">
-              <button
-                onClick={() => setFcTenant(null)}
-                className="border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-5 py-2 text-sm"
-              >
-                {fcDirty ? 'Cancel' : 'Close'}
-              </button>
-              {fcDirty && (
-                <button
-                  onClick={handleFcSave}
-                  disabled={fcSaving}
-                  className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium"
-                >
-                  {fcSaving ? 'Saving...' : 'Save'}
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
+        <FeatureConfigModal
+          fcTenant={fcTenant}
+          fcConfig={fcConfig}
+          fcLoading={fcLoading}
+          fcSaving={fcSaving}
+          fcError={fcError}
+          fcSuccess={fcSuccess}
+          fcDirty={fcDirty}
+          handleFcChange={handleFcChange}
+          handleFcSave={handleFcSave}
+          setFcTenant={setFcTenant}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/system/systemDashboardConstants.js
+++ b/frontend/src/pages/system/systemDashboardConstants.js
@@ -1,0 +1,90 @@
+// beacon2/frontend/src/pages/system/systemDashboardConstants.js
+//
+// Constants and a small helper shared by SystemDashboard and its extracted
+// sections.
+
+export const EMPTY_FORM = {
+  name: '',
+  slug: '',
+  adminEmail: '',
+  adminName: '',
+  adminPassword: '',
+  adminUsername: '',
+};
+
+// ─── Feature toggle definitions (same structure as FeatureConfig.jsx) ────────
+export const SECTIONS = [
+  {
+    title: 'Membership',
+    master: null,
+    toggles: [
+      { key: 'membershipCards', label: 'Membership Cards', defaultValue: true },
+      { key: 'membershipRenewals', label: 'Membership Renewals', defaultValue: true },
+      { key: 'addressesExport', label: 'Addresses Export', defaultValue: true },
+      { key: 'giftAid', label: 'Gift Aid', defaultValue: false },
+      { key: 'customFields', label: 'Custom Fields', defaultValue: true },
+      { key: 'polls', label: 'Polls', defaultValue: true },
+      { key: 'statistics', label: 'Membership Statistics', defaultValue: true },
+    ],
+  },
+  {
+    title: 'Groups',
+    master: { key: 'groups', label: 'Groups module', defaultValue: true },
+    toggles: [
+      { key: 'teams', label: 'Teams', defaultValue: true, dependsOn: 'groups' },
+      { key: 'venues', label: 'Venues', defaultValue: true, dependsOn: 'groups' },
+      { key: 'faculties', label: 'Faculties', defaultValue: true, dependsOn: 'groups' },
+      { key: 'groupLedger', label: 'Group Ledger', defaultValue: false, dependsOn: 'groups' },
+      { key: 'siteworks', label: 'SiteWorks', defaultValue: false, dependsOn: 'groups' },
+    ],
+  },
+  {
+    title: 'Events & Calendar',
+    master: { key: 'events', label: 'Events & Calendar module', defaultValue: true },
+    toggles: [
+      { key: 'calendar', label: 'Calendar', defaultValue: true, dependsOn: 'events' },
+      { key: 'eventTypes', label: 'Event Types', defaultValue: true, dependsOn: 'events' },
+    ],
+  },
+  {
+    title: 'Finance',
+    master: { key: 'finance', label: 'Finance module', defaultValue: true },
+    toggles: [
+      { key: 'creditBatches', label: 'Credit Batches', defaultValue: true, dependsOn: 'finance' },
+      { key: 'reconciliation', label: 'Reconciliation', defaultValue: true, dependsOn: 'finance' },
+      {
+        key: 'financialStatement',
+        label: 'Financial Statement',
+        defaultValue: true,
+        dependsOn: 'finance',
+      },
+      {
+        key: 'groupsStatement',
+        label: 'Groups Statement',
+        defaultValue: true,
+        dependsOn: 'finance',
+      },
+      { key: 'transferMoney', label: 'Transfer Money', defaultValue: true, dependsOn: 'finance' },
+    ],
+  },
+  {
+    title: 'Email & Letters',
+    master: { key: 'email', label: 'Email & Letters module', defaultValue: true },
+    toggles: [],
+  },
+  {
+    title: 'Members Portal',
+    master: { key: 'portal', label: 'Members Portal', defaultValue: true },
+    toggles: [],
+  },
+  {
+    title: 'Online Joining',
+    master: { key: 'onlineJoining', label: 'Online Joining', defaultValue: true },
+    toggles: [],
+  },
+];
+
+export function getVal(config, key, defaultValue) {
+  if (key in config) return config[key];
+  return defaultValue;
+}


### PR DESCRIPTION
Completes the remaining (deferred) M2 pages from ImprovementPlan Chunk 10. Pure
extraction — no behaviour change. Each extracted part is presentation-only with
all state and handlers passed in from the parent, following the pattern
established earlier in Chunk 10.

## Pages split

| Page | Before | After | New files |
|------|--------|-------|-----------|
| `finance/TransactionEditor.jsx` | 1,097 | 792 | `transactionEditorUtils.js`, `TransactionAssociations.jsx`, `TransactionGiftAidSection.jsx`, `TransactionCategories.jsx` |
| `finance/CreditBatches.jsx` | 1,028 | 446 | `creditBatchesUtils.js`, `CreditBatchPicker.jsx`, `CreditBatchList.jsx`, `CreditBatchDetail.jsx`, `CreditBatchAddTxns.jsx`, `CreditBatchCreate.jsx` |
| `members/MemberList.jsx` | 921 | 453 | `memberListConstants.js`, `MemberListFilters.jsx`, `MemberListTable.jsx`, `MemberListBulkActions.jsx` |
| `finance/FinanceLedger.jsx` | 892 | 395 | `financeLedgerUtils.js`, `FinanceLedgerControls.jsx`, `FinanceLedgerTable.jsx` |
| `system/SystemDashboard.jsx` | 832 | 458 | `systemDashboardConstants.js`, `CreateTenantForm.jsx`, `RestoreBackupSection.jsx`, `RestoreConfirmModal.jsx`, `FeatureConfigModal.jsx` |

Notable: `CreditBatchPicker.jsx` deduplicates the near-identical "select unbatched
transactions" table that previously appeared in both the create and add-to-batch
views.

## Verification

- Frontend suite green: 53 files, 140 tests.
- `npm run lint`: 0 errors (31 pre-existing `exhaustive-deps` warnings unchanged).
- `npm run format:check`: clean.

## Docs

Updated `docs/ImprovementPlan.md` (Chunk 10 notes), `KNOWN-ISSUES.md` (M2 entry),
and `CHANGELOG.md`. This completes Chunk 10 — every M2 page originally flagged is
now split.

https://claude.ai/code/session_01AD5NV6oMVyxhyFpD8xat6F

---
_Generated by [Claude Code](https://claude.ai/code/session_01AD5NV6oMVyxhyFpD8xat6F)_