### PR TITLE
Chunk 11: frontend test quality & accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
   Chunk 5) — shared image magic-byte sniffer, attachment-filename sanitiser,
   and a reusable multer MIME `fileFilter` with spreadsheet/attachment
   whitelists, with unit coverage in `__tests__/uploads.test.js`.
+- **Frontend test quality (ImprovementPlan Chunk 11, findings C2/M4)** — added
+  behaviour/interaction tests (form fill, submit, validation, and API-call
+  assertions) modelled on `CookieConsent.test.jsx` for eight critical pages:
+  Login, ChangePassword, VenueEditor, MemberClassEditor, RoleEditor, UserEditor,
+  TransferMoney, and JoinForm. Added unit tests for the shared components and
+  helpers that previously had none: `Button`, `FormError`, `DateInput`,
+  `SortableHeader`, and the new `lib/a11y.js`. New shared `__tests__/testUtils.jsx`
+  (router-render helpers + `authValue` factory) reduces per-file boilerplate
+  (M4, frontend half), and `__tests__/setup.js` now stubs `window.scrollTo` /
+  `scrollIntoView` so form-submit tests run without jsdom "Not implemented"
+  noise. Frontend suite: 53 → 59 files, 140 → 196 tests.
 
 ### Changed
 - **Backend consistency cleanup (ImprovementPlan Chunk 6, findings N2/N6)** —
@@ -201,6 +212,17 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
     now split.
 
 ### Fixed
+- **Keyboard-accessible sortable column headers (ImprovementPlan Chunk 11,
+  finding O5)** — the shared `SortableHeader` component (used by ~17 list pages)
+  and the inline forename/surname split headers (MemberList, EntityMembers,
+  MembershipCards, MembershipRenewals, NonRenewals, RecentMembers) are now
+  focusable and activate on Enter/Space, and `SortableHeader` exposes `aria-sort`
+  reflecting the current sort state. New shared helper `lib/a11y.js`
+  (`clickableKeyProps`) provides the role/tabIndex/onKeyDown bundle.
+- **Form-label associations (ImprovementPlan Chunk 11, finding O5)** — continued
+  the `htmlFor`/`id` sweep across VenueEditor, MemberClassEditor (incl. `aria-label`
+  on the monthly-fee grid inputs), ChangePassword, and RoleEditor, so their fields
+  are programmatically labelled for screen readers and `getByLabelText`.
 - **Duplicated security findings in `KNOWN-ISSUES.md`** — the Chunk 4 and Chunk 5
   edits had appended a second copy of findings #8–#22, leaving two contradictory
   blocks (each showing only one chunk's fixes). Consolidated back to a single,

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -877,6 +877,31 @@ the shared versions incrementally when touching a file for other reasons.
   `MEMBERS`, `HOME`). The full route table stays in `App.jsx`. Privilege strings
   are deliberately **not** centralised — `can('resource', 'action')` reads fine and
   hoisting ~90 call sites adds indirection for no real safety gain.
+- `lib/a11y.js` — `clickableKeyProps(onActivate)` returns the
+  `{ role:'button', tabIndex:0, onClick, onKeyDown }` bundle that makes a
+  non-button element (a `<th>` or `<span>` used as a sort control) keyboard
+  operable: it activates on Enter/Space and `preventDefault`s the Space-scroll.
+  Used by `SortableHeader` (which also sets `aria-sort`) and the inline
+  forename/surname split headers. Reach for this instead of a bare `onClick` on
+  any clickable non-button.
+
+### Frontend test patterns (Chunk 11)
+
+- `__tests__/testUtils.jsx` — shared render boilerplate: `renderWithRouter(ui, { route })`,
+  `renderAtRoute(ui, { path, route })` (for `useParams` editor pages), and an
+  `authValue(overrides)` factory for `useAuth` mocks. **`vi.mock(...)` itself
+  cannot be centralised** — Vitest hoists each `vi.mock` to the top of its own
+  test file and scopes it per module path, so the per-file `vi.mock('../lib/api.js', …)`
+  blocks stay in each test. To assert on a mocked API call, declare a top-level
+  `const api = { create: vi.fn(), … }` and have the `vi.mock` factory delegate to
+  it (`create: (...a) => api.create(...a)`) — the factory may not reference
+  outer `vi.fn()`s directly, but it may call through at runtime.
+- Interaction tests follow `CookieConsent.test.jsx`: render → `fireEvent.change`
+  the labelled inputs (use `getByLabelText` now that the label sweep associates
+  them) → click the submit button → `await waitFor(() => expect(api.x).toHaveBeenCalledWith(…))`.
+- `__tests__/setup.js` stubs `window.scrollTo` and `Element.prototype.scrollIntoView`
+  (unimplemented in jsdom) so form-submit handlers that scroll-to-top/error don't
+  emit "Not implemented" noise.
 
 ### Common Tailwind patterns
 

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -287,8 +287,20 @@ These are catalogued and re-verified in `docs/ImprovementPlan.md` (Chunks 4–5)
    `getByLabel()` and hurts screen-reader accessibility. The highest-traffic pages
    have been fixed (April 2026): MemberEditor, TransactionEditor, GroupRecord,
    SystemSettings, JoinForm, PortalPersonalDetails, UserEditor, TransferMoney,
-   TransactionRefund, PersonalPreferences, and DateInput. Remaining lower-traffic
-   pages should be fixed incrementally as E2E tests are written for each page.
+   TransactionRefund, PersonalPreferences, and DateInput. Further pages fixed in
+   ImprovementPlan Chunk 11 (June 2026): VenueEditor, MemberClassEditor (incl.
+   `aria-label` on the monthly-fee grid inputs), ChangePassword, and RoleEditor.
+   Remaining lower-traffic pages should be fixed incrementally as E2E tests are
+   written for each page.
+
+2. `[FIXED]` **Sortable column headers not keyboard-accessible** (June 2026,
+   ImprovementPlan Chunk 11, finding O5) — sortable `<th>`/`<span>` headers were
+   `onClick`-only. The shared `SortableHeader` component and the inline
+   forename/surname split headers are now focusable and activate on Enter/Space
+   via `lib/a11y.js` (`clickableKeyProps`); `SortableHeader` also exposes
+   `aria-sort`. Note: the RoleEditor privilege-matrix toggle-all headers (a
+   non-sortable bulk-toggle affordance) remain `onClick`-only — out of scope for
+   the sortable-header fix; fix incrementally if revisited.
 
 ---
 

--- a/docs/ImprovementPlan.md
+++ b/docs/ImprovementPlan.md
@@ -436,12 +436,34 @@ only, no behaviour change.
   - All presentation-only with state/handlers passed in from the parent; frontend suite
     green (53 files, 140 tests); lint 0 errors, Prettier clean. M2 is now fully addressed.
 
-### Chunk 11 — Frontend test quality & accessibility (C2, O5, M4 frontend half)
+### Chunk 11 — Frontend test quality & accessibility (C2, O5, M4 frontend half) ✅ Done (2026-06-13)
 - Shared mock factories; interaction tests (form submit, validation error,
   API call assertions) for ~10 critical pages using CookieConsent.test.jsx as
   the model; unit tests for shared components.
 - Keyboard accessibility for sortable headers (`<button>` or role/tabIndex/
   onKeyDown); continue the `htmlFor`/`id` label sweep.
+
+**Notes:** new shared helper `lib/a11y.js` (`clickableKeyProps`) bundles
+`role="button"` + `tabIndex={0}` + an Enter/Space `onKeyDown`. Applied to the
+shared `SortableHeader` (used by ~17 list pages; also given `aria-sort`) and to
+the six inline forename/surname split headers (MemberList, EntityMembers,
+MembershipCards, MembershipRenewals, NonRenewals, RecentMembers) — so all
+sortable headers are now keyboard-operable. `htmlFor`/`id` label sweep continued
+on VenueEditor, MemberClassEditor (with `aria-label` on the monthly-fee grid
+inputs), ChangePassword, and RoleEditor; the remaining lower-traffic pages stay
+tracked in KNOWN-ISSUES → Accessibility #1. **Test quality (C2):**
+behaviour/interaction tests added for eight critical pages — Login,
+ChangePassword (new file), VenueEditor, MemberClassEditor, RoleEditor,
+UserEditor, TransferMoney, JoinForm — covering form fill, submit→API-call
+assertions, and validation paths. **Shared-component units:** `Button`,
+`FormError`, `DateInput`, `SortableHeader`, and `lib/a11y.js` (previously
+untested). **M4 (frontend half):** new `__tests__/testUtils.jsx`
+(`renderWithRouter`/`renderAtRoute`/`authValue`) for render boilerplate — note
+`vi.mock` itself can't be centralised (hoisted per module path); `setup.js` now
+stubs `window.scrollTo`/`scrollIntoView` to silence jsdom noise on submit paths.
+Frontend suite: 53 → 59 files, 140 → 196 tests; lint 0 errors, Prettier clean.
+The RoleEditor privilege-matrix toggle-all `<th onClick>` (a non-sortable
+bulk-toggle) was left as-is — outside the sortable-header scope.
 
 ### Chunk 12 — CI & E2E improvements (T2 rest, P1, P2)
 - Coverage reporting (`@vitest/coverage-v8`) surfaced in CI.

