### PR TITLE
Improvement plan 2026-06-14: Chunks 1 & 2 (licensing/legal hygiene + logging baseline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,30 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
   - `docs/FromBeacon/README.md` provenance statement: the original Beacon
     reference files (© John Franklin 2017) are retained **for reference only**,
     with all original copyright retained and no claim of redistribution rights.
+- **Structured logging baseline (2026-06-14 review, Chunk 2)** —
+  - New `backend/src/utils/logger.js`: a minimal, dependency-free leveled
+    logger (`error`/`warn`/`info`/`debug`) gated by `LOG_LEVEL` (default `info`
+    in production, `debug` otherwise). Each call emits one line —
+    timestamp, level, message, optional JSON context — backed by the matching
+    `console` method, with safe handling of non-serialisable context.
+  - Unit tests (`logger.test.js`) covering console routing, level gating,
+    line format, and circular-context safety.
+  - A `CLAUDE-STANDARDS.md` rule: use `logger`, never `console.*`, and never
+    log PII/secrets in app logs.
 
 ### Changed
 - `CONTRIBUTING.md` Licensing section now points at the new `LICENSE`,
   `SECURITY.md`, and `docs/FromBeacon/README.md` instead of saying a licence is
   undecided.
+
+### Security
+- **Removed PII from operational logs (2026-06-14 review, Chunk 2)** — replaced
+  all 60+ `console.*` call sites across backend non-test code (auth recovery,
+  portal auth/profile/renewals/helpers, online-join email helpers, migrate/seed,
+  redis, error handler, server startup) with the new `logger`. In the process,
+  log lines no longer include recipient/member email addresses, names, the
+  online-join payment link, or reset/verification tokens — only error messages,
+  ids, counts and booleans are logged now.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 
 ---
 
+## [Unreleased] — 2026-06-14
+
+### Added
+- **Licensing & legal hygiene (2026-06-14 review, Chunk 1)** —
+  - Root `LICENSE` declaring Beacon2 **proprietary / all rights reserved**
+    (Copyright (c) 2026 Peter Cooper), noting the project is a clean-room
+    reproduction not affiliated with the Third Age Trust.
+  - `SECURITY.md` vulnerability-disclosure policy directing reports through
+    GitHub private security advisories, with supported scope and a
+    do-not-include-real-PII note.
+  - `docs/FromBeacon/README.md` provenance statement: the original Beacon
+    reference files (© John Franklin 2017) are retained **for reference only**,
+    with all original copyright retained and no claim of redistribution rights.
+
+### Changed
+- `CONTRIBUTING.md` Licensing section now points at the new `LICENSE`,
+  `SECURITY.md`, and `docs/FromBeacon/README.md` instead of saying a licence is
+  undecided.
+
+---
+
 ## [Unreleased] — 2026-06-12
 
 ### Security

--- a/CLAUDE-STANDARDS.md
+++ b/CLAUDE-STANDARDS.md
@@ -261,6 +261,18 @@ Every item below applies to every new feature — no exceptions.
   from `backend/src/utils/audit.js` for create/update/delete operations. `logAudit`
   never throws, so no try/catch needed around it.
 
+- [ ] **App logging — use the logger, never `console.*`.** Import
+  `{ logger }` from `backend/src/utils/logger.js` and call
+  `logger.error|warn|info|debug(message, context?)`. The diagnostic message is
+  the first arg; pass structured fields as a plain object in `context`
+  (e.g. `logger.error('…failed', { message: err.message })`). Levels are gated
+  by `LOG_LEVEL` (default `info` in production, `debug` otherwise). **Never log
+  PII or secrets** — no member/recipient email addresses, names, tokens, reset
+  or verification links, or payment links. Log error *messages* (`err.message`),
+  ids, counts and booleans, not the sensitive values themselves. This is
+  distinct from `logAudit` (durable audit trail) — `logger` is for operational
+  app logs.
+
 - [ ] **Response shape and status codes** — adopt one convention consistently:
 
   | Outcome | Status | Body |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,11 @@ Beacon2 keeps several living documents up to date alongside code:
 
 ## Licensing
 
-A repository LICENSE has not yet been finalised (see `KNOWN-ISSUES.md`). Until
-one is added, treat the code as **all rights reserved** by the project owner and
-check before reusing it outside this project.
+This project is **proprietary** — see the root [`LICENSE`](LICENSE). The code is
+**all rights reserved** by the project owner; do not reuse it outside this
+project without prior written consent.
+
+Original Beacon reference material under [`docs/FromBeacon/`](docs/FromBeacon/)
+is third-party copyright and is included for reference only — see
+[`docs/FromBeacon/README.md`](docs/FromBeacon/README.md). To report a security
+issue, see [`SECURITY.md`](SECURITY.md).

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -146,16 +146,20 @@ These are catalogued and re-verified in `docs/history/ImprovementPlan.md` (Chunk
 
 ## Repo hygiene & licensing (ImprovementPlan Chunk 2)
 
-1. `[DEFERRED]` **No repository LICENSE** — owner has not yet chosen a licence
-   (proprietary vs open-source). Until one is added, the code is treated as
-   "all rights reserved" by the project owner. Decide and add a `LICENSE` file.
-   Deferred during Chunk 2 (2026-06-12) pending the owner's choice.
-2. `[DEFERRED]` **`docs/FromBeacon/` provenance unconfirmed** — the directory
-   redistributes original Beacon source (`privileges.php`, `styles.css`)
-   carrying "© John Franklin 2017 — this copyright notice must be retained",
-   plus sample exports. Kept as-is for now (owner to confirm permission and
-   reference-only status, then add a provenance README or remove). Deferred
-   during Chunk 2 (2026-06-12).
+1. `[FIXED]` **No repository LICENSE** — owner chose **proprietary / all rights
+   reserved**. Added a root `LICENSE` (Copyright (c) 2026 Peter Cooper, all
+   rights reserved) and updated `CONTRIBUTING.md`. Resolved in the 2026-06-14
+   review, Chunk 1.
+2. `[FIXED]` **`docs/FromBeacon/` provenance unconfirmed** — added
+   `docs/FromBeacon/README.md` stating the directory is third-party reference
+   material only, with all original copyright (© John Franklin 2017) retained
+   and **no claim of redistribution rights** asserted. Files retained for
+   reference; removal offered on rights-holder request. Resolved in the
+   2026-06-14 review, Chunk 1.
+3. `[FIXED]` **No `SECURITY.md`** — added a vulnerability-disclosure policy
+   directing reports through GitHub private security advisories, with supported
+   scope and a do-not-include-real-PII note. Resolved in the 2026-06-14 review,
+   Chunk 1.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Beacon2 — Proprietary Licence
+Copyright (c) 2026 Peter Cooper. All rights reserved.
+
+This software and its associated source code, documentation, and other
+materials (the "Software") are the proprietary work of the copyright holder.
+
+No permission is granted to any person to use, copy, modify, merge, publish,
+distribute, sublicense, or sell copies of the Software, in whole or in part,
+without the prior written consent of the copyright holder.
+
+The Software is a clean-room reproduction, for demonstration and portfolio
+purposes, of concepts from the u3a "Beacon" management system. It is not
+affiliated with, endorsed by, or a product of the Third Age Trust or the
+original authors of Beacon. Any third-party material retained for reference
+remains the property of its respective copyright holders (see
+docs/FromBeacon/README.md).
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF,
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+Beacon2 is a multi-tenant web application that stores u3a member personal
+data (names, contact details, membership and payment records). We take security
+reports seriously and appreciate responsible disclosure.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately through GitHub's security advisory workflow:
+
+1. Go to the repository's **Security** tab.
+2. Select **Report a vulnerability** (Advisories → Report a vulnerability).
+3. Provide a clear description, including:
+   - the affected area (endpoint, page, or module),
+   - steps to reproduce or a proof of concept,
+   - the impact you believe it has, and
+   - any suggested remediation, if known.
+
+If you are unable to use the GitHub advisory flow, you may open a minimal,
+non-sensitive issue asking a maintainer to open a private channel — without
+including any vulnerability details in that issue.
+
+We aim to acknowledge a report within a few days and to keep you informed of
+progress toward a fix. Please give us a reasonable opportunity to investigate
+and remediate before any public disclosure.
+
+## Supported scope
+
+Beacon2 is a demonstration / portfolio project and is **not yet running in
+production**. There is no released, supported version with a security-update
+guarantee; fixes are applied to the `main` branch.
+
+In scope:
+
+- The Beacon2 backend (`backend/`) and frontend (`frontend/`) application code
+  in this repository.
+- Authentication, authorisation/privilege, multi-tenant isolation, and member
+  data handling.
+
+Out of scope:
+
+- Third-party dependencies (please report those upstream; we track advisories
+  via Dependabot).
+- Original Beacon reference material under `docs/FromBeacon/`, which is not part
+  of the running application (see `docs/FromBeacon/README.md`).
+- Hosting-platform or infrastructure issues not caused by this code.
+
+## Handling of personal data
+
+Because Beacon2 processes member PII, please **do not include real member data**
+in any vulnerability report. Use synthetic or redacted examples when
+demonstrating an issue.

--- a/backend/src/__tests__/logger.test.js
+++ b/backend/src/__tests__/logger.test.js
@@ -1,0 +1,85 @@
+// beacon2/backend/src/__tests__/logger.test.js
+// Unit tests for the minimal structured logger: console routing, level
+// gating via LOG_LEVEL, line format, and safe handling of bad context.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { logger } from '../utils/logger.js';
+
+describe('logger', () => {
+  let errorSpy;
+  let warnSpy;
+  let logSpy;
+  const savedLevel = process.env.LOG_LEVEL;
+  const savedEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    // Ensure all levels are eligible unless a test overrides LOG_LEVEL.
+    delete process.env.LOG_LEVEL;
+    process.env.NODE_ENV = 'development';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (savedLevel === undefined) delete process.env.LOG_LEVEL;
+    else process.env.LOG_LEVEL = savedLevel;
+    process.env.NODE_ENV = savedEnv;
+  });
+
+  it('routes each level to the matching console method', () => {
+    logger.error('boom');
+    logger.warn('careful');
+    logger.info('fyi');
+    logger.debug('details');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // info and debug both go to console.log
+    expect(logSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('formats a line with timestamp, level, message and JSON context', () => {
+    logger.info('hello', { a: 1, b: 'two' });
+    const line = logSpy.mock.calls[0][0];
+    expect(line).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z \[info\] hello /);
+    expect(line).toContain('{"a":1,"b":"two"}');
+  });
+
+  it('omits the context segment when none is given', () => {
+    logger.warn('lonely');
+    const line = warnSpy.mock.calls[0][0];
+    expect(line).toMatch(/\[warn\] lonely$/);
+  });
+
+  it('gates lower-priority levels when LOG_LEVEL is raised', () => {
+    process.env.LOG_LEVEL = 'warn';
+    logger.error('e');
+    logger.warn('w');
+    logger.info('i');
+    logger.debug('d');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // info and debug are below the warn threshold — suppressed
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('never logs below info even with an unknown/invalid LOG_LEVEL in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.LOG_LEVEL = 'nonsense';
+    logger.info('shown');
+    logger.debug('hidden');
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0][0]).toContain('shown');
+  });
+
+  it('does not throw on non-serialisable context', () => {
+    const circular = {};
+    circular.self = circular;
+    expect(() => logger.info('round', circular)).not.toThrow();
+    expect(logSpy.mock.calls[0][0]).toContain('[unserialisable context]');
+  });
+});

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,11 +1,16 @@
 // beacon2/backend/src/middleware/errorHandler.js
 // Central error handler. Always returns JSON. Never exposes stack traces in production.
 
+import { logger } from '../utils/logger.js';
+
 export function errorHandler(err, req, res, _next) {
   const isDev = process.env.NODE_ENV === 'development';
 
   // Log all errors server-side
-  console.error(`[${new Date().toISOString()}] ${req.method} ${req.path}:`, err);
+  logger.error(`${req.method} ${req.path}`, {
+    message: err.message,
+    stack: err.stack,
+  });
 
   // Known application errors (thrown with a status property)
   if (err.status) {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -12,6 +12,7 @@ import { passwordSchema, generateTempPassword } from '../utils/passwordPolicy.js
 import { invalidateUserSessions } from '../utils/redis.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { logAudit } from '../utils/audit.js';
+import { logger } from '../utils/logger.js';
 
 const router = Router();
 
@@ -300,7 +301,7 @@ router.post('/recover', async (req, res, next) => {
     // sendRecoveryEmail (which would otherwise leak account existence by
     // timing — a matched account responds noticeably slower than a miss).
     void sendRecoveryEmail(data.tenantSlug, user).catch((err) =>
-      console.error('[Recovery] Background recovery email failed:', err.message),
+      logger.error('[Recovery] Background recovery email failed', { message: err.message }),
     );
     res.json({ message: RECOVER_GENERIC });
   } catch (err) {
@@ -345,7 +346,7 @@ router.post('/recover/verify', async (req, res, next) => {
     }
 
     void sendRecoveryEmail(data.tenantSlug, user).catch((err) =>
-      console.error('[Recovery] Background recovery email failed:', err.message),
+      logger.error('[Recovery] Background recovery email failed', { message: err.message }),
     );
     res.json({ message: RECOVER_GENERIC });
   } catch (err) {
@@ -432,9 +433,9 @@ async function sendRecoveryEmail(tenantSlug, user) {
   const body = `Your username is: ${user.username}\n\nA temporary password has been set: ${tempPassword}\n\nYou will be required to change this password when you next log in.`;
 
   if (!process.env.SENDGRID_API_KEY) {
-    console.warn(
-      `[Recovery] SendGrid not configured — cannot deliver recovery email to ${user.email}. ` +
-        `Set SENDGRID_API_KEY to enable account recovery emails.`,
+    logger.warn(
+      '[Recovery] SendGrid not configured — cannot deliver recovery email. ' +
+        'Set SENDGRID_API_KEY to enable account recovery emails.',
     );
     return;
   }
@@ -447,8 +448,8 @@ async function sendRecoveryEmail(tenantSlug, user) {
       text: body,
     });
   } catch (err) {
-    // Never include the body/password in the error log.
-    console.error(`[Recovery] Failed to send recovery email to ${user.email}:`, err.message);
+    // Never include the recipient email or the body/password in the error log.
+    logger.error('[Recovery] Failed to send recovery email', { message: err.message });
   }
 }
 

--- a/backend/src/routes/portal/helpers.js
+++ b/backend/src/routes/portal/helpers.js
@@ -5,6 +5,7 @@
 import sgMail from '@sendgrid/mail';
 import { tenantQuery, prisma } from '../../utils/db.js';
 import { resolveTokens } from '../../utils/emailTokens.js';
+import { logger } from '../../utils/logger.js';
 
 if (process.env.SENDGRID_API_KEY) {
   sgMail.setApiKey(process.env.SENDGRID_API_KEY);
@@ -46,23 +47,18 @@ export async function notifyGroupLeaders(slug, groupId, memberId, action, groupN
       [groupId],
     );
 
-    const [member] = await tenantQuery(
-      slug,
-      `SELECT forenames, surname FROM members WHERE id = $1`,
-      [memberId],
-    );
-    const memberName = member ? `${member.forenames} ${member.surname}` : 'A member';
-
-    for (const leader of leaders) {
-      if (leader.email) {
-        const verb = action === 'join' ? 'joined' : 'left';
-        console.log(
-          `[Portal] Would notify leader ${leader.forenames} ${leader.surname} (${leader.email}): ${memberName} has ${verb} ${groupName}`,
-        );
-      }
+    // In production this would email each leader that a member joined/left.
+    // Log only the operational facts — never leader/member names or emails.
+    const recipientCount = leaders.filter((l) => l.email).length;
+    if (recipientCount > 0) {
+      logger.info('[Portal] Group-leader notifications prepared (SendGrid not configured)', {
+        action,
+        group: groupName,
+        recipients: recipientCount,
+      });
     }
   } catch (err) {
-    console.error('[Portal] Failed to notify group leaders:', err.message);
+    logger.error('[Portal] Failed to notify group leaders', { message: err.message });
   }
 }
 
@@ -88,15 +84,15 @@ export async function sendDetailsUpdateEmail(slug, memberId, emailChanged) {
     const u3aName = tenant?.name ?? slug;
 
     if (template) {
-      const { subject } = resolveTokens(template.subject, template.body, member, u3aName);
-      console.log(`[Portal] Would send details update confirmation to ${emailAddr}: "${subject}"`);
-    } else {
-      console.log(
-        `[Portal] Would send details update confirmation to ${emailAddr} (no template found for 'portal_details_updated')`,
-      );
+      // In production the resolved subject/body populate the SendGrid message.
+      resolveTokens(template.subject, template.body, member, u3aName);
     }
+    // Log only non-PII metadata — never the recipient email or resolved subject.
+    logger.info('[Portal] Details-update confirmation prepared (SendGrid not configured)', {
+      hasTemplate: Boolean(template),
+    });
   } catch (err) {
-    console.error('[Portal] Failed to send details update email:', err.message);
+    logger.error('[Portal] Failed to send details update email', { message: err.message });
   }
 }
 
@@ -114,9 +110,9 @@ ${verifyLink}
 If you did not request this, please contact your u3a.`;
 
   if (!process.env.SENDGRID_API_KEY) {
-    console.warn(
-      `[Portal] SendGrid not configured — cannot deliver email-verification message to ${toEmail}. ` +
-        `Set SENDGRID_API_KEY to enable portal verification emails.`,
+    logger.warn(
+      '[Portal] SendGrid not configured — cannot deliver email-verification message. ' +
+        'Set SENDGRID_API_KEY to enable portal verification emails.',
     );
     return;
   }
@@ -124,7 +120,7 @@ If you did not request this, please contact your u3a.`;
   try {
     await sgMail.send({ to: toEmail, from: PORTAL_FROM, subject, text: body });
   } catch (err) {
-    // Never include the verification link in the error log.
-    console.error(`[Portal] Failed to send email-verification message to ${toEmail}:`, err.message);
+    // Never include the recipient email or the verification link in the error log.
+    logger.error('[Portal] Failed to send email-verification message', { message: err.message });
   }
 }

--- a/backend/src/routes/portal/profile.js
+++ b/backend/src/routes/portal/profile.js
@@ -17,6 +17,7 @@ import { resolveTokens } from '../../utils/emailTokens.js';
 import { logAudit } from '../../utils/audit.js';
 import { generateSingleCardPdf } from '../membershipCards.js';
 import { decodeAndValidateImage } from '../../utils/uploads.js';
+import { logger } from '../../utils/logger.js';
 import { sendDetailsUpdateEmail, sendPortalVerificationEmail } from './helpers.js';
 
 const router = Router({ mergeParams: true });
@@ -269,7 +270,9 @@ router.patch('/personal-details', async (req, res, next) => {
       // Send the link by email. Fire-and-forget; never log the token (a leaked
       // verification token lets an attacker confirm a changed email address).
       void sendPortalVerificationEmail(data.email.toLowerCase(), verifyLink).catch((err) =>
-        console.error('[Portal] Background email-verification send failed:', err.message),
+        logger.error('[Portal] Background email-verification send failed', {
+          message: err.message,
+        }),
       );
     }
 
@@ -537,7 +540,8 @@ router.post('/request-card', async (req, res, next) => {
     const u3aName = tenant?.name ?? slug;
 
     if (template) {
-      const { subject } = resolveTokens(template.subject, template.body, { ...member }, u3aName);
+      // In production the resolved subject/body populate the SendGrid message.
+      resolveTokens(template.subject, template.body, { ...member }, u3aName);
 
       // Generate the membership card PDF to attach to the email
       const attachments = [];
@@ -550,21 +554,16 @@ router.post('/request-card', async (req, res, next) => {
           disposition: 'attachment',
         });
       } catch (cardErr) {
-        console.error('[Portal] Failed to generate card PDF for attachment:', cardErr.message);
+        logger.error('[Portal] Failed to generate card PDF for attachment', {
+          message: cardErr.message,
+        });
       }
 
-      // In production, this would call SendGrid with the msg object below.
-      // const msg = {
-      //   to:          { email: emailAddr, name: `${member.forenames} ${member.surname}`.trim() },
-      //   from:        { email: FROM_ADDRESS, name: u3aName },
-      //   subject,
-      //   text:        body,
-      //   attachments: attachments.length > 0 ? attachments : undefined,
-      // };
-      // await sgMail.send(msg);
-      console.log(
-        `[Portal] Would send card replacement email to ${emailAddr}: "${subject}"${attachments.length ? ` [+card PDF: ${attachments[0].filename}]` : ''}`,
-      );
+      // In production, this would call SendGrid with the resolved subject/body,
+      // emailAddr as recipient, and the card PDF attachment. Log only metadata.
+      logger.info('[Portal] Card replacement email prepared (SendGrid not configured)', {
+        attachments: attachments.length,
+      });
     }
 
     // Mark card as not printed so admin knows to reprint

--- a/backend/src/routes/portal/renewals.js
+++ b/backend/src/routes/portal/renewals.js
@@ -11,6 +11,7 @@ import { isFeatureEnabled } from '../../middleware/requireFeature.js';
 import { logAudit } from '../../utils/audit.js';
 import { generateSingleCardPdf } from '../membershipCards.js';
 import { fmtDateISO } from './helpers.js';
+import { logger } from '../../utils/logger.js';
 
 const router = Router({ mergeParams: true });
 
@@ -499,7 +500,8 @@ router.post('/renewal-confirm', async (req, res, next) => {
 
       const emailAddr = member.email;
       if (emailAddr) {
-        const { subject } = resolveTokens(
+        // In production the resolved subject/body populate the SendGrid message.
+        resolveTokens(
           template.subject,
           template.body,
           { ...member, class_name: member.class_name },
@@ -518,21 +520,17 @@ router.post('/renewal-confirm', async (req, res, next) => {
               disposition: 'attachment',
             });
           } catch (cardErr) {
-            console.error('[Portal] Failed to generate renewal card PDF:', cardErr.message);
+            logger.error('[Portal] Failed to generate renewal card PDF', {
+              message: cardErr.message,
+            });
           }
         }
 
-        // const msg = {
-        //   to:          { email: emailAddr, name: `${member.forenames} ${member.surname}`.trim() },
-        //   from:        { email: FROM_ADDRESS, name: u3aName },
-        //   subject,
-        //   text:        body,
-        //   attachments: attachments.length > 0 ? attachments : undefined,
-        // };
-        // await sgMail.send(msg);
-        console.log(
-          `[Portal] Would send renewal confirmation to ${emailAddr}: "${subject}"${attachments.length ? ` [+card PDF: ${attachments[0].filename}]` : ''}`,
-        );
+        // In production this would call SendGrid with the resolved subject/body,
+        // emailAddr as recipient, and the card PDF. Log only non-PII metadata.
+        logger.info('[Portal] Renewal confirmation prepared (SendGrid not configured)', {
+          attachments: attachments.length,
+        });
       }
       // Also email partner if joint — partner gets their own card
       if (partnerMember?.email) {
@@ -542,7 +540,8 @@ router.post('/renewal-confirm', async (req, res, next) => {
               partnerMember.class_id,
             ])
           )[0]?.name ?? '';
-        const { subject } = resolveTokens(
+        // In production the resolved subject/body populate the SendGrid message.
+        resolveTokens(
           template.subject,
           template.body,
           { ...partnerMember, class_name: pClassName },
@@ -560,21 +559,16 @@ router.post('/renewal-confirm', async (req, res, next) => {
               disposition: 'attachment',
             });
           } catch (cardErr) {
-            console.error('[Portal] Failed to generate partner renewal card PDF:', cardErr.message);
+            logger.error('[Portal] Failed to generate partner renewal card PDF', {
+              message: cardErr.message,
+            });
           }
         }
 
-        // const msg = {
-        //   to:          { email: partnerMember.email, name: `${partnerMember.forenames} ${partnerMember.surname}`.trim() },
-        //   from:        { email: FROM_ADDRESS, name: u3aName },
-        //   subject,
-        //   text:        body,
-        //   attachments: partnerAttachments.length > 0 ? partnerAttachments : undefined,
-        // };
-        // await sgMail.send(msg);
-        console.log(
-          `[Portal] Would send renewal confirmation to ${partnerMember.email}: "${subject}"${partnerAttachments.length ? ` [+card PDF: ${partnerAttachments[0].filename}]` : ''}`,
-        );
+        // In production this would call SendGrid for the partner. Log only metadata.
+        logger.info('[Portal] Partner renewal confirmation prepared (SendGrid not configured)', {
+          attachments: partnerAttachments.length,
+        });
       }
     }
 

--- a/backend/src/routes/public/join.js
+++ b/backend/src/routes/public/join.js
@@ -13,6 +13,7 @@ import { generateSingleCardPdf } from '../membershipCards.js';
 import { initiatePayment, verifyPaymentNotification } from '../../utils/paypal.js';
 import { isFeatureEnabled } from '../../middleware/requireFeature.js';
 import { logAudit } from '../../utils/audit.js';
+import { logger } from '../../utils/logger.js';
 
 const router = Router();
 
@@ -644,7 +645,8 @@ router.post('/:slug/email-payment-link', async (req, res, next) => {
     );
     const replyTo = settings?.online_join_email || null;
 
-    const { subject } = resolveTokens(
+    // In production the resolved subject/body populate the SendGrid message.
+    resolveTokens(
       template.subject,
       template.body,
       { ...member, class_name: member.class_name },
@@ -652,11 +654,11 @@ router.post('/:slug/email-payment-link', async (req, res, next) => {
       { '#PAYMENTLINK': paymentLink },
     );
 
-    // In production, this would call SendGrid
-    console.log(
-      `[Online Join] Would send payment link email to ${member.email}: "${subject}"${replyTo ? ` (reply-to: ${replyTo})` : ''}`,
-    );
-    console.log(`[Online Join] Payment link: ${paymentLink}`);
+    // In production, this would call SendGrid. We deliberately do NOT log the
+    // recipient email, resolved subject, or the payment link (a bearer token).
+    logger.info('[Online Join] Payment link email prepared (SendGrid not configured)', {
+      hasReplyTo: Boolean(replyTo),
+    });
 
     res.json({ message: 'Payment link has been sent to your email address.' });
   } catch (err) {
@@ -684,7 +686,8 @@ async function sendJoinConfirmationEmail(slug, member) {
     );
     const replyTo = settings?.online_join_email || null;
 
-    const { subject } = resolveTokens(
+    // In production the resolved subject/body populate the SendGrid message.
+    resolveTokens(
       template.subject,
       template.body,
       { ...member, class_name: member.class_name },
@@ -703,26 +706,21 @@ async function sendJoinConfirmationEmail(slug, member) {
           disposition: 'attachment',
         });
       } catch (cardErr) {
-        console.error('[Online Join] Failed to generate card PDF for attachment:', cardErr.message);
+        logger.error('[Online Join] Failed to generate card PDF for attachment', {
+          message: cardErr.message,
+        });
       }
     }
 
-    // In production, this would call SendGrid with the msg object below.
-    // For now, log the email that would be sent.
-    // const msg = {
-    //   to:          { email: member.email, name: `${member.forenames} ${member.surname}`.trim() },
-    //   from:        { email: FROM_ADDRESS, name: u3aName },
-    //   replyTo:     replyTo ? { email: replyTo, name: u3aName } : undefined,
-    //   subject,
-    //   text:        body,
-    //   attachments: attachments.length > 0 ? attachments : undefined,
-    // };
-    // await sgMail.send(msg);
-    console.log(
-      `[Online Join] Would send confirmation email to ${member.email}: "${subject}"${replyTo ? ` (reply-to: ${replyTo})` : ''}${attachments.length ? ` [+${attachments.length} attachment(s): ${attachments.map((a) => a.filename).join(', ')}]` : ''}`,
-    );
+    // In production, this would call SendGrid with the resolved subject/body,
+    // the member's email as recipient, replyTo, and the attachments below.
+    // We log only non-identifying metadata — never the recipient or subject.
+    logger.info('[Online Join] Confirmation email prepared (SendGrid not configured)', {
+      hasReplyTo: Boolean(replyTo),
+      attachments: attachments.length,
+    });
   } catch (err) {
-    console.error('[Online Join] Failed to send confirmation email:', err.message);
+    logger.error('[Online Join] Failed to send confirmation email', { message: err.message });
   }
 }
 
@@ -747,21 +745,22 @@ async function sendOfficerNotifications(slug, member) {
     const tenant = await prisma.sysTenant.findUnique({ where: { slug } });
     const u3aName = tenant?.name ?? '';
 
-    const { subject } = resolveTokens(
+    // In production the resolved subject/body populate the SendGrid message.
+    resolveTokens(
       template.subject,
       template.body,
       { ...member, class_name: member.class_name },
       u3aName,
     );
 
-    for (const officer of officers) {
-      const email = officer.office_email || officer.email;
-      if (email) {
-        console.log(`[Online Join] Would notify officer at ${email}: "${subject}"`);
-      }
+    const recipientCount = officers.filter((o) => o.office_email || o.email).length;
+    if (recipientCount > 0) {
+      logger.info('[Online Join] Officer notifications prepared (SendGrid not configured)', {
+        recipients: recipientCount,
+      });
     }
   } catch (err) {
-    console.error('[Online Join] Failed to send officer notifications:', err.message);
+    logger.error('[Online Join] Failed to send officer notifications', { message: err.message });
   }
 }
 

--- a/backend/src/routes/public/portalAuth.js
+++ b/backend/src/routes/public/portalAuth.js
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import sgMail from '@sendgrid/mail';
 import { rateLimit } from 'express-rate-limit';
 import { tenantQuery } from '../../utils/db.js';
+import { logger } from '../../utils/logger.js';
 import {
   hashPassword,
   verifyPassword,
@@ -165,7 +166,7 @@ router.post('/:slug/portal/register', portalAuthLimiter, async (req, res, next) 
     const frontendBase = process.env.CORS_ORIGIN || 'http://localhost:5173';
     const verifyLink = `${frontendBase}/public/${slug}/portal/verify?token=${verificationToken}`;
     void sendPortalVerificationEmail(data.email.toLowerCase(), verifyLink).catch((err) =>
-      console.error('[Portal] Background verification email failed:', err.message),
+      logger.error('[Portal] Background verification email failed', { message: err.message }),
     );
 
     logAudit(slug, {
@@ -375,7 +376,7 @@ router.post('/:slug/portal/forgot-password', portalAuthLimiter, async (req, res,
     // Fire-and-forget so the response time does not depend on email delivery
     // (which only happens on a hit) and so cannot be used to enumerate accounts.
     void sendPortalResetEmail(email.toLowerCase(), resetLink).catch((err) =>
-      console.error('[Portal] Background reset email failed:', err.message),
+      logger.error('[Portal] Background reset email failed', { message: err.message }),
     );
 
     res.json({ message: 'If an account exists with that email, a reset link has been sent.' });
@@ -400,9 +401,9 @@ ${resetLink}
 If you did not request this, you can ignore this email.`;
 
   if (!process.env.SENDGRID_API_KEY) {
-    console.warn(
-      `[Portal] SendGrid not configured — cannot deliver password reset email to ${toEmail}. ` +
-        `Set SENDGRID_API_KEY to enable portal reset emails.`,
+    logger.warn(
+      '[Portal] SendGrid not configured — cannot deliver password reset email. ' +
+        'Set SENDGRID_API_KEY to enable portal reset emails.',
     );
     return;
   }
@@ -415,8 +416,8 @@ If you did not request this, you can ignore this email.`;
       text: body,
     });
   } catch (err) {
-    // Never include the reset link in the error log.
-    console.error(`[Portal] Failed to send password reset email to ${toEmail}:`, err.message);
+    // Never include the recipient email or the reset link in the error log.
+    logger.error('[Portal] Failed to send password reset email', { message: err.message });
   }
 }
 
@@ -435,9 +436,9 @@ ${verifyLink}
 If you did not request this, you can ignore this email.`;
 
   if (!process.env.SENDGRID_API_KEY) {
-    console.warn(
-      `[Portal] SendGrid not configured — cannot deliver verification email to ${toEmail}. ` +
-        `Set SENDGRID_API_KEY to enable portal verification emails.`,
+    logger.warn(
+      '[Portal] SendGrid not configured — cannot deliver verification email. ' +
+        'Set SENDGRID_API_KEY to enable portal verification emails.',
     );
     return;
   }
@@ -445,8 +446,8 @@ If you did not request this, you can ignore this email.`;
   try {
     await sgMail.send({ to: toEmail, from: PORTAL_FROM, subject, text: body });
   } catch (err) {
-    // Never include the verification link in the error log.
-    console.error(`[Portal] Failed to send verification email to ${toEmail}:`, err.message);
+    // Never include the recipient email or the verification link in the error log.
+    logger.error('[Portal] Failed to send verification email', { message: err.message });
   }
 }
 

--- a/backend/src/seed/createTenant.js
+++ b/backend/src/seed/createTenant.js
@@ -10,6 +10,7 @@ import { hashPassword } from '../utils/password.js';
 import { splitSQL } from '../utils/migrate.js';
 import { PRIVILEGE_RESOURCES } from './privilegeResources.js';
 import { DEFAULT_ROLES } from './defaultRoles.js';
+import { logger } from '../utils/logger.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -114,6 +115,6 @@ export async function createTenantSchema({
     );
   }
 
-  console.log(`✓ Tenant created: ${name} (${schemaName})`);
+  logger.info(`✓ Tenant created: ${name} (${schemaName})`);
   return tenant;
 }

--- a/backend/src/seed/index.js
+++ b/backend/src/seed/index.js
@@ -9,6 +9,7 @@
 import 'dotenv/config';
 import { prisma } from '../utils/db.js';
 import { hashPassword } from '../utils/password.js';
+import { logger } from '../utils/logger.js';
 
 const email = process.env.SEED_ADMIN_EMAIL;
 const password = process.env.SEED_ADMIN_PASSWORD;
@@ -16,15 +17,15 @@ const name = process.env.SEED_ADMIN_NAME ?? 'System Administrator';
 
 async function seed() {
   if (!email || !password) {
-    console.error('Seed failed: SEED_ADMIN_EMAIL and SEED_ADMIN_PASSWORD must be set.');
+    logger.error('Seed failed: SEED_ADMIN_EMAIL and SEED_ADMIN_PASSWORD must be set.');
     process.exit(1);
   }
 
-  console.log('Seeding system administrator...');
+  logger.info('Seeding system administrator...');
 
   const existing = await prisma.sysAdmin.findUnique({ where: { email } });
   if (existing) {
-    console.log(`System admin already exists: ${email}`);
+    logger.info('System admin already exists — nothing to seed.');
     await prisma.$disconnect();
     return;
   }
@@ -35,17 +36,15 @@ async function seed() {
     data: { email, name, passwordHash, active: true },
   });
 
-  console.log('');
-  console.log('✓ System administrator created:');
-  console.log(`  Email:    ${email}`);
-  console.log(`  Password: (set via SEED_ADMIN_PASSWORD env var)`);
-  console.log('');
-  console.log('IMPORTANT: Change this password immediately after first login.');
+  logger.info(
+    '✓ System administrator created (credentials set via SEED_ADMIN env vars). ' +
+      'IMPORTANT: change this password immediately after first login.',
+  );
 
   await prisma.$disconnect();
 }
 
 seed().catch((err) => {
-  console.error('Seed failed:', err);
+  logger.error('Seed failed', { message: err.message, stack: err.stack });
   process.exit(1);
 });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -7,6 +7,7 @@ import { createRequire } from 'module';
 import app from './app.js';
 import { prisma } from './utils/db.js';
 import { migrateAndSeed } from './utils/migrate.js';
+import { logger } from './utils/logger.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json');
@@ -16,11 +17,13 @@ const PORT = process.env.PORT ?? 3001;
 migrateAndSeed()
   .then(() => {
     app.listen(PORT, () => {
-      console.log(`Beacon2 API v${version} running on port ${PORT} [${process.env.NODE_ENV}]`);
+      logger.info(`Beacon2 API v${version} running on port ${PORT}`, {
+        env: process.env.NODE_ENV,
+      });
     });
   })
   .catch((err) => {
-    console.error('Startup failed:', err);
+    logger.error('Startup failed', { message: err.message, stack: err.stack });
     process.exit(1);
   });
 

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -1,0 +1,59 @@
+// beacon2/backend/src/utils/logger.js
+//
+// Minimal, dependency-free structured logger.
+//
+// Goals:
+//   - Levels (error > warn > info > debug) gated by LOG_LEVEL, so noisy
+//     diagnostics can be turned down in production without code changes.
+//   - One readable line per call: timestamp, level, message, and an optional
+//     context object serialised as JSON.
+//   - Backed by the matching console method (error→console.error,
+//     warn→console.warn, info/debug→console.log) so existing test spies and
+//     platform log capture keep working unchanged.
+//
+// NOT a redaction layer: it does not scrub values for you. Never pass tokens,
+// passwords, reset/verification links, or member PII (e.g. raw email
+// addresses) into a log call. Put only non-identifying diagnostics in the
+// message and context (error messages, ids, counts, booleans).
+
+const LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
+
+function resolveThreshold() {
+  const fromEnv = (process.env.LOG_LEVEL || '').toLowerCase();
+  if (fromEnv in LEVELS) return LEVELS[fromEnv];
+  // Default: quieter in production, chattier elsewhere — but never below info,
+  // so warnings and errors always surface.
+  return process.env.NODE_ENV === 'production' ? LEVELS.info : LEVELS.debug;
+}
+
+const CONSOLE_FOR = {
+  error: 'error',
+  warn: 'warn',
+  info: 'log',
+  debug: 'log',
+};
+
+function emit(level, message, context) {
+  if (LEVELS[level] > resolveThreshold()) return;
+  const ts = new Date().toISOString();
+  let line = `${ts} [${level}] ${message}`;
+  if (context !== undefined && context !== null) {
+    try {
+      line += ` ${JSON.stringify(context)}`;
+    } catch {
+      // Circular or non-serialisable context — fall back to a marker rather
+      // than throwing inside a log call.
+      line += ' [unserialisable context]';
+    }
+  }
+  console[CONSOLE_FOR[level]](line);
+}
+
+export const logger = {
+  error: (message, context) => emit('error', message, context),
+  warn: (message, context) => emit('warn', message, context),
+  info: (message, context) => emit('info', message, context),
+  debug: (message, context) => emit('debug', message, context),
+};
+
+export default logger;

--- a/backend/src/utils/migrate.js
+++ b/backend/src/utils/migrate.js
@@ -11,17 +11,18 @@ import { tenantQuery } from './db.js';
 import { hashPassword } from './password.js';
 import { PRIVILEGE_RESOURCES } from '../seed/privilegeResources.js';
 import { DEFAULT_ROLES } from '../seed/defaultRoles.js';
+import { logger } from './logger.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export async function migrateAndSeed() {
   // 1. Run Prisma migrations (creates system-level tables if they don't exist)
-  console.log('Pushing database schema...');
+  logger.info('Pushing database schema...');
   try {
     execSync('npx prisma db push --accept-data-loss', { stdio: 'inherit' });
-    console.log('Schema push complete.');
+    logger.info('Schema push complete.');
   } catch (err) {
-    console.error('Migration failed:', err.message);
+    logger.error('Migration failed', { message: err.message });
     throw err;
   }
 
@@ -44,12 +45,10 @@ export async function migrateAndSeed() {
     const passwordHash = await hashPassword(password);
     await prisma.sysAdmin.create({ data: { email, name, passwordHash, active: true } });
 
-    console.log('');
-    console.log('✓ System administrator created:');
-    console.log(`  Email:    ${email}`);
-    console.log(`  Password: (set via SEED_ADMIN_PASSWORD env var)`);
-    console.log('  IMPORTANT: Change this password immediately after first login.');
-    console.log('');
+    logger.info(
+      '✓ System administrator created (set via SEED_ADMIN env vars). ' +
+        'IMPORTANT: change this password immediately after first login.',
+    );
   }
 
   // 3. Bring all existing tenant schemas up to date
@@ -171,7 +170,7 @@ async function migrateTenantSchemas() {
   for (const tenant of tenants) {
     const slug = tenant.slug;
     const schemaName = `u3a_${slug}`;
-    console.log(`Migrating tenant schema: ${schemaName}`);
+    logger.info(`Migrating tenant schema: ${schemaName}`);
 
     let ddlErrors = 0;
 
@@ -185,7 +184,7 @@ async function migrateTenantSchemas() {
         await prisma.$executeRawUnsafe(stmt);
       } catch (err) {
         ddlErrors++;
-        console.error(`  ✗ DDL error [${schemaName}]: ${err.message}`);
+        logger.error(`  ✗ DDL error [${schemaName}]`, { message: err.message });
       }
     }
 
@@ -281,13 +280,13 @@ async function migrateTenantSchemas() {
         }
       }
     } catch (err) {
-      console.error(`  ✗ Seed error [${schemaName}]:`, err.message);
+      logger.error(`  ✗ Seed error [${schemaName}]`, { message: err.message });
     }
 
     if (ddlErrors > 0) {
-      console.warn(`  ⚠ ${schemaName}: ${ddlErrors} DDL statement(s) failed (see errors above)`);
+      logger.warn(`  ⚠ ${schemaName}: ${ddlErrors} DDL statement(s) failed (see errors above)`);
     } else {
-      console.log(`  ✓ ${schemaName} up to date`);
+      logger.info(`  ✓ ${schemaName} up to date`);
     }
   }
 }
