### PR TITLE
Dependabot: ignore major bumps + pin pdfmake (cut PR noise)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,12 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+      # pdfmake 0.3 is a breaking rewrite (drops pdfmake/src/printer, used by
+      # routes/letters.js). For a 0.x package that arrives as a "minor", so the
+      # major rule above doesn't catch it — pin to 0.2.x patches until the
+      # migration is done (see KNOWN-ISSUES).
+      - dependency-name: 'pdfmake'
+        update-types: ['version-update:semver-minor']
 
   - package-ecosystem: npm
     directory: /frontend

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 # Dependabot keeps dependencies patched across the three npm packages and the
 # GitHub Actions workflows. Updates are grouped to keep PR noise low and are
-# capped so they never overwhelm the review queue.
+# capped so they never overwhelm the review queue. Major-version bumps are
+# ignored for the npm packages — they tend to be breaking and several versions
+# are deliberately pinned (e.g. eslint-plugin-react-hooks v5); take majors by
+# hand when there's budget for the refactor.
 version: 2
 updates:
   - package-ecosystem: npm
@@ -15,6 +18,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: npm
     directory: /frontend
@@ -28,6 +34,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: npm
     directory: /e2e
@@ -41,6 +50,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: github-actions
     directory: /

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -177,6 +177,12 @@ These are catalogued and re-verified in `docs/history/ImprovementPlan.md` (Chunk
    `format:check`** — it lives outside `backend/src` and `frontend/src`, so CI
    does not enforce its style. It was Prettier-formatted once during Chunk 3.
    Add a dedicated lint/format target for `shared/` if it grows.
+5. `[DEFERRED]` **`pdfmake` pinned to 0.2.x — 0.3 migration needed** — pdfmake
+   0.3 is a breaking rewrite: it drops `pdfmake/src/printer`, which
+   `backend/src/routes/letters.js` imports, so the backend fails to load under
+   0.3 (`Cannot find module 'pdfmake/src/printer'`). Dependabot is configured to
+   ignore pdfmake minor bumps until the import is migrated to the 0.3 API.
+   Surfaced 2026-06-14 when a grouped Dependabot PR (#429) broke backend tests.
 
 ---
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-backend",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-backend",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2-frontend",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2-frontend",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.20.4",
         "@tiptap/extension-text-style": "^3.20.4",


### PR DESCRIPTION
## Why

The Dependabot config merged in #425 opened a burst of PRs on its first run — including 9 individual major-version bumps and a grouped backend PR that broke CI. This tightens the config so future runs stay quiet, and records the one real follow-up.

## Changes
- **Ignore major-version npm bumps** for `/backend`, `/frontend`, `/e2e`. Majors are usually breaking and several versions are deliberately pinned (e.g. `eslint-plugin-react-hooks` v5); take majors by hand when there's budget. GitHub Actions majors stay grouped/allowed.
- **Pin `pdfmake` to 0.2.x** — 0.3 is a breaking rewrite that drops `pdfmake/src/printer` (imported by `routes/letters.js`), so it fails to load under 0.3. For a 0.x package that arrives as a "minor", so it needs an explicit ignore. Logged in `KNOWN-ISSUES.md` as a deferred migration.
- Sync `package-lock.json` versions to 0.11.1 (they lagged the `package.json` bump that landed on main).

## Triage already done on the first-run PRs (separate from this PR)
- **Merged** (CI green): #434 frontend group, #427 e2e Playwright, #426 GitHub Actions (also clears the upcoming Node-20 action deprecation).
- **Closed**: the 9 major bumps (#428, #430–#433, #435–#438) and #429 (backend group — broke on the pdfmake 0.3 issue above).

Once this merges, the major bumps won't be re-opened on the next weekly run.

https://claude.ai/code/session_017KCDUyDJEmL3VJvHEnGNk4

---
_Generated by [Claude Code](https://claude.ai/code/session_017KCDUyDJEmL3VJvHEnGNk4)_