--- a/frontend/src/__tests__/Button.test.jsx
+++ b/frontend/src/__tests__/Button.test.jsx
@@ -1,0 +1,50 @@
+// beacon2/frontend/src/__tests__/Button.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import Button from '../components/ui/Button.jsx';
+
+describe('Button', () => {
+  it('renders its children', () => {
+    const { getByRole } = render(<Button>Save</Button>);
+    expect(getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+
+  it('fires onClick when clicked', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(<Button onClick={onClick}>Go</Button>);
+    fireEvent.click(getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the primary variant classes by default', () => {
+    const { getByRole } = render(<Button>Go</Button>);
+    expect(getByRole('button').className).toContain('bg-blue-600');
+  });
+
+  it('applies the danger variant classes', () => {
+    const { getByRole } = render(<Button variant="danger">Delete</Button>);
+    expect(getByRole('button').className).toContain('bg-red-600');
+  });
+
+  it('falls back to primary for an unknown variant', () => {
+    const { getByRole } = render(<Button variant="nope">Go</Button>);
+    expect(getByRole('button').className).toContain('bg-blue-600');
+  });
+
+  it('applies the requested size classes', () => {
+    const { getByRole } = render(<Button size="sm">Go</Button>);
+    expect(getByRole('button').className).toContain('text-xs');
+  });
+
+  it('appends a custom className and forwards arbitrary props', () => {
+    const { getByRole } = render(
+      <Button className="extra-class" type="submit" disabled>
+        Go
+      </Button>,
+    );
+    const btn = getByRole('button');
+    expect(btn.className).toContain('extra-class');
+    expect(btn).toHaveAttribute('type', 'submit');
+    expect(btn).toBeDisabled();
+  });
+});

--- a/frontend/src/__tests__/ChangePassword.test.jsx
+++ b/frontend/src/__tests__/ChangePassword.test.jsx
@@ -1,0 +1,103 @@
+// beacon2/frontend/src/__tests__/ChangePassword.test.jsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ChangePassword from '../pages/ChangePassword.jsx';
+
+const forceChangePassword = vi.fn();
+const clearMustChangePassword = vi.fn();
+const navigate = vi.fn();
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    user: { name: 'Jane Admin' },
+    clearMustChangePassword,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('../lib/api.js', () => ({
+  auth: { forceChangePassword: (...args) => forceChangePassword(...args) },
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => navigate };
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ChangePassword />
+    </MemoryRouter>,
+  );
+}
+
+describe('ChangePassword page', () => {
+  beforeEach(() => {
+    forceChangePassword.mockReset().mockResolvedValue({});
+    clearMustChangePassword.mockReset();
+    navigate.mockReset();
+  });
+
+  it('greets the user by name', () => {
+    renderPage();
+    expect(screen.getByText('Change password for Jane Admin')).toBeInTheDocument();
+  });
+
+  it('keeps Submit disabled until the form is valid', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+  });
+
+  it('shows complexity feedback for a weak password', () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'short' } });
+    expect(screen.getByText(/At least 10 characters/)).toBeInTheDocument();
+  });
+
+  it('confirms when the password meets requirements', () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'Goodpass123' } });
+    expect(screen.getByText('Password meets requirements')).toBeInTheDocument();
+  });
+
+  it('reports when the confirmation matches', () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'Goodpass123' } });
+    fireEvent.change(screen.getByLabelText('Confirm'), { target: { value: 'Goodpass123' } });
+    expect(screen.getByText('Passwords match')).toBeInTheDocument();
+  });
+
+  it('submits the new password, security Q&A and navigates home', async () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'Goodpass123' } });
+    fireEvent.change(screen.getByLabelText('Confirm'), { target: { value: 'Goodpass123' } });
+    fireEvent.change(screen.getByLabelText('Answer'), { target: { value: 'Greendale' } });
+
+    const submit = screen.getByRole('button', { name: /submit/i });
+    expect(submit).not.toBeDisabled();
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(forceChangePassword).toHaveBeenCalled());
+    expect(forceChangePassword).toHaveBeenCalledWith(
+      'Goodpass123',
+      'Your first school',
+      'Greendale',
+    );
+    await waitFor(() => expect(clearMustChangePassword).toHaveBeenCalled());
+    expect(navigate).toHaveBeenCalledWith('/');
+  });
+
+  it('surfaces an API error and does not navigate', async () => {
+    forceChangePassword.mockRejectedValueOnce(new Error('Server rejected password'));
+    renderPage();
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'Goodpass123' } });
+    fireEvent.change(screen.getByLabelText('Confirm'), { target: { value: 'Goodpass123' } });
+    fireEvent.change(screen.getByLabelText('Answer'), { target: { value: 'Greendale' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(await screen.findByText('Server rejected password')).toBeInTheDocument();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/DateInput.test.jsx
+++ b/frontend/src/__tests__/DateInput.test.jsx
@@ -1,0 +1,60 @@
+// beacon2/frontend/src/__tests__/DateInput.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import DateInput from '../components/DateInput.jsx';
+
+// The text field is the first <input>; query by its placeholder.
+function getTextInput(getByPlaceholderText) {
+  return getByPlaceholderText('dd/mm/yyyy');
+}
+
+describe('DateInput', () => {
+  it('displays an ISO value in dd/mm/yyyy format', () => {
+    const { getByPlaceholderText } = render(<DateInput value="2026-03-09" onChange={vi.fn()} />);
+    expect(getTextInput(getByPlaceholderText).value).toBe('09/03/2026');
+  });
+
+  it('shows an empty field for an empty value', () => {
+    const { getByPlaceholderText } = render(<DateInput value="" onChange={vi.fn()} />);
+    expect(getTextInput(getByPlaceholderText).value).toBe('');
+  });
+
+  it('emits ISO format when a full date is typed', () => {
+    const onChange = vi.fn();
+    const { getByPlaceholderText } = render(<DateInput value="" onChange={onChange} />);
+    fireEvent.change(getTextInput(getByPlaceholderText), { target: { value: '25/12/2026' } });
+    expect(onChange).toHaveBeenCalledWith('2026-12-25');
+  });
+
+  it('emits an empty string when the field is cleared', () => {
+    const onChange = vi.fn();
+    const { getByPlaceholderText } = render(<DateInput value="2026-01-01" onChange={onChange} />);
+    fireEvent.change(getTextInput(getByPlaceholderText), { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('does not emit for an incomplete / invalid date', () => {
+    const onChange = vi.fn();
+    const { getByPlaceholderText } = render(<DateInput value="" onChange={onChange} />);
+    fireEvent.change(getTextInput(getByPlaceholderText), { target: { value: '25/12' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('re-syncs the displayed text when the value prop changes', () => {
+    const { getByPlaceholderText, rerender } = render(
+      <DateInput value="2026-03-09" onChange={vi.fn()} />,
+    );
+    rerender(<DateInput value="2027-06-01" onChange={vi.fn()} />);
+    expect(getTextInput(getByPlaceholderText).value).toBe('01/06/2027');
+  });
+
+  it('hides the calendar picker button when disabled', () => {
+    const { queryByTitle } = render(<DateInput value="" onChange={vi.fn()} disabled />);
+    expect(queryByTitle('Open date picker')).toBeNull();
+  });
+
+  it('shows the calendar picker button when enabled', () => {
+    const { getByTitle } = render(<DateInput value="" onChange={vi.fn()} />);
+    expect(getByTitle('Open date picker')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/FormError.test.jsx
+++ b/frontend/src/__tests__/FormError.test.jsx
@@ -1,0 +1,36 @@
+// beacon2/frontend/src/__tests__/FormError.test.jsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import FormError from '../components/FormError.jsx';
+
+describe('FormError', () => {
+  it('renders nothing when there is no error', () => {
+    const { container } = render(<FormError error={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for an empty-string error', () => {
+    const { container } = render(<FormError error="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the error message when present', () => {
+    const { getByText } = render(<FormError error="Surname is required" />);
+    expect(getByText('Surname is required')).toBeInTheDocument();
+  });
+
+  it('uses the default (sm) size classes', () => {
+    const { getByText } = render(<FormError error="Bad" />);
+    expect(getByText('Bad').className).toContain('text-sm');
+  });
+
+  it('uses the xs size classes when requested', () => {
+    const { getByText } = render(<FormError error="Bad" size="xs" />);
+    expect(getByText('Bad').className).toContain('text-xs');
+  });
+
+  it('appends a custom className', () => {
+    const { getByText } = render(<FormError error="Bad" className="mt-4" />);
+    expect(getByText('Bad').className).toContain('mt-4');
+  });
+});

--- a/frontend/src/__tests__/JoinForm.test.jsx
+++ b/frontend/src/__tests__/JoinForm.test.jsx
@@ -1,32 +1,62 @@
 // beacon2/frontend/src/__tests__/JoinForm.test.jsx
 
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import JoinForm from '../pages/public/JoinForm.jsx';
 
+const publicApi = { getJoinConfig: vi.fn(), submitJoin: vi.fn() };
+
 vi.mock('../lib/api.js', () => ({
   publicApi: {
-    getJoinConfig: vi.fn().mockResolvedValue({
+    getJoinConfig: (...a) => publicApi.getJoinConfig(...a),
+    submitJoin: (...a) => publicApi.submitJoin(...a),
+  },
+}));
+
+function renderForm() {
+  return render(
+    <MemoryRouter initialEntries={['/public/test-u3a/join']}>
+      <Routes>
+        <Route path="/public/:slug/join" element={<JoinForm />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('JoinForm page', () => {
+  beforeEach(() => {
+    publicApi.getJoinConfig.mockReset().mockResolvedValue({
       u3aName: 'Test u3a',
       privacyPolicyUrl: 'https://example.com/privacy',
       giftAidEnabled: true,
       defaultTown: 'Oxford',
       defaultCounty: 'Oxon',
-      classes: [{ id: 'c1', name: 'Individual', fee: 20, explanation: '' }],
-    }),
-  },
-}));
+      classes: [{ id: 'c1', name: 'Individual', fee: 20, explanation: '', is_joint: false }],
+    });
+    publicApi.submitJoin.mockReset().mockResolvedValue({ ok: true });
+  });
 
-describe('JoinForm page', () => {
-  it('renders without crashing', () => {
-    const { container } = render(
-      <MemoryRouter initialEntries={['/public/test-u3a/join']}>
-        <Routes>
-          <Route path="/public/:slug/join" element={<JoinForm />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-    expect(container).toBeTruthy();
+  it('renders the join heading once config has loaded', async () => {
+    renderForm();
+    expect(await screen.findByText('Join Test u3a')).toBeInTheDocument();
+  });
+
+  it('shows validation errors and does not submit when required fields are empty', async () => {
+    renderForm();
+    // Wait for the form to load (single class is auto-selected).
+    await screen.findByText('Join Test u3a');
+    fireEvent.click(screen.getByRole('button', { name: /make payment/i }));
+
+    expect(await screen.findByText('First name is required.')).toBeInTheDocument();
+    expect(screen.getByText('Surname is required.')).toBeInTheDocument();
+    expect(screen.getByText('Email is required.')).toBeInTheDocument();
+    expect(publicApi.submitJoin).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an unavailable-joining message when config fails to load', async () => {
+    publicApi.getJoinConfig.mockRejectedValueOnce(new Error('Online joining is not enabled.'));
+    renderForm();
+    expect(await screen.findByText('Online Joining Unavailable')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/Login.test.jsx
+++ b/frontend/src/__tests__/Login.test.jsx
@@ -1,38 +1,91 @@
 // beacon2/frontend/src/__tests__/Login.test.jsx
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Login from '../pages/Login.jsx';
 
+const login = vi.fn();
+const navigate = vi.fn();
+let authError = null;
+
 vi.mock('../context/AuthContext.jsx', () => ({
-  useAuth: () => ({ login: vi.fn(), loading: false, error: null }),
+  useAuth: () => ({ login, loading: false, error: authError }),
 }));
 
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => navigate };
+});
+
+function renderLogin() {
+  return render(
+    <MemoryRouter>
+      <Login />
+    </MemoryRouter>,
+  );
+}
+
 describe('Login page', () => {
-  it('renders without crashing', () => {
-    const { container } = render(
-      <MemoryRouter>
-        <Login />
-      </MemoryRouter>,
-    );
-    expect(container).toBeTruthy();
+  beforeEach(() => {
+    login.mockReset();
+    navigate.mockReset();
+    authError = null;
   });
 
   it('shows the Administration heading', () => {
-    const { getByText } = render(
-      <MemoryRouter>
-        <Login />
-      </MemoryRouter>,
-    );
-    expect(getByText('Administration')).toBeInTheDocument();
+    renderLogin();
+    expect(screen.getByText('Administration')).toBeInTheDocument();
   });
 
   it('shows the Enter button', () => {
-    const { getByRole } = render(
-      <MemoryRouter>
-        <Login />
-      </MemoryRouter>,
-    );
-    expect(getByRole('button', { name: /enter/i })).toBeInTheDocument();
+    renderLogin();
+    expect(screen.getByRole('button', { name: /enter/i })).toBeInTheDocument();
+  });
+
+  it('submits the entered credentials and navigates home on success', async () => {
+    login.mockResolvedValue(true);
+    renderLogin();
+
+    fireEvent.change(screen.getByLabelText('u3a'), { target: { value: 'oxford-u3a' } });
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'jadmin' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: /enter/i }));
+
+    await waitFor(() => expect(login).toHaveBeenCalledWith('oxford-u3a', 'jadmin', 'secret123'));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/'));
+  });
+
+  it('does not navigate when login fails', async () => {
+    login.mockResolvedValue(false);
+    renderLogin();
+
+    fireEvent.change(screen.getByLabelText('u3a'), { target: { value: 'oxford-u3a' } });
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'jadmin' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByRole('button', { name: /enter/i }));
+
+    await waitFor(() => expect(login).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('reveals the password when the show-password toggle is clicked', () => {
+    renderLogin();
+    const pw = screen.getByLabelText('Password');
+    expect(pw).toHaveAttribute('type', 'password');
+    fireEvent.click(screen.getByTitle('Show password'));
+    expect(pw).toHaveAttribute('type', 'text');
+  });
+
+  it('opens the credential-recovery section on request', () => {
+    renderLogin();
+    expect(screen.queryByText('Recover your credentials')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /click here/i }));
+    expect(screen.getByText('Recover your credentials')).toBeInTheDocument();
+  });
+
+  it('renders the login error banner when auth reports an error', () => {
+    authError = 'bad';
+    renderLogin();
+    expect(screen.getByText(/login credentials are not recognised/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/MemberClassEditor.test.jsx
+++ b/frontend/src/__tests__/MemberClassEditor.test.jsx
@@ -1,8 +1,18 @@
 // beacon2/frontend/src/__tests__/MemberClassEditor.test.jsx
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MemberClassEditor from '../pages/membership/MemberClassEditor.jsx';
+
+const mcApi = {
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getMonthlyFees: vi.fn(),
+  saveMonthlyFees: vi.fn(),
+};
+const settingsApi = { get: vi.fn() };
 
 vi.mock('react-router-dom', async (importActual) => {
   const actual = await importActual();
@@ -19,34 +29,60 @@ vi.mock('../context/AuthContext.jsx', () => ({
 
 vi.mock('../lib/api.js', () => ({
   memberClasses: {
-    get: vi.fn().mockResolvedValue({}),
-    create: vi.fn().mockResolvedValue({}),
-    update: vi.fn().mockResolvedValue({}),
-    delete: vi.fn().mockResolvedValue({}),
-    getMonthlyFees: vi.fn().mockResolvedValue([]),
-    saveMonthlyFees: vi.fn().mockResolvedValue({}),
+    get: (...a) => mcApi.get(...a),
+    create: (...a) => mcApi.create(...a),
+    update: (...a) => mcApi.update(...a),
+    delete: (...a) => mcApi.delete(...a),
+    getMonthlyFees: (...a) => mcApi.getMonthlyFees(...a),
+    saveMonthlyFees: (...a) => mcApi.saveMonthlyFees(...a),
   },
-  settings: {
-    get: vi.fn().mockResolvedValue({ fee_variation: 'same_all_year', gift_aid_enabled: false }),
-  },
+  settings: { get: (...a) => settingsApi.get(...a) },
 }));
 
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <MemberClassEditor />
+    </MemoryRouter>,
+  );
+}
+
 describe('MemberClassEditor page (new class)', () => {
+  beforeEach(() => {
+    mcApi.get.mockReset().mockResolvedValue({});
+    mcApi.create.mockReset().mockResolvedValue({});
+    mcApi.update.mockReset().mockResolvedValue({});
+    mcApi.getMonthlyFees.mockReset().mockResolvedValue([]);
+    mcApi.saveMonthlyFees.mockReset().mockResolvedValue({});
+    settingsApi.get
+      .mockReset()
+      .mockResolvedValue({ fee_variation: 'same_all_year', gift_aid_enabled: false });
+  });
+
   it('renders without crashing', () => {
-    const { container } = render(
-      <MemoryRouter>
-        <MemberClassEditor />
-      </MemoryRouter>,
-    );
+    const { container } = renderPage();
     expect(container).toBeTruthy();
   });
 
   it('shows the Add Membership Class heading', () => {
-    const { getByText } = render(
-      <MemoryRouter>
-        <MemberClassEditor />
-      </MemoryRouter>,
+    renderPage();
+    expect(screen.getByText('Add Membership Class')).toBeInTheDocument();
+  });
+
+  it('associates the class-name label with its input', () => {
+    renderPage();
+    expect(screen.getByLabelText('Class name')).toBeInTheDocument();
+  });
+
+  it('creates the class with the entered name and fee on submit', async () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText('Class name'), { target: { value: 'Concession' } });
+    fireEvent.change(screen.getByLabelText('Fee per person (£)'), { target: { value: '15' } });
+    fireEvent.click(screen.getByRole('button', { name: /save record/i }));
+
+    await waitFor(() => expect(mcApi.create).toHaveBeenCalledTimes(1));
+    expect(mcApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Concession', fee: 15 }),
     );
-    expect(getByText('Add Membership Class')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/RoleEditor.test.jsx
+++ b/frontend/src/__tests__/RoleEditor.test.jsx
@@ -1,8 +1,11 @@
 // beacon2/frontend/src/__tests__/RoleEditor.test.jsx
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import RoleEditor from '../pages/roles/RoleEditor.jsx';
+
+const rolesApi = { get: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() };
+const privsApi = { resources: vi.fn() };
 
 vi.mock('../context/AuthContext.jsx', () => ({
   useAuth: () => ({
@@ -13,9 +16,12 @@ vi.mock('../context/AuthContext.jsx', () => ({
 
 vi.mock('../lib/api.js', () => ({
   roles: {
-    get: vi.fn().mockResolvedValue({ name: '', is_committee: false, notes: '', privileges: [] }),
+    get: (...a) => rolesApi.get(...a),
+    create: (...a) => rolesApi.create(...a),
+    update: (...a) => rolesApi.update(...a),
+    delete: (...a) => rolesApi.delete(...a),
   },
-  privileges: { resources: vi.fn().mockResolvedValue([]) },
+  privileges: { resources: (...a) => privsApi.resources(...a) },
 }));
 
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -23,22 +29,49 @@ vi.mock('react-router-dom', async (importOriginal) => {
   return { ...actual, useParams: () => ({ id: 'new' }), useNavigate: () => vi.fn() };
 });
 
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <RoleEditor />
+    </MemoryRouter>,
+  );
+}
+
 describe('RoleEditor page (new role)', () => {
-  it('renders without crashing', () => {
-    const { container } = render(
-      <MemoryRouter>
-        <RoleEditor />
-      </MemoryRouter>,
-    );
-    expect(container).toBeTruthy();
+  beforeEach(() => {
+    rolesApi.get
+      .mockReset()
+      .mockResolvedValue({ name: '', is_committee: false, notes: '', privileges: [] });
+    rolesApi.create.mockReset().mockResolvedValue({ id: 'r1' });
+    rolesApi.update.mockReset().mockResolvedValue({});
+    privsApi.resources.mockReset().mockResolvedValue([]);
   });
 
   it('shows the Role Record heading', () => {
-    const { getByText } = render(
-      <MemoryRouter>
-        <RoleEditor />
-      </MemoryRouter>,
+    renderPage();
+    expect(screen.getByText('Role Record')).toBeInTheDocument();
+  });
+
+  it('associates the Name label with its input', async () => {
+    renderPage();
+    expect(await screen.findByLabelText(/^Name/)).toBeInTheDocument();
+  });
+
+  it('blocks saving and shows an error when the name is empty', async () => {
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: /save role/i }));
+    expect(await screen.findByText('Role name is required.')).toBeInTheDocument();
+    expect(rolesApi.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the role with the entered name on save', async () => {
+    renderPage();
+    fireEvent.change(await screen.findByLabelText(/^Name/), { target: { value: 'Treasurer' } });
+    fireEvent.click(screen.getByRole('button', { name: /save role/i }));
+
+    await waitFor(() => expect(rolesApi.create).toHaveBeenCalledTimes(1));
+    expect(rolesApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Treasurer', isCommittee: false }),
     );
-    expect(getByText('Role Record')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/SortableHeader.test.jsx
+++ b/frontend/src/__tests__/SortableHeader.test.jsx
@@ -1,0 +1,91 @@
+// beacon2/frontend/src/__tests__/SortableHeader.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import SortableHeader from '../components/SortableHeader.jsx';
+
+// SortableHeader renders a <th>, so wrap it in a valid table structure.
+function renderHeader(props) {
+  return render(
+    <table>
+      <thead>
+        <tr>
+          <SortableHeader {...props} />
+        </tr>
+      </thead>
+    </table>,
+  );
+}
+
+describe('SortableHeader', () => {
+  it('renders the label', () => {
+    const { getByText } = renderHeader({ col: 'name', label: 'Name', onSort: vi.fn() });
+    expect(getByText('Name')).toBeInTheDocument();
+  });
+
+  it('calls onSort with the column on click', () => {
+    const onSort = vi.fn();
+    const { getByRole } = renderHeader({ col: 'name', label: 'Name', onSort });
+    fireEvent.click(getByRole('button'));
+    expect(onSort).toHaveBeenCalledWith('name');
+  });
+
+  it('is keyboard-focusable and activates on Enter', () => {
+    const onSort = vi.fn();
+    const { getByRole } = renderHeader({ col: 'name', label: 'Name', onSort });
+    const th = getByRole('button');
+    expect(th).toHaveAttribute('tabindex', '0');
+    fireEvent.keyDown(th, { key: 'Enter' });
+    expect(onSort).toHaveBeenCalledWith('name');
+  });
+
+  it('activates on Space', () => {
+    const onSort = vi.fn();
+    const { getByRole } = renderHeader({ col: 'name', label: 'Name', onSort });
+    fireEvent.keyDown(getByRole('button'), { key: ' ' });
+    expect(onSort).toHaveBeenCalledWith('name');
+  });
+
+  it('reflects ascending sort state via aria-sort', () => {
+    const { getByRole } = renderHeader({
+      col: 'name',
+      label: 'Name',
+      sortKey: 'name',
+      sortDir: 'asc',
+      onSort: vi.fn(),
+    });
+    expect(getByRole('button')).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('reflects descending sort state via aria-sort', () => {
+    const { getByRole } = renderHeader({
+      col: 'name',
+      label: 'Name',
+      sortKey: 'name',
+      sortDir: 'desc',
+      onSort: vi.fn(),
+    });
+    expect(getByRole('button')).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  it('reports aria-sort none when not the active column', () => {
+    const { getByRole } = renderHeader({
+      col: 'name',
+      label: 'Name',
+      sortKey: 'other',
+      sortDir: 'asc',
+      onSort: vi.fn(),
+    });
+    expect(getByRole('button')).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('matches an array column against an array sortKey', () => {
+    const { getByRole } = renderHeader({
+      col: ['surname', 'forenames'],
+      label: 'by surname',
+      sortKey: ['surname', 'forenames'],
+      sortDir: 'asc',
+      onSort: vi.fn(),
+    });
+    expect(getByRole('button')).toHaveAttribute('aria-sort', 'ascending');
+  });
+});

--- a/frontend/src/__tests__/TransferMoney.test.jsx
+++ b/frontend/src/__tests__/TransferMoney.test.jsx
@@ -1,8 +1,16 @@
 // beacon2/frontend/src/__tests__/TransferMoney.test.jsx
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import TransferMoney from '../pages/finance/TransferMoney.jsx';
+
+const financeApi = {
+  listAccounts: vi.fn(),
+  listTransfers: vi.fn(),
+  createTransfer: vi.fn(),
+  updateTransfer: vi.fn(),
+  deleteTransfer: vi.fn(),
+};
 
 vi.mock('../context/AuthContext.jsx', () => ({
   useAuth: () => ({
@@ -13,28 +21,68 @@ vi.mock('../context/AuthContext.jsx', () => ({
 
 vi.mock('../lib/api.js', () => ({
   finance: {
-    listAccounts: vi.fn().mockResolvedValue([]),
-    listTransfers: vi.fn().mockResolvedValue([]),
+    listAccounts: (...a) => financeApi.listAccounts(...a),
+    listTransfers: (...a) => financeApi.listTransfers(...a),
+    createTransfer: (...a) => financeApi.createTransfer(...a),
+    updateTransfer: (...a) => financeApi.updateTransfer(...a),
+    deleteTransfer: (...a) => financeApi.deleteTransfer(...a),
   },
   requestBlob: vi.fn(),
 }));
 
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <TransferMoney />
+    </MemoryRouter>,
+  );
+}
+
 describe('TransferMoney page', () => {
-  it('renders without crashing', () => {
-    const { container } = render(
-      <MemoryRouter>
-        <TransferMoney />
-      </MemoryRouter>,
-    );
-    expect(container).toBeTruthy();
+  beforeEach(() => {
+    financeApi.listAccounts.mockReset().mockResolvedValue([
+      { id: 'a1', name: 'Current', active: true },
+      { id: 'a2', name: 'Savings', active: true },
+    ]);
+    financeApi.listTransfers.mockReset().mockResolvedValue([]);
+    financeApi.createTransfer.mockReset().mockResolvedValue({});
   });
 
-  it('shows the Transfer Money heading', () => {
-    render(
-      <MemoryRouter>
-        <TransferMoney />
-      </MemoryRouter>,
+  it('shows the Transfer Money heading', async () => {
+    renderPage();
+    expect(await screen.findByText('Transfer Money')).toBeInTheDocument();
+  });
+
+  it('validates that a positive amount is required', async () => {
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: /^save$/i }));
+    expect(await screen.findByText('A positive amount is required.')).toBeInTheDocument();
+    expect(financeApi.createTransfer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a transfer between the same account', async () => {
+    renderPage();
+    await screen.findByLabelText(/Amount/);
+    fireEvent.change(screen.getByLabelText(/Amount/), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText(/From account/), { target: { value: 'a1' } });
+    fireEvent.change(screen.getByLabelText(/To account/), { target: { value: 'a1' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(await screen.findByText('From and To accounts must be different.')).toBeInTheDocument();
+    expect(financeApi.createTransfer).not.toHaveBeenCalled();
+  });
+
+  it('creates a valid transfer', async () => {
+    renderPage();
+    await screen.findByLabelText(/Amount/);
+    fireEvent.change(screen.getByLabelText(/Amount/), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText(/From account/), { target: { value: 'a1' } });
+    fireEvent.change(screen.getByLabelText(/To account/), { target: { value: 'a2' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(financeApi.createTransfer).toHaveBeenCalledTimes(1));
+    expect(financeApi.createTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 50, from_account_id: 'a1', to_account_id: 'a2' }),
     );
-    expect(screen.getByText('Transfer Money')).toBeTruthy();
   });
 });

--- a/frontend/src/__tests__/UserEditor.test.jsx
+++ b/frontend/src/__tests__/UserEditor.test.jsx
@@ -1,8 +1,19 @@
 // beacon2/frontend/src/__tests__/UserEditor.test.jsx
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import UserEditor from '../pages/users/UserEditor.jsx';
+
+const usersApi = {
+  get: vi.fn(),
+  availableMembers: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  assignRole: vi.fn(),
+  removeRole: vi.fn(),
+  setTempPassword: vi.fn(),
+};
+const rolesApi = { list: vi.fn() };
 
 vi.mock('../context/AuthContext.jsx', () => ({
   useAuth: () => ({
@@ -13,19 +24,15 @@ vi.mock('../context/AuthContext.jsx', () => ({
 
 vi.mock('../lib/api.js', () => ({
   users: {
-    get: vi.fn().mockResolvedValue({
-      name: '',
-      email: '',
-      username: '',
-      active: true,
-      is_site_admin: false,
-      member_id: '',
-      member_name: '',
-      roles: [],
-    }),
-    availableMembers: vi.fn().mockResolvedValue([]),
+    get: (...a) => usersApi.get(...a),
+    availableMembers: (...a) => usersApi.availableMembers(...a),
+    create: (...a) => usersApi.create(...a),
+    update: (...a) => usersApi.update(...a),
+    assignRole: (...a) => usersApi.assignRole(...a),
+    removeRole: (...a) => usersApi.removeRole(...a),
+    setTempPassword: (...a) => usersApi.setTempPassword(...a),
   },
-  roles: { list: vi.fn().mockResolvedValue([]) },
+  roles: { list: (...a) => rolesApi.list(...a) },
 }));
 
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -33,22 +40,47 @@ vi.mock('react-router-dom', async (importOriginal) => {
   return { ...actual, useParams: () => ({ id: 'new' }), useNavigate: () => vi.fn() };
 });
 
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <UserEditor />
+    </MemoryRouter>,
+  );
+}
+
 describe('UserEditor page (new user)', () => {
-  it('renders without crashing', () => {
-    const { container } = render(
-      <MemoryRouter>
-        <UserEditor />
-      </MemoryRouter>,
-    );
-    expect(container).toBeTruthy();
+  beforeEach(() => {
+    usersApi.get.mockReset().mockResolvedValue({});
+    usersApi.availableMembers
+      .mockReset()
+      .mockResolvedValue([{ id: 'm1', surname: 'Bloggs', forenames: 'Joe', email: 'joe@x.com' }]);
+    usersApi.create.mockReset().mockResolvedValue({ id: 'u9', tempPassword: 'Temp123!' });
+    rolesApi.list.mockReset().mockResolvedValue([]);
   });
 
   it('shows the Add New User heading', async () => {
-    render(
-      <MemoryRouter>
-        <UserEditor />
-      </MemoryRouter>,
-    );
+    renderPage();
     expect(await screen.findByText('Add New User')).toBeInTheDocument();
+  });
+
+  it('requires a member to be selected before saving', async () => {
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: /save user/i }));
+    expect(await screen.findByText('Please select a member.')).toBeInTheDocument();
+    expect(usersApi.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the user and shows the temporary-password notice', async () => {
+    renderPage();
+    // Member dropdown is populated from availableMembers once loaded.
+    fireEvent.change(await screen.findByLabelText('Member'), { target: { value: 'm1' } });
+    fireEvent.change(screen.getByLabelText(/Login name/), { target: { value: 'jbloggs' } });
+    fireEvent.click(screen.getByRole('button', { name: /save user/i }));
+
+    await waitFor(() => expect(usersApi.create).toHaveBeenCalledTimes(1));
+    expect(usersApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({ memberId: 'm1', username: 'jbloggs' }),
+    );
+    expect(await screen.findByText(/temporary password of Temp123!/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/VenueEditor.test.jsx
+++ b/frontend/src/__tests__/VenueEditor.test.jsx
@@ -1,8 +1,15 @@
 // beacon2/frontend/src/__tests__/VenueEditor.test.jsx
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import VenueEditor from '../pages/groups/VenueEditor.jsx';
+
+const venuesApi = {
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
 
 vi.mock('../context/AuthContext.jsx', () => ({
   useAuth: () => ({
@@ -13,7 +20,36 @@ vi.mock('../context/AuthContext.jsx', () => ({
 
 vi.mock('../lib/api.js', () => ({
   venues: {
-    get: vi.fn().mockResolvedValue({
+    get: (...a) => venuesApi.get(...a),
+    create: (...a) => venuesApi.create(...a),
+    update: (...a) => venuesApi.update(...a),
+    delete: (...a) => venuesApi.delete(...a),
+  },
+}));
+
+function renderNew() {
+  return render(
+    <MemoryRouter initialEntries={['/venues/new']}>
+      <Routes>
+        <Route path="/venues/new" element={<VenueEditor />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderExisting() {
+  return render(
+    <MemoryRouter initialEntries={['/venues/v1']}>
+      <Routes>
+        <Route path="/venues/:id" element={<VenueEditor />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('VenueEditor page — new venue', () => {
+  beforeEach(() => {
+    venuesApi.get.mockReset().mockResolvedValue({
       id: 'v1',
       name: 'Village Hall',
       contact: null,
@@ -25,46 +61,72 @@ vi.mock('../lib/api.js', () => ({
       notes: null,
       private_address: false,
       accessible: false,
-    }),
-    create: vi.fn().mockResolvedValue({}),
-    update: vi.fn().mockResolvedValue({}),
-    delete: vi.fn().mockResolvedValue({}),
-  },
-}));
+    });
+    venuesApi.create.mockReset().mockResolvedValue({});
+    venuesApi.update.mockReset().mockResolvedValue({});
+    venuesApi.delete.mockReset().mockResolvedValue({});
+  });
 
-describe('VenueEditor page — new venue', () => {
   it('renders without crashing', () => {
-    const { container } = render(
-      <MemoryRouter initialEntries={['/venues/new']}>
-        <Routes>
-          <Route path="/venues/new" element={<VenueEditor />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    const { container } = renderNew();
     expect(container).toBeTruthy();
   });
 
   it('shows Add New Venue heading', () => {
-    const { getByText } = render(
-      <MemoryRouter initialEntries={['/venues/new']}>
-        <Routes>
-          <Route path="/venues/new" element={<VenueEditor />} />
-        </Routes>
-      </MemoryRouter>,
+    renderNew();
+    expect(screen.getByText('Add New Venue')).toBeTruthy();
+  });
+
+  it('associates the Venue label with its input', () => {
+    renderNew();
+    // Label association added in the accessibility sweep — getByLabelText works.
+    expect(screen.getByLabelText(/Venue/)).toBeInTheDocument();
+  });
+
+  it('creates the venue with the entered details on submit', async () => {
+    renderNew();
+    fireEvent.change(screen.getByLabelText(/Venue/), { target: { value: 'Parish Rooms' } });
+    fireEvent.change(screen.getByLabelText('Postcode'), { target: { value: 'OX1 1AA' } });
+    fireEvent.click(screen.getByRole('button', { name: /save record/i }));
+
+    await waitFor(() => expect(venuesApi.create).toHaveBeenCalledTimes(1));
+    expect(venuesApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Parish Rooms', postcode: 'OX1 1AA' }),
     );
-    expect(getByText('Add New Venue')).toBeTruthy();
+    expect(venuesApi.update).not.toHaveBeenCalled();
   });
 });
 
 describe('VenueEditor page — existing venue', () => {
-  it('renders without crashing', () => {
-    const { container } = render(
-      <MemoryRouter initialEntries={['/venues/v1']}>
-        <Routes>
-          <Route path="/venues/:id" element={<VenueEditor />} />
-        </Routes>
-      </MemoryRouter>,
+  beforeEach(() => {
+    venuesApi.get.mockReset().mockResolvedValue({
+      id: 'v1',
+      name: 'Village Hall',
+      contact: null,
+      address: null,
+      postcode: null,
+      telephone: null,
+      email: null,
+      website: null,
+      notes: null,
+      private_address: false,
+      accessible: false,
+    });
+    venuesApi.create.mockReset().mockResolvedValue({});
+    venuesApi.update.mockReset().mockResolvedValue({});
+  });
+
+  it('loads the venue and updates it on submit', async () => {
+    renderExisting();
+    expect(await screen.findByDisplayValue('Village Hall')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Venue/), { target: { value: 'Village Hall Annexe' } });
+    fireEvent.click(screen.getByRole('button', { name: /save record/i }));
+
+    await waitFor(() => expect(venuesApi.update).toHaveBeenCalledTimes(1));
+    expect(venuesApi.update).toHaveBeenCalledWith(
+      'v1',
+      expect.objectContaining({ name: 'Village Hall Annexe' }),
     );
-    expect(container).toBeTruthy();
+    expect(venuesApi.create).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/a11y.test.js
+++ b/frontend/src/__tests__/a11y.test.js
@@ -1,0 +1,41 @@
+// beacon2/frontend/src/__tests__/a11y.test.js
+import { describe, it, expect, vi } from 'vitest';
+import { clickableKeyProps } from '../lib/a11y.js';
+
+describe('clickableKeyProps', () => {
+  it('exposes button role and is focusable', () => {
+    const props = clickableKeyProps(() => {});
+    expect(props.role).toBe('button');
+    expect(props.tabIndex).toBe(0);
+  });
+
+  it('fires the handler on click', () => {
+    const fn = vi.fn();
+    clickableKeyProps(fn).onClick();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the handler on Enter and prevents default', () => {
+    const fn = vi.fn();
+    const e = { key: 'Enter', preventDefault: vi.fn() };
+    clickableKeyProps(fn).onKeyDown(e);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(e.preventDefault).toHaveBeenCalled();
+  });
+
+  it('fires the handler on Space and prevents the page scroll', () => {
+    const fn = vi.fn();
+    const e = { key: ' ', preventDefault: vi.fn() };
+    clickableKeyProps(fn).onKeyDown(e);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(e.preventDefault).toHaveBeenCalled();
+  });
+
+  it('ignores other keys', () => {
+    const fn = vi.fn();
+    const e = { key: 'a', preventDefault: vi.fn() };
+    clickableKeyProps(fn).onKeyDown(e);
+    expect(fn).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/setup.js
+++ b/frontend/src/__tests__/setup.js
@@ -1,2 +1,11 @@
 // beacon2/frontend/src/__tests__/setup.js
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// jsdom does not implement window.scrollTo / element.scrollIntoView; many pages
+// call them after a successful save. Stub them so interaction tests that submit
+// forms don't emit "Not implemented" noise.
+window.scrollTo = vi.fn();
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}

--- a/frontend/src/__tests__/testUtils.jsx
+++ b/frontend/src/__tests__/testUtils.jsx
@@ -1,0 +1,53 @@
+// beacon2/frontend/src/__tests__/testUtils.jsx
+//
+// Shared test helpers for frontend component/page tests, to cut the
+// render-wrapping boilerplate repeated across the suite.
+//
+// NOTE: `vi.mock(...)` calls cannot be centralised here — Vitest hoists them to
+// the top of each test file and they are scoped per module path. These helpers
+// cover the *rendering* boilerplate (router wrapping) and provide plain factory
+// objects (e.g. `authValue`) that a test's own `vi.mock` factory can spread.
+
+import { render } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/**
+ * Render `ui` inside a MemoryRouter. Pass `route` to set the initial URL.
+ *   renderWithRouter(<RoleList />);
+ *   renderWithRouter(<MemberList />, { route: '/members?status=current' });
+ */
+export function renderWithRouter(ui, { route = '/' } = {}) {
+  return render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>);
+}
+
+/**
+ * Render `ui` for a single parameterised route — the common pattern for editor
+ * pages that read `useParams()`.
+ *   renderAtRoute(<VenueEditor />, { path: '/venues/:id', route: '/venues/v1' });
+ */
+export function renderAtRoute(ui, { path, route }) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path={path} element={ui} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Default auth-context value for `vi.mock('../context/AuthContext.jsx', ...)`.
+ * Spread it and override per test:
+ *   useAuth: () => authValue({ can: () => false })
+ */
+export function authValue(overrides = {}) {
+  return {
+    tenant: 'test-u3a',
+    user: { id: 'u1', name: 'Test User' },
+    can: () => true,
+    hasFeature: () => true,
+    login: () => {},
+    logout: () => {},
+    ...overrides,
+  };
+}

--- a/frontend/src/components/EntityMembers.jsx
+++ b/frontend/src/components/EntityMembers.jsx
@@ -19,6 +19,7 @@ import { formatShortAddress, isSubscriptionOverdue } from '../lib/memberFormatte
 import { formatMemberName } from '../hooks/usePreferences.js';
 import { SS_EMAIL_COMPOSE_MEMBER_IDS } from '../lib/storageKeys.js';
 import { ROUTES } from '../lib/routes.js';
+import { clickableKeyProps } from '../lib/a11y.js';
 
 const BASE_DL_FIELDS = [
   { key: 'membership_number', label: 'Membership No', default: true },
@@ -365,7 +366,10 @@ export default function EntityMembers({ entityId, api, entityType = 'group' }) {
                   className="px-3 py-2 font-normal"
                 />
                 <th className="px-3 py-2 font-normal">
-                  <span className="cursor-pointer select-none" onClick={() => onSort('forenames')}>
+                  <span
+                    className="cursor-pointer select-none"
+                    {...clickableKeyProps(() => onSort('forenames'))}
+                  >
                     Name
                     <span
                       className={`ml-1 text-xs ${sortKey === 'forenames' ? 'text-blue-600' : 'text-slate-300'}`}
@@ -376,7 +380,7 @@ export default function EntityMembers({ entityId, api, entityType = 'group' }) {
                   <span className="text-slate-300 mx-1">|</span>
                   <span
                     className="cursor-pointer select-none text-xs not-italic"
-                    onClick={() => onSort(SORT_SURNAME)}
+                    {...clickableKeyProps(() => onSort(SORT_SURNAME))}
                   >
                     by surname
                     <span

--- a/frontend/src/components/SortableHeader.jsx
+++ b/frontend/src/components/SortableHeader.jsx
@@ -1,8 +1,12 @@
 // beacon2/frontend/src/components/SortableHeader.jsx
 // Renders a <th> that shows a sort indicator and calls onSort when clicked.
+// Keyboard accessible: focusable and activates on Enter/Space, with aria-sort
+// reflecting the current sort state for screen readers.
 // Usage:
 //   <SortableHeader col="name" label="Name" sortKey={sortKey} sortDir={sortDir}
 //                   onSort={onSort} className="px-4 py-2.5 font-normal" />
+
+import { clickableKeyProps } from '../lib/a11y.js';
 
 export default function SortableHeader({ col, label, sortKey, sortDir, onSort, className = '' }) {
   const active =
@@ -10,7 +14,11 @@ export default function SortableHeader({ col, label, sortKey, sortDir, onSort, c
       ? col.length === sortKey.length && col.every((v, i) => v === sortKey[i])
       : col === sortKey;
   return (
-    <th className={`cursor-pointer select-none ${className}`} onClick={() => onSort(col)}>
+    <th
+      className={`cursor-pointer select-none ${className}`}
+      aria-sort={active ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+      {...clickableKeyProps(() => onSort(col))}
+    >
       {label}
       <span className={`ml-1 text-xs ${active ? 'text-blue-600' : 'text-slate-300'}`}>
         {active ? (sortDir === 'asc' ? '▲' : '▼') : '⇅'}

--- a/frontend/src/lib/a11y.js
+++ b/frontend/src/lib/a11y.js
@@ -1,0 +1,24 @@
+// Accessibility helpers.
+
+/**
+ * Props that make a non-button element (e.g. a <span> or <th>) behave like a
+ * button for keyboard users: it becomes focusable and activates on Enter/Space.
+ *
+ *   <span {...clickableKeyProps(() => onSort('name'))}>Name</span>
+ *
+ * Spreads `role="button"`, `tabIndex={0}`, `onClick`, and an `onKeyDown` that
+ * fires the same handler on Enter or Space (preventing the Space-scroll).
+ */
+export function clickableKeyProps(onActivate) {
+  return {
+    role: 'button',
+    tabIndex: 0,
+    onClick: onActivate,
+    onKeyDown: (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onActivate(e);
+      }
+    },
+  };
+}

--- a/frontend/src/pages/ChangePassword.jsx
+++ b/frontend/src/pages/ChangePassword.jsx
@@ -101,9 +101,15 @@ export default function ChangePassword() {
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* New password */}
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">New password</label>
+            <label
+              htmlFor="cp-newPassword"
+              className="block text-sm font-medium text-slate-700 mb-1"
+            >
+              New password
+            </label>
             <div className="relative">
               <input
+                id="cp-newPassword"
                 type={showPw ? 'text' : 'password'}
                 name="newPassword"
                 value={form.newPassword}
@@ -131,9 +137,12 @@ export default function ChangePassword() {
 
           {/* Confirm */}
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">Confirm</label>
+            <label htmlFor="cp-confirm" className="block text-sm font-medium text-slate-700 mb-1">
+              Confirm
+            </label>
             <div className="relative">
               <input
+                id="cp-confirm"
                 type={showConfirm ? 'text' : 'password'}
                 name="confirm"
                 value={form.confirm}
@@ -168,8 +177,11 @@ export default function ChangePassword() {
 
           {/* Question */}
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">Question</label>
+            <label htmlFor="cp-question" className="block text-sm font-medium text-slate-700 mb-1">
+              Question
+            </label>
             <input
+              id="cp-question"
               type="text"
               name="question"
               value={form.question}
@@ -181,8 +193,11 @@ export default function ChangePassword() {
 
           {/* Answer */}
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">Answer</label>
+            <label htmlFor="cp-answer" className="block text-sm font-medium text-slate-700 mb-1">
+              Answer
+            </label>
             <input
+              id="cp-answer"
               type="text"
               name="answer"
               value={form.answer}

--- a/frontend/src/pages/groups/VenueEditor.jsx
+++ b/frontend/src/pages/groups/VenueEditor.jsx
@@ -159,10 +159,11 @@ export default function VenueEditor() {
           <form onSubmit={handleSave} noValidate className="space-y-4">
             {/* Venue name */}
             <div>
-              <label className={labelCls}>
+              <label htmlFor="venue-name" className={labelCls}>
                 Venue <RequiredMark />
               </label>
               <input
+                id="venue-name"
                 name="name"
                 className={`${inputCls} w-full`}
                 required
@@ -174,8 +175,11 @@ export default function VenueEditor() {
 
             {/* Address */}
             <div>
-              <label className={labelCls}>Address</label>
+              <label htmlFor="venue-address" className={labelCls}>
+                Address
+              </label>
               <input
+                id="venue-address"
                 name="address"
                 className={`${inputCls} w-full`}
                 value={form.address}
@@ -186,8 +190,11 @@ export default function VenueEditor() {
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <label className={labelCls}>Postcode</label>
+                <label htmlFor="venue-postcode" className={labelCls}>
+                  Postcode
+                </label>
                 <input
+                  id="venue-postcode"
                   name="postcode"
                   className={`${inputCls} w-full`}
                   value={form.postcode}
@@ -196,8 +203,11 @@ export default function VenueEditor() {
                 />
               </div>
               <div>
-                <label className={labelCls}>Contact</label>
+                <label htmlFor="venue-contact" className={labelCls}>
+                  Contact
+                </label>
                 <input
+                  id="venue-contact"
                   name="contact"
                   className={`${inputCls} w-full`}
                   value={form.contact}
@@ -208,8 +218,11 @@ export default function VenueEditor() {
             </div>
 
             <div>
-              <label className={labelCls}>Telephone</label>
+              <label htmlFor="venue-telephone" className={labelCls}>
+                Telephone
+              </label>
               <input
+                id="venue-telephone"
                 name="telephone"
                 className={`${inputCls} w-full`}
                 type="tel"
@@ -221,9 +234,12 @@ export default function VenueEditor() {
 
             {/* Email with send button */}
             <div>
-              <label className={labelCls}>Email</label>
+              <label htmlFor="venue-email" className={labelCls}>
+                Email
+              </label>
               <div className="flex gap-2 items-start">
                 <input
+                  id="venue-email"
                   name="email"
                   className={`${inputCls} flex-1`}
                   type="email"
@@ -245,9 +261,12 @@ export default function VenueEditor() {
 
             {/* Website with open button */}
             <div>
-              <label className={labelCls}>Website</label>
+              <label htmlFor="venue-website" className={labelCls}>
+                Website
+              </label>
               <div className="flex gap-2 items-start">
                 <input
+                  id="venue-website"
                   name="website"
                   className={`${inputCls} flex-1`}
                   type="url"
@@ -285,8 +304,11 @@ export default function VenueEditor() {
 
             {/* Notes */}
             <div>
-              <label className={labelCls}>Notes</label>
+              <label htmlFor="venue-notes" className={labelCls}>
+                Notes
+              </label>
               <textarea
+                id="venue-notes"
                 name="notes"
                 rows={3}
                 className={`${inputCls} w-full resize-y`}

--- a/frontend/src/pages/members/MemberListTable.jsx
+++ b/frontend/src/pages/members/MemberListTable.jsx
@@ -6,6 +6,7 @@
 
 import SortableHeader from '../../components/SortableHeader.jsx';
 import NoEmailIcon from '../../components/NoEmailIcon.jsx';
+import { clickableKeyProps } from '../../lib/a11y.js';
 import { formatShortAddress, isSubscriptionOverdue } from '../../lib/memberFormatters.js';
 import { formatMemberName } from '../../hooks/usePreferences.js';
 
@@ -79,7 +80,10 @@ export default function MemberListTable({
                 className="px-3 py-2 font-normal"
               />
               <th className="px-3 py-2 font-normal">
-                <span className="cursor-pointer select-none" onClick={() => onSort('forenames')}>
+                <span
+                  className="cursor-pointer select-none"
+                  {...clickableKeyProps(() => onSort('forenames'))}
+                >
                   Name
                   <span
                     className={`ml-1 text-xs ${sortKey === 'forenames' ? 'text-blue-600' : 'text-slate-300'}`}
@@ -90,7 +94,7 @@ export default function MemberListTable({
                 <span className="text-slate-300 mx-1">|</span>
                 <span
                   className="cursor-pointer select-none text-xs not-italic"
-                  onClick={() => onSort(sortSurname)}
+                  {...clickableKeyProps(() => onSort(sortSurname))}
                 >
                   by surname
                   <span

--- a/frontend/src/pages/members/RecentMembers.jsx
+++ b/frontend/src/pages/members/RecentMembers.jsx
@@ -9,6 +9,7 @@ import PageHeader from '../../components/PageHeader.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import DateInput from '../../components/DateInput.jsx';
 import SortableHeader from '../../components/SortableHeader.jsx';
+import { clickableKeyProps } from '../../lib/a11y.js';
 import { useSortedData } from '../../hooks/useSortedData.js';
 import {
   formatShortAddress,
@@ -368,7 +369,7 @@ export default function RecentMembers() {
                     <th className={TH}>
                       <span
                         className="cursor-pointer select-none"
-                        onClick={() => onSort('forenames')}
+                        {...clickableKeyProps(() => onSort('forenames'))}
                       >
                         Name
                         <span
@@ -380,7 +381,7 @@ export default function RecentMembers() {
                       <span className="text-slate-300 mx-1">|</span>
                       <span
                         className="cursor-pointer select-none text-xs"
-                        onClick={() => onSort(SORT_SURNAME)}
+                        {...clickableKeyProps(() => onSort(SORT_SURNAME))}
                       >
                         by surname
                         <span

--- a/frontend/src/pages/membership/MemberClassEditor.jsx
+++ b/frontend/src/pages/membership/MemberClassEditor.jsx
@@ -245,8 +245,11 @@ export default function MemberClassEditor() {
           className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6 space-y-4"
         >
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">Class name</label>
+            <label htmlFor="mc-name" className="block text-sm font-medium text-slate-700 mb-1">
+              Class name
+            </label>
             <input
+              id="mc-name"
               type="text"
               name="name"
               value={form.name}
@@ -261,11 +264,15 @@ export default function MemberClassEditor() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">
+            <label
+              htmlFor="mc-explanation"
+              className="block text-sm font-medium text-slate-700 mb-1"
+            >
               Explanation{' '}
               <span className="text-slate-400 font-normal">(shown to members joining online)</span>
             </label>
             <textarea
+              id="mc-explanation"
               name="explanation"
               value={form.explanation}
               onChange={(e) => set('explanation', e.target.value)}
@@ -278,10 +285,11 @@ export default function MemberClassEditor() {
           {feeVariation === 'same_all_year' && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">
+                <label htmlFor="mc-fee" className="block text-sm font-medium text-slate-700 mb-1">
                   Fee per person (£)
                 </label>
                 <input
+                  id="mc-fee"
                   type="number"
                   min="0"
                   step="0.01"
@@ -293,10 +301,14 @@ export default function MemberClassEditor() {
               </div>
               {giftAidEnabled && (
                 <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">
+                  <label
+                    htmlFor="mc-giftAidFee"
+                    className="block text-sm font-medium text-slate-700 mb-1"
+                  >
                     Gift Aid eligible (£)
                   </label>
                   <input
+                    id="mc-giftAidFee"
                     type="number"
                     min="0"
                     step="0.01"
@@ -420,6 +432,7 @@ export default function MemberClassEditor() {
                           min="0"
                           step="0.01"
                           name={`fee_${row.monthIndex}`}
+                          aria-label={`Fee per person for ${MONTH_LABELS[row.monthIndex]}`}
                           value={row.fee}
                           onChange={(e) => setMonthFee(row.monthIndex, 'fee', e.target.value)}
                           className="w-28 border border-slate-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -432,6 +445,7 @@ export default function MemberClassEditor() {
                             min="0"
                             step="0.01"
                             name={`giftAidFee_${row.monthIndex}`}
+                            aria-label={`Gift Aid eligible fee for ${MONTH_LABELS[row.monthIndex]}`}
                             value={row.giftAidFee}
                             onChange={(e) =>
                               setMonthFee(row.monthIndex, 'giftAidFee', e.target.value)

--- a/frontend/src/pages/membership/MembershipCards.jsx
+++ b/frontend/src/pages/membership/MembershipCards.jsx
@@ -8,6 +8,7 @@ import { useAuth } from '../../context/AuthContext.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
 import SortableHeader from '../../components/SortableHeader.jsx';
+import { clickableKeyProps } from '../../lib/a11y.js';
 import { useSortedData } from '../../hooks/useSortedData.js';
 import ScrollButtons from '../../components/ScrollButtons.jsx';
 import NoEmailIcon from '../../components/NoEmailIcon.jsx';
@@ -258,7 +259,7 @@ export default function MembershipCards() {
                       <th className="px-3 py-2 font-normal">
                         <span
                           className="cursor-pointer select-none"
-                          onClick={() => onSort('forenames')}
+                          {...clickableKeyProps(() => onSort('forenames'))}
                         >
                           Name
                           <span
@@ -270,7 +271,7 @@ export default function MembershipCards() {
                         <span className="text-slate-300 mx-1">|</span>
                         <span
                           className="cursor-pointer select-none text-xs not-italic"
-                          onClick={() => onSort(SORT_SURNAME)}
+                          {...clickableKeyProps(() => onSort(SORT_SURNAME))}
                         >
                           by surname
                           <span

--- a/frontend/src/pages/membership/MembershipRenewals.jsx
+++ b/frontend/src/pages/membership/MembershipRenewals.jsx
@@ -9,6 +9,7 @@ import PageHeader from '../../components/PageHeader.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import ScrollButtons from '../../components/ScrollButtons.jsx';
 import SortableHeader from '../../components/SortableHeader.jsx';
+import { clickableKeyProps } from '../../lib/a11y.js';
 import { useSortedData } from '../../hooks/useSortedData.js';
 import { formatMemberName } from '../../hooks/usePreferences.js';
 import { isSubscriptionOverdue } from '../../lib/memberFormatters.js';
@@ -488,7 +489,7 @@ export default function MembershipRenewals() {
                       <th className="px-4 py-2.5 font-normal">
                         <span
                           className="cursor-pointer select-none"
-                          onClick={() => onSort('forenames')}
+                          {...clickableKeyProps(() => onSort('forenames'))}
                         >
                           Name
                           <span
@@ -500,7 +501,7 @@ export default function MembershipRenewals() {
                         <span className="text-slate-300 mx-1">|</span>
                         <span
                           className="cursor-pointer select-none text-xs"
-                          onClick={() => onSort(SORT_SURNAME)}
+                          {...clickableKeyProps(() => onSort(SORT_SURNAME))}
                         >
                           by surname
                           <span

--- a/frontend/src/pages/membership/NonRenewals.jsx
+++ b/frontend/src/pages/membership/NonRenewals.jsx
@@ -9,6 +9,7 @@ import PageHeader from '../../components/PageHeader.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import { useSortedData } from '../../hooks/useSortedData.js';
 import SortableHeader from '../../components/SortableHeader.jsx';
+import { clickableKeyProps } from '../../lib/a11y.js';
 import NoEmailIcon from '../../components/NoEmailIcon.jsx';
 import { formatMemberName } from '../../hooks/usePreferences.js';
 import { formatShortAddress } from '../../lib/memberFormatters.js';
@@ -312,7 +313,7 @@ export default function NonRenewals() {
                     <th className={thCls}>
                       <span
                         className="cursor-pointer select-none"
-                        onClick={() => onSort('forenames')}
+                        {...clickableKeyProps(() => onSort('forenames'))}
                       >
                         Name
                         <span
@@ -324,7 +325,7 @@ export default function NonRenewals() {
                       <span className="text-slate-300 mx-1">|</span>
                       <span
                         className="cursor-pointer select-none text-xs"
-                        onClick={() => onSort(SORT_SURNAME)}
+                        {...clickableKeyProps(() => onSort(SORT_SURNAME))}
                       >
                         by surname
                         <span

--- a/frontend/src/pages/roles/RoleEditor.jsx
+++ b/frontend/src/pages/roles/RoleEditor.jsx
@@ -279,13 +279,14 @@ export default function RoleEditor() {
         {/* Role details card */}
         <div className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6 mb-6 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">
+            <label htmlFor="role-name" className="block text-sm font-medium text-slate-700 mb-1">
               Name
               {isNew && (
                 <span className="ml-2 text-xs text-slate-400 italic font-normal">New Role</span>
               )}
             </label>
             <input
+              id="role-name"
               type="text"
               name="name"
               value={name}
@@ -299,8 +300,11 @@ export default function RoleEditor() {
           </div>
 
           <div className="flex items-center gap-3">
-            <label className="text-sm font-medium text-slate-700">Committee role</label>
+            <label htmlFor="role-committee" className="text-sm font-medium text-slate-700">
+              Committee role
+            </label>
             <input
+              id="role-committee"
               type="checkbox"
               checked={isCommittee}
               onChange={(e) => {
@@ -313,8 +317,11 @@ export default function RoleEditor() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">Notes</label>
+            <label htmlFor="role-notes" className="block text-sm font-medium text-slate-700 mb-1">
+              Notes
+            </label>
             <textarea
+              id="role-notes"
               name="notes"
               value={notes}
               onChange={(e) => {


### PR DESCRIPTION
Implements **Chunk 11** of `docs/ImprovementPlan.md` — *Frontend test quality & accessibility* (findings C2, O5, M4 frontend half).

## Accessibility (O5)
- New shared helper `lib/a11y.js` → `clickableKeyProps(onActivate)` bundles `role="button"` + `tabIndex={0}` + an Enter/Space `onKeyDown` (with Space-scroll prevention).
- Applied to the shared `SortableHeader` (used by ~17 list pages; now also exposes `aria-sort`) and to the six inline forename/surname split headers (MemberList, EntityMembers, MembershipCards, MembershipRenewals, NonRenewals, RecentMembers). **All sortable headers are now keyboard-operable.**
- Continued the `htmlFor`/`id` label sweep on **VenueEditor**, **MemberClassEditor** (plus `aria-label` on the monthly-fee grid inputs), **ChangePassword** and **RoleEditor**. Remaining lower-traffic pages stay tracked in `KNOWN-ISSUES.md → Accessibility #1`.

## Test quality (C2 + M4 frontend half)
- **Interaction tests** (form fill → submit → API-call assertions + validation paths) modelled on `CookieConsent.test.jsx` for eight critical pages: Login, ChangePassword (new file), VenueEditor, MemberClassEditor, RoleEditor, UserEditor, TransferMoney, JoinForm.
- **Unit tests for shared components/helpers** that had none: `Button`, `FormError`, `DateInput`, `SortableHeader`, and `lib/a11y.js`.
- New `__tests__/testUtils.jsx` (`renderWithRouter` / `renderAtRoute` / `authValue`) trims render boilerplate. *(Note: `vi.mock` is hoisted per module path and can't be centralised — documented in CLAUDE-REFERENCE §11.)*
- `__tests__/setup.js` now stubs `window.scrollTo` / `Element.prototype.scrollIntoView` so submit-path tests run without jsdom "Not implemented" noise.

## Verification
- Frontend suite: **53 → 59 files, 140 → 196 tests**, all green.
- `npm run lint` → 0 errors (pre-existing `exhaustive-deps` warnings only); `npm run format:check` clean.

Docs updated: `docs/ImprovementPlan.md` (Chunk 11 marked ✅), `CHANGELOG.md`, `KNOWN-ISSUES.md`, `CLAUDE-REFERENCE.md`.

Out of scope: the RoleEditor privilege-matrix toggle-all `<th onClick>` (a non-sortable bulk-toggle affordance) was left as-is.

https://claude.ai/code/session_014ypB3AVumW5NkFA3YH4ahQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014ypB3AVumW5NkFA3YH4ahQ)_