@@ -323,7 +322,7 @@ export async function syncDefaultRolePrivileges(slug) {
       );
     }
   }
-  console.log(`  ✓ Default role privileges synced for ${slug}`);
+  logger.info(`  ✓ Default role privileges synced for ${slug}`);
 }
 
 /**
@@ -348,7 +347,7 @@ async function migrateDefaultRolePrivileges() {
     try {
       await syncDefaultRolePrivileges(slug);
     } catch (err) {
-      console.error(`  ✗ Privilege sync error [${slug}]:`, err.message);
+      logger.error(`  ✗ Privilege sync error [${slug}]`, { message: err.message });
     }
   }
 }

--- a/backend/src/utils/redis.js
+++ b/backend/src/utils/redis.js
@@ -8,6 +8,7 @@
 // (up to 15 min) — acceptable for POC, dangerous unannounced in production.
 
 import { createClient } from 'redis';
+import { logger } from './logger.js';
 
 const USE_REDIS = process.env.USE_REDIS !== 'false' && !!process.env.REDIS_URL;
 const IS_PROD = process.env.NODE_ENV === 'production';
@@ -20,7 +21,7 @@ if (IS_PROD && process.env.USE_REDIS !== 'false' && !process.env.REDIS_URL) {
 }
 
 if (IS_PROD && process.env.USE_REDIS === 'false') {
-  console.warn(
+  logger.warn(
     '⚠ Redis is disabled in production (USE_REDIS=false). Session invalidation ' +
       'is OFF — revoked roles remain effective until the access token expires.',
   );
@@ -31,17 +32,17 @@ let client = null;
 // Wrapped in a function to avoid top-level await (compatibility with all Node versions)
 async function connectRedis() {
   if (!USE_REDIS) {
-    console.log('Redis disabled — running without session invalidation (POC mode).');
+    logger.info('Redis disabled — running without session invalidation (POC mode).');
     return;
   }
   client = createClient({ url: process.env.REDIS_URL });
-  client.on('error', (err) => console.error('Redis error:', err));
+  client.on('error', (err) => logger.error('Redis error', { message: err.message }));
   await client.connect();
-  console.log('Redis connected.');
+  logger.info('Redis connected.');
 }
 
 // Fire and forget on startup — errors are logged but do not crash the app
-connectRedis().catch((err) => console.error('Redis connection failed:', err));
+connectRedis().catch((err) => logger.error('Redis connection failed', { message: err.message }));
 
 export default client;
 

--- a/docs/FromBeacon/README.md
+++ b/docs/FromBeacon/README.md
@@ -1,0 +1,45 @@
+# `docs/FromBeacon/` — original Beacon reference material
+
+This directory holds selected artefacts from the original u3a **Beacon** system,
+kept **strictly as reference material** while building Beacon2. They are **not**
+part of the Beacon2 application, are not imported or executed by it, and are not
+covered by the Beacon2 `LICENSE`.
+
+## Copyright and status
+
+All material in this directory remains the property of its respective copyright
+holders. In particular, the original Beacon source files carry the notice:
+
+> *This script is Copyright John Franklin for all content as at 1st February
+> 2017. © John Franklin 2017. The Third Age Trust is permitted to use and modify
+> the script according to the terms of the Software Licence Agreement dated
+> 7th February 2017. This copyright notice must be retained.*
+
+That notice is **retained in full** in the files themselves and is reproduced
+here. The Beacon2 project:
+
+- makes **no claim of ownership** over any of this material;
+- makes **no claim of any right to redistribute** it;
+- includes it **only as reference** to inform a clean-room reproduction, not as
+  a basis for copying the original code.
+
+If any rights holder would prefer this material not be present in the
+repository, it will be removed on request (see `SECURITY.md` / repository
+contact).
+
+## Contents
+
+| File | What it is |
+|------|------------|
+| `privileges.php` | Original Beacon source — privilege/audit-type definitions (© John Franklin 2017). Reference for the privilege model only. |
+| `styles.css` | Original Beacon stylesheet (© John Franklin 2017). Reference for legacy look-and-feel only. |
+| `202603170140_St Ives Cambridge Demo24 u3abackup.xlsx` | A sample/demo Beacon backup export, used to understand the export format and data shapes. |
+| `Gift-Aid-Schedule-Excel.ods` | Example Gift Aid schedule spreadsheet, used as a format reference. |
+| `Cookie Control text.png` | Screenshot reference. |
+
+## Why keep it here
+
+Beacon2 is an independent reproduction; these files document *what the original
+behaved like* so the reproduction can be faithful without copying the original
+implementation. Treat everything here as read-only reference, never as code to
+lift into Beacon2.


### PR DESCRIPTION
Implements the first two chunks of `docs/ImprovementPlan-2026-06-14.md` (suggested order 1 → 2 → …). Each chunk re-verified its findings before changing anything.

## Chunk 1 — Licensing & legal hygiene
Owner decisions taken via prompt: **proprietary** licence, FromBeacon kept **reference-only** (no permission asserted), security reports via **GitHub private advisory**.

- **`LICENSE`** (new) — proprietary / all rights reserved (Copyright (c) 2026 Peter Cooper); notes Beacon2 is an unaffiliated clean-room reproduction.
- **`SECURITY.md`** (new) — disclosure via GitHub private security advisories, supported scope, do-not-include-real-PII note.
- **`docs/FromBeacon/README.md`** (new) — provenance for the original Beacon files (© John Franklin 2017): reference-only, original copyright retained, **no redistribution rights asserted**; removal offered on rights-holder request.
- `CONTRIBUTING.md` Licensing section now points at the new files; three repo-hygiene items in `KNOWN-ISSUES.md` marked `[FIXED]`.

## Chunk 2 — Logging baseline (standards + security)
- **`backend/src/utils/logger.js`** (new) — minimal, dependency-free leveled logger (`error`/`warn`/`info`/`debug`) gated by `LOG_LEVEL` (default `info` in prod, `debug` otherwise). One line per call (timestamp, level, message, optional JSON context), backed by the matching `console` method, safe on non-serialisable context.
- Replaced **every** `console.*` call in backend non-test code (60+ sites across `auth`, portal `auth`/`profile`/`renewals`/`helpers`, online-join email helpers, `migrate`/`seed`/`createTenant`, `redis`, `errorHandler`, `server`) with the logger.
- **Removed PII/secrets from logs** (chunk's security half): no recipient/member email addresses, names, the online-join payment link, or reset/verification tokens — only `err.message`, ids, counts and booleans remain.
- Added `logger.test.js` (routing, level gating, line format, circular-context safety) and a `CLAUDE-STANDARDS.md` rule: use `logger`, never `console.*`, never log PII.

## Verification
- Per-chunk grep: no `console.*` remains in `backend/src` except the logger's own dispatch.
- `npm run lint` clean, `npm run format:check` clean (backend).
- Backend tests: **599 passed** (46 files, +6 new). Backend-only code change, so the frontend suite is unaffected; Chunk 1 is docs-only.

https://claude.ai/code/session_014m7CBZxWZw9HArUTQqTzVb

---
_Generated by [Claude Code](https://claude.ai/code/session_014m7CBZxWZw9HArUTQqTzVb)_