### PR TITLE
Improvement plan Chunks 3 & 6: service-layer extraction + security test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
     log PII/secrets in app logs.
 
 ### Changed
+- **Service-layer extraction for finance transactions (2026-06-14 review,
+  Chunk 3)** — introduced the marquee maintainability pattern on one route
+  end-to-end. New `backend/src/services/transactionService.js` now holds all
+  transaction business logic and data access (`list`/`get`/`create`/
+  `bulkSetPending`/`update`/`delete`/`refund`), and
+  `routes/finance/transactions.js` (747 → 179 lines) is a thin controller that
+  validates input with Zod at the route boundary and delegates to the service,
+  mirroring `services/authService.js`. Behaviour-preserving: the existing
+  finance route tests pass unchanged. The two larger offenders
+  (`routes/backup/restore.js`, `routes/members/crud.js`) are recorded in
+  `KNOWN-ISSUES.md` for the same treatment in follow-up sessions.
 - `CONTRIBUTING.md` Licensing section now points at the new `LICENSE`,
   `SECURITY.md`, and `docs/FromBeacon/README.md` instead of saying a licence is
   undecided.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,24 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
   - A `CLAUDE-STANDARDS.md` rule: use `logger`, never `console.*`, and never
     log PII/secrets in app logs.
 
+### Added
+- **Security-critical test coverage (2026-06-14 review, Chunk 3 follow-on,
+  Chunk 6)** — re-verified the three paths the plan flagged as untested and
+  found most were *already* covered (account-lockout in `authService.test.js`,
+  refresh-token tenant-slug mismatch in `authService.test.js`, tenant-slug
+  guards in `db.test.js`, and the role-escalation guard via `POST/DELETE
+  /users/:id/roles` in `users.test.js`). Added the two genuinely-missing
+  branches:
+  - `POST /users` **escalation guard** — creating a user with a `roleIds` entry
+    whose role grants a privilege the actor does not hold is rejected (403) and
+    no `user_roles` row is written. This third `assertActorHoldsRolePrivileges`
+    call site was previously untested.
+  - `loginUser` **failure-counter reset** — a successful login clears
+    `failed_login_count`/`locked_until`, so a legitimate user is not
+    progressively locked out by past failures.
+  Both new tests were confirmed to fail against a deliberately broken guard
+  (they bite).
+
 ### Changed
 - **Service-layer extraction for finance transactions (2026-06-14 review,
   Chunk 3)** — introduced the marquee maintainability pattern on one route

--- a/CLAUDE-STANDARDS.md
+++ b/CLAUDE-STANDARDS.md
@@ -282,6 +282,17 @@ Every item below applies to every new feature — no exceptions.
   distinct from `logAudit` (durable audit trail) — `logger` is for operational
   app logs.
 
+- [ ] **Service layer for non-trivial logic** — keep routes thin. When a handler
+  carries real business logic (multi-step DB work, cross-entity rules, computed
+  results), put that logic in a `backend/src/services/<thing>Service.js` module
+  and have the route call it. The split: **validation (Zod) and HTTP concerns
+  (status codes, `req`/`res`) stay at the route boundary; tenant data access
+  (`tenantQuery`/`withTenant`), business rules and `AppError` throws live in the
+  service.** Services take `tenantSlug` (and an explicit `actor` `{ userId, name }`
+  when they audit) rather than touching `req`. Mirror `services/authService.js`
+  and `services/transactionService.js`. Small CRUD handlers can stay inline — the
+  goal is no large logic blocks in route files, not ceremony for one-liners.
+
 - [ ] **Response shape and status codes** — adopt one convention consistently:
 
   | Outcome | Status | Body |

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -158,6 +158,15 @@ These are catalogued and re-verified in `docs/history/ImprovementPlan.md` (Chunk
     matched the in-memory sys-token model (`frontend/src/lib/api/system.js`).
     Reworded to point at the in-memory token. Resolved in the 2026-06-14 review
     (ImprovementPlan Chunk 8).
+27. `[OPEN]` **`POST /users` runs the role-escalation guard after inserting the
+    user row** (`routes/users.js` ~141–158). The user `INSERT` happens before
+    the per-`roleId` `assertActorHoldsRolePrivileges` loop, and each
+    `tenantQuery` is its own transaction, so a blocked escalation attempt leaves
+    an orphaned user account (no role is assigned, so **no privilege escalation
+    occurs** — this is a data-hygiene wart, not a security hole). Found while
+    adding the Chunk 6 escalation test. Fix: validate every requested role
+    against the actor's privileges *before* the `INSERT`, or wrap the create +
+    role assignment in a single `withTenant` transaction. Low priority.
 
 ---
 

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -240,6 +240,21 @@ These are catalogued and re-verified in `docs/history/ImprovementPlan.md` (Chunk
 
 ---
 
+## Backend service-layer extraction (ImprovementPlan-2026-06-14 Chunk 3)
+
+1. `[OPEN]` **Largest route files still carry their business logic.** Chunk 3
+   established the service-layer pattern end-to-end on one route:
+   `routes/finance/transactions.js` (747 → 179) now delegates all logic and data
+   access to the new `services/transactionService.js`, with Zod validation kept
+   at the route boundary (mirrors `services/authService.js`). The two larger
+   offenders remain to be extracted the same way in follow-up sessions:
+   `routes/backup/restore.js` (~1,512) and `routes/members/crud.js` (~1,037).
+   Each is a behaviour-preserving extraction — the route's existing tests must
+   pass unchanged. `routes/public/join.js` (~768) and the rest of
+   `routes/finance/*` are lower priority.
+
+---
+
 ## UI Terminology
 
 1. `[OPEN]` **Group/Team Cash — "Central Ledger" vs "Finance Ledger" wording** — The

--- a/backend/src/__tests__/authService.test.js
+++ b/backend/src/__tests__/authService.test.js
@@ -136,6 +136,27 @@ describe('loginUser — failed-login lockout (H2)', () => {
     );
   });
 
+  it('resets the failure counter and lockout on a successful login', async () => {
+    // A user mid-way to a lockout who now logs in with the correct password.
+    tenantQuery.mockResolvedValueOnce([userRow({ failed_login_count: 3 })]); // user lookup
+    verifyPassword.mockResolvedValueOnce(true);
+    tenantQuery.mockResolvedValue([]); // reset UPDATE, privileges, refresh insert, last_login
+
+    const result = await loginUser(TENANT, 'alice', 'correct');
+    expect(result.accessToken).toBeTruthy();
+
+    // The counter and lockout window are cleared so a legitimate user is not
+    // progressively locked out by past failures.
+    const resetCall = tenantQuery.mock.calls.find((c) =>
+      /failed_login_count = 0, locked_until = NULL/.test(c[1]),
+    );
+    expect(resetCall).toBeTruthy();
+    expect(resetCall[2]).toEqual(['u1']);
+
+    // A successful login is not an audit "failed/locked" event.
+    expect(logAudit).not.toHaveBeenCalled();
+  });
+
   it('does not touch the counter when the user does not exist', async () => {
     tenantQuery.mockResolvedValueOnce([]); // username lookup
     tenantQuery.mockResolvedValueOnce([]); // email-fallback lookup

--- a/backend/src/__tests__/users.test.js
+++ b/backend/src/__tests__/users.test.js
@@ -138,6 +138,33 @@ describe('POST /users', () => {
 
     expect(res.status).toBe(422);
   });
+
+  it('blocks creating a user with a role granting a privilege the actor lacks', async () => {
+    // member lookup → exists; not-already-a-user → none; INSERT user → created
+    tenantQuery
+      .mockResolvedValueOnce([
+        { id: 'm1', forenames: 'Bob', surname: 'Smith', email: 'bob@example.com' },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'u2', name: 'Bob Smith' }])
+      // escalation guard: the requested role grants a privilege the actor lacks
+      .mockResolvedValueOnce([{ code: 'finance_accounts', action: 'delete' }]);
+
+    // Actor can create users but does NOT hold finance_accounts:delete
+    const limitedAuth = makeAuthHeader({ privileges: ['user_record:create'] });
+
+    const res = await request(app)
+      .post('/users')
+      .set('Authorization', limitedAuth)
+      .send({ memberId: 'm1', username: 'bsmith', roleIds: ['role-admin'] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/finance_accounts:delete/);
+
+    // The role must NOT have been assigned — no INSERT into user_roles.
+    const assignedRole = tenantQuery.mock.calls.some((c) => /INSERT INTO user_roles/.test(c[1]));
+    expect(assignedRole).toBe(false);
+  });
 });
 
 // ── PATCH /users/:id ──────────────────────────────────────────────────────

--- a/backend/src/routes/finance/transactions.js
+++ b/backend/src/routes/finance/transactions.js
@@ -1,13 +1,20 @@
 // beacon2/backend/src/routes/finance/transactions.js
-// Transaction list, single, create, bulk-pending, update, delete, and refund.
+// Thin controllers for transaction list, single, create, bulk-pending, update,
+// delete, and refund. Input is validated here (Zod) at the route boundary; the
+// business logic and data access live in services/transactionService.js.
 
 import { Router } from 'express';
 import { z } from 'zod';
 import { requirePrivilege } from '../../middleware/requirePrivilege.js';
-import { tenantQuery } from '../../utils/db.js';
-import { AppError } from '../../middleware/errorHandler.js';
-import { logAudit } from '../../utils/audit.js';
-import { computeYearBounds } from './helpers.js';
+import {
+  listTransactions,
+  getTransaction,
+  createTransaction,
+  bulkSetPending,
+  updateTransaction,
+  deleteTransaction,
+  refundTransaction,
+} from '../../services/transactionService.js';
 
 const router = Router();
 
@@ -16,169 +23,8 @@ const router = Router();
 // GET /finance/transactions?accountId=&categoryId=&groupId=&memberId=&eventId=&year=
 router.get('/transactions', requirePrivilege('finance_ledger', 'view'), async (req, res, next) => {
   try {
-    const { accountId, categoryId, groupId, memberId, eventId, year } = req.query;
-    const yearNum = year ? parseInt(year, 10) : new Date().getFullYear();
-    const yearStart = `${yearNum}-01-01`;
-    const yearEnd = `${yearNum}-12-31`;
-
-    let sql, params;
-
-    // Common SELECT columns shared by all views
-    const commonCols = `
-               t.id, t.transaction_number, t.account_id, t.date, t.type,
-               t.from_to, t.amount::float, t.payment_method, t.payment_ref,
-               t.detail, t.remarks, t.cleared_at, t.pending,
-               t.member_id_1, t.member_id_2, t.group_id, t.event_id,
-               t.batch_id,
-               t.refund_of_id, t.refunded_by_id,
-               ref_orig.transaction_number AS refund_of_txn_number,
-               ref_by.transaction_number AS refunded_by_txn_number,
-               m1.forenames || ' ' || m1.surname AS member_1_name,
-               m1.membership_number AS member_1_no,
-               m2.forenames || ' ' || m2.surname AS member_2_name,
-               m2.membership_number AS member_2_no,
-               g.name AS group_name, g.short_name AS group_short_name, g.type AS group_type,
-               ge_ev.event_date AS event_date, ge_ev.topic AS event_topic,
-               COALESCE(ge_g.name, ge_et.name) AS event_label,
-               fa.name AS account_name,
-               cb.batch_ref AS batch_no,
-               cb.description AS batch_description`;
-    const commonJoins = `
-        LEFT JOIN members m1 ON m1.id = t.member_id_1
-        LEFT JOIN members m2 ON m2.id = t.member_id_2
-        LEFT JOIN groups g   ON g.id  = t.group_id
-        LEFT JOIN group_events ge_ev ON ge_ev.id = t.event_id
-        LEFT JOIN groups ge_g ON ge_g.id = ge_ev.group_id
-        LEFT JOIN event_types ge_et ON ge_et.id = ge_ev.event_type_id
-        LEFT JOIN finance_accounts fa ON fa.id = t.account_id
-        LEFT JOIN credit_batches cb ON cb.id = t.batch_id
-        LEFT JOIN transactions ref_orig ON ref_orig.id = t.refund_of_id
-        LEFT JOIN transactions ref_by   ON ref_by.id   = t.refunded_by_id
-        LEFT JOIN transaction_categories tc ON tc.transaction_id = t.id
-        LEFT JOIN finance_categories fc ON fc.id = tc.category_id`;
-    const categoriesAgg = `
-               COALESCE(
-                 json_agg(json_build_object('category_id', tc.category_id, 'name', fc.name, 'amount', tc.amount::float))
-                   FILTER (WHERE tc.id IS NOT NULL), '[]'
-               ) AS categories`;
-    const commonGroupBy = `t.id, m1.forenames, m1.surname, m1.membership_number,
-                 m2.forenames, m2.surname, m2.membership_number,
-                 g.name, g.short_name, g.type,
-                 ge_ev.event_date, ge_ev.topic, ge_g.name, ge_et.name,
-                 fa.name, cb.batch_ref, cb.description,
-                 ref_orig.transaction_number, ref_by.transaction_number`;
-
-    if (memberId) {
-      sql = `
-        SELECT ${commonCols},
-               ${categoriesAgg}
-        FROM transactions t
-        ${commonJoins}
-        WHERE (t.member_id_1 = $1 OR t.member_id_2 = $1)
-        GROUP BY ${commonGroupBy}
-        ORDER BY t.date, t.transaction_number`;
-      params = [memberId];
-    } else if (accountId) {
-      sql = `
-        SELECT ${commonCols},
-               ${categoriesAgg}
-        FROM transactions t
-        ${commonJoins}
-        WHERE t.account_id = $1 AND t.date BETWEEN $2::date AND $3::date
-        GROUP BY ${commonGroupBy}
-        ORDER BY t.date, t.transaction_number`;
-      params = [accountId, yearStart, yearEnd];
-    } else if (categoryId) {
-      sql = `
-        SELECT ${commonCols},
-               tc_this.amount::float AS category_amount,
-               ${categoriesAgg}
-        FROM transactions t
-        JOIN transaction_categories tc_this ON tc_this.transaction_id = t.id AND tc_this.category_id = $1
-        ${commonJoins}
-        WHERE t.date BETWEEN $2::date AND $3::date
-        GROUP BY ${commonGroupBy}, tc_this.amount
-        ORDER BY t.date, t.transaction_number`;
-      params = [categoryId, yearStart, yearEnd];
-    } else if (groupId) {
-      sql = `
-        SELECT ${commonCols},
-               ${categoriesAgg}
-        FROM transactions t
-        ${commonJoins}
-        WHERE ($1 = 'all' OR t.group_id = $1) AND t.date BETWEEN $2::date AND $3::date
-        GROUP BY ${commonGroupBy}
-        ORDER BY t.date, t.transaction_number`;
-      params = [groupId, yearStart, yearEnd];
-    } else if (eventId) {
-      sql = `
-        SELECT ${commonCols},
-               ${categoriesAgg}
-        FROM transactions t
-        ${commonJoins}
-        WHERE t.event_id = $1
-        GROUP BY ${commonGroupBy}
-        ORDER BY t.date, t.transaction_number`;
-      params = [eventId];
-    } else {
-      return res.json([]);
-    }
-
-    const rows = await tenantQuery(req.user.tenantSlug, sql, params);
-
-    // For account view, also compute the opening balance (BF + net of prior-year transactions)
-    if (accountId) {
-      const [acc] = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT balance_brought_forward::float FROM finance_accounts WHERE id = $1`,
-        [accountId],
-      );
-      const bf = acc?.balance_brought_forward ?? 0;
-      const [priorNet] = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT COALESCE(SUM(CASE WHEN type='in' THEN amount ELSE -amount END), 0)::float AS net
-         FROM transactions WHERE account_id = $1 AND date < $2::date AND pending = false`,
-        [accountId, yearStart],
-      );
-      const openingBalance = bf + (priorNet?.net ?? 0);
-      return res.json({ transactions: rows, openingBalance });
-    }
-
-    // For group view, compute per-group opening balances if group_bf_enabled
-    if (groupId) {
-      const [setting] = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT group_bf_enabled FROM tenant_settings WHERE id = 'singleton'`,
-      );
-      if (setting?.group_bf_enabled) {
-        let bfSql, bfParams;
-        if (groupId === 'all') {
-          bfSql = `
-            SELECT t.group_id, g.name AS group_name, g.short_name AS group_short_name, g.type AS group_type,
-                   COALESCE(SUM(CASE WHEN t.type='in' THEN t.amount ELSE -t.amount END), 0)::float AS balance
-            FROM transactions t
-            LEFT JOIN groups g ON g.id = t.group_id
-            WHERE t.group_id IS NOT NULL AND t.date < $1::date AND t.pending = false
-            GROUP BY t.group_id, g.name, g.short_name, g.type
-            HAVING SUM(CASE WHEN t.type='in' THEN t.amount ELSE -t.amount END) <> 0
-            ORDER BY g.name`;
-          bfParams = [yearStart];
-        } else {
-          bfSql = `
-            SELECT t.group_id, g.name AS group_name, g.short_name AS group_short_name, g.type AS group_type,
-                   COALESCE(SUM(CASE WHEN t.type='in' THEN t.amount ELSE -t.amount END), 0)::float AS balance
-            FROM transactions t
-            LEFT JOIN groups g ON g.id = t.group_id
-            WHERE t.group_id = $1 AND t.date < $2::date AND t.pending = false
-            GROUP BY t.group_id, g.name, g.short_name, g.type`;
-          bfParams = [groupId, yearStart];
-        }
-        const groupBfRows = await tenantQuery(req.user.tenantSlug, bfSql, bfParams);
-        return res.json({ transactions: rows, groupBf: groupBfRows });
-      }
-    }
-
-    res.json(rows);
+    const result = await listTransactions(req.user.tenantSlug, req.query);
+    res.json(result);
   } catch (err) {
     next(err);
   }
@@ -190,51 +36,7 @@ router.get(
   requirePrivilege('finance_transactions', 'view'),
   async (req, res, next) => {
     try {
-      const [txn] = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT t.id, t.transaction_number, t.account_id, t.date, t.type,
-              t.from_to, t.amount::float, t.payment_method, t.payment_ref,
-              t.detail, t.remarks, t.cleared_at, t.pending, t.transfer_id,
-              t.member_id_1, t.member_id_2, t.group_id, t.event_id,
-              t.gift_aid_amount::float AS gift_aid_amount, t.gift_aid_claimed_at,
-              t.gift_aid_amount_2::float AS gift_aid_amount_2, t.gift_aid_claimed_at_2,
-              t.batch_id, cb.batch_ref,
-              t.refund_of_id, t.refunded_by_id,
-              ref_orig.transaction_number AS refund_of_txn_number,
-              ref_by.transaction_number AS refunded_by_txn_number,
-              ref_by.amount::float AS refunded_amount,
-              m1.forenames || ' ' || m1.surname AS member_1_name,
-              m2.forenames || ' ' || m2.surname AS member_2_name,
-              g.name AS group_name, g.short_name AS group_short_name, g.type AS group_type,
-              ge_ev.event_date AS event_date, ge_ev.topic AS event_topic,
-              COALESCE(ge_g.name, ge_et.name) AS event_label,
-              fa.name AS account_name,
-              fa.enable_refunds AS account_enable_refunds,
-              COALESCE(
-                json_agg(json_build_object('category_id', tc.category_id, 'name', fc.name, 'amount', tc.amount::float))
-                  FILTER (WHERE tc.id IS NOT NULL), '[]'
-              ) AS categories
-       FROM transactions t
-       LEFT JOIN members m1 ON m1.id = t.member_id_1
-       LEFT JOIN members m2 ON m2.id = t.member_id_2
-       LEFT JOIN groups g   ON g.id  = t.group_id
-       LEFT JOIN group_events ge_ev ON ge_ev.id = t.event_id
-       LEFT JOIN groups ge_g ON ge_g.id = ge_ev.group_id
-       LEFT JOIN event_types ge_et ON ge_et.id = ge_ev.event_type_id
-       LEFT JOIN finance_accounts fa ON fa.id = t.account_id
-       LEFT JOIN credit_batches cb ON cb.id = t.batch_id
-       LEFT JOIN transactions ref_orig ON ref_orig.id = t.refund_of_id
-       LEFT JOIN transactions ref_by   ON ref_by.id   = t.refunded_by_id
-       LEFT JOIN transaction_categories tc ON tc.transaction_id = t.id
-       LEFT JOIN finance_categories fc ON fc.id = tc.category_id
-       WHERE t.id = $1
-       GROUP BY t.id, m1.forenames, m1.surname, m2.forenames, m2.surname, g.name, g.short_name, g.type,
-                ge_ev.event_date, ge_ev.topic, ge_g.name, ge_et.name,
-                fa.name, cb.batch_ref,
-                ref_orig.transaction_number, ref_by.transaction_number, ref_by.amount, fa.enable_refunds`,
-        [req.params.id],
-      );
-      if (!txn) throw AppError('Transaction not found.', 404);
+      const txn = await getTransaction(req.user.tenantSlug, req.params.id);
       res.json(txn);
     } catch (err) {
       next(err);
@@ -274,68 +76,8 @@ router.post(
   async (req, res, next) => {
     try {
       const data = createTxnSchema.parse(req.body);
-
-      // Validate category amounts sum to transaction amount
-      const catTotal = data.categories.reduce((s, c) => s + c.amount, 0);
-      if (Math.abs(catTotal - data.amount) > 0.001) {
-        throw AppError(
-          `Category amounts (${catTotal.toFixed(2)}) must equal transaction amount (${data.amount.toFixed(2)}).`,
-          400,
-        );
-      }
-
-      // Determine pending status based on account config
-      let pending = data.pending ?? false;
-      const [acct] = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT pending_config, pending_types FROM finance_accounts WHERE id = $1`,
-        [data.account_id],
-      );
-      if (acct) {
-        if (acct.pending_config === 'disabled') {
-          pending = false;
-        } else if (acct.pending_config === 'by_type') {
-          const types = acct.pending_types ?? [];
-          pending = types.includes(data.payment_method ?? '');
-        }
-        // 'optional' — use whatever the client sent
-      }
-
-      const [txn] = await tenantQuery(
-        req.user.tenantSlug,
-        `INSERT INTO transactions
-         (account_id, date, type, from_to, amount, payment_method, payment_ref, detail, remarks, member_id_1, member_id_2, group_id, event_id, pending, gift_aid_amount, gift_aid_amount_2)
-       VALUES ($1, $2::date, $3, $4, $5::numeric, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::numeric, $16::numeric)
-       RETURNING id, transaction_number`,
-        [
-          data.account_id,
-          data.date,
-          data.type,
-          data.from_to ?? null,
-          data.amount,
-          data.payment_method ?? null,
-          data.payment_ref ?? null,
-          data.detail ?? null,
-          data.remarks ?? null,
-          data.member_id_1 ?? null,
-          data.member_id_2 ?? null,
-          data.group_id ?? null,
-          data.event_id ?? null,
-          pending,
-          data.gift_aid_amount ?? null,
-          data.gift_aid_amount_2 ?? null,
-        ],
-      );
-
-      for (const cat of data.categories) {
-        await tenantQuery(
-          req.user.tenantSlug,
-          `INSERT INTO transaction_categories (transaction_id, category_id, amount) VALUES ($1, $2, $3::numeric)`,
-          [txn.id, cat.category_id, cat.amount],
-        );
-      }
-
-      res.status(201).json({ id: txn.id, transaction_number: txn.transaction_number });
+      const result = await createTransaction(req.user.tenantSlug, data);
+      res.status(201).json(result);
     } catch (err) {
       next(err);
     }
@@ -356,29 +98,8 @@ router.patch(
   async (req, res, next) => {
     try {
       const { ids, pending } = bulkPendingSchema.parse(req.body);
-
-      // Validate: only non-cleared, non-transfer, non-batched transactions
-      const rows = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT id, cleared_at, transfer_id, batch_id FROM transactions WHERE id = ANY($1::text[])`,
-        [ids],
-      );
-
-      const errors = [];
-      for (const r of rows) {
-        if (r.cleared_at) errors.push(`Transaction ${r.id} is cleared.`);
-        if (r.transfer_id) errors.push(`Transaction ${r.id} is a transfer.`);
-        if (r.batch_id) errors.push(`Transaction ${r.id} is in a credit batch.`);
-      }
-      if (errors.length > 0) throw AppError(errors.join(' '), 400);
-
-      await tenantQuery(
-        req.user.tenantSlug,
-        `UPDATE transactions SET pending = $1, updated_at = now() WHERE id = ANY($2::text[])`,
-        [pending, ids],
-      );
-
-      res.json({ message: `${ids.length} transaction(s) updated.`, count: ids.length });
+      const result = await bulkSetPending(req.user.tenantSlug, ids, pending);
+      res.json(result);
     } catch (err) {
       next(err);
     }
@@ -397,146 +118,9 @@ router.patch(
   requirePrivilege('finance_transactions', 'change'),
   async (req, res, next) => {
     try {
-      const [current] = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT id, amount::float AS amount, cleared_at, transfer_id, pending, refund_of_id, refunded_by_id FROM transactions WHERE id = $1`,
-        [req.params.id],
-      );
-      if (!current) throw AppError('Transaction not found.', 404);
-      if (current.transfer_id)
-        throw AppError(
-          'This transaction is part of a transfer. Use the Transfer Money page to edit it.',
-          400,
-        );
-      if (current.cleared_at) throw AppError('Cleared transactions cannot be changed.', 400);
-      if (current.refunded_by_id)
-        throw AppError(
-          'This transaction has been refunded and cannot be changed. Delete the refund first.',
-          400,
-        );
-      if (current.refund_of_id)
-        throw AppError(
-          'Refund transactions cannot be edited. Delete and re-create the refund instead.',
-          400,
-        );
-
       const data = updateTxnSchema.parse(req.body);
-
-      // Transfers cannot be marked as pending
-      if (data.pending === true && current.transfer_id) {
-        throw AppError('Transfers cannot be marked as pending.', 400);
-      }
-
-      // If categories are being updated, validate sum
-      if (data.categories) {
-        const newAmount = data.amount ?? current.amount;
-        const catTotal = data.categories.reduce((s, c) => s + c.amount, 0);
-        if (Math.abs(catTotal - newAmount) > 0.001) {
-          throw AppError(
-            `Category amounts (${catTotal.toFixed(2)}) must equal transaction amount (${newAmount.toFixed(2)}).`,
-            400,
-          );
-        }
-      }
-
-      const fields = [];
-      const values = [];
-      let i = 1;
-      if (data.account_id !== undefined) {
-        fields.push(`account_id = $${i++}`);
-        values.push(data.account_id);
-      }
-      if (data.date !== undefined) {
-        fields.push(`date = $${i++}::date`);
-        values.push(data.date);
-      }
-      if (data.type !== undefined) {
-        fields.push(`type = $${i++}`);
-        values.push(data.type);
-      }
-      if (data.from_to !== undefined) {
-        fields.push(`from_to = $${i++}`);
-        values.push(data.from_to);
-      }
-      if (data.amount !== undefined) {
-        fields.push(`amount = $${i++}::numeric`);
-        values.push(data.amount);
-      }
-      if (data.payment_method !== undefined) {
-        fields.push(`payment_method = $${i++}`);
-        values.push(data.payment_method);
-      }
-      if (data.payment_ref !== undefined) {
-        fields.push(`payment_ref = $${i++}`);
-        values.push(data.payment_ref);
-      }
-      if (data.detail !== undefined) {
-        fields.push(`detail = $${i++}`);
-        values.push(data.detail);
-      }
-      if (data.remarks !== undefined) {
-        fields.push(`remarks = $${i++}`);
-        values.push(data.remarks);
-      }
-      if (data.member_id_1 !== undefined) {
-        fields.push(`member_id_1 = $${i++}`);
-        values.push(data.member_id_1);
-      }
-      if (data.member_id_2 !== undefined) {
-        fields.push(`member_id_2 = $${i++}`);
-        values.push(data.member_id_2);
-      }
-      if (data.group_id !== undefined) {
-        fields.push(`group_id = $${i++}`);
-        values.push(data.group_id);
-      }
-      if (data.event_id !== undefined) {
-        fields.push(`event_id = $${i++}`);
-        values.push(data.event_id);
-      }
-      if (data.batch_id !== undefined) {
-        fields.push(`batch_id = $${i++}`);
-        values.push(data.batch_id);
-      }
-      if (data.pending !== undefined) {
-        fields.push(`pending = $${i++}`);
-        values.push(data.pending);
-      }
-      if (data.gift_aid_amount !== undefined) {
-        fields.push(`gift_aid_amount = $${i++}::numeric`);
-        values.push(data.gift_aid_amount);
-      }
-      if (data.gift_aid_amount_2 !== undefined) {
-        fields.push(`gift_aid_amount_2 = $${i++}::numeric`);
-        values.push(data.gift_aid_amount_2);
-      }
-
-      if (fields.length > 0) {
-        fields.push(`updated_at = now()`);
-        values.push(req.params.id);
-        await tenantQuery(
-          req.user.tenantSlug,
-          `UPDATE transactions SET ${fields.join(', ')} WHERE id = $${i}`,
-          values,
-        );
-      }
-
-      if (data.categories) {
-        await tenantQuery(
-          req.user.tenantSlug,
-          `DELETE FROM transaction_categories WHERE transaction_id = $1`,
-          [req.params.id],
-        );
-        for (const cat of data.categories) {
-          await tenantQuery(
-            req.user.tenantSlug,
-            `INSERT INTO transaction_categories (transaction_id, category_id, amount) VALUES ($1, $2, $3::numeric)`,
-            [req.params.id, cat.category_id, cat.amount],
-          );
-        }
-      }
-
-      res.json({ message: 'Transaction updated.' });
+      const result = await updateTransaction(req.user.tenantSlug, req.params.id, data);
+      res.json(result);
     } catch (err) {
       next(err);
     }
@@ -549,37 +133,8 @@ router.delete(
   requirePrivilege('finance_transactions', 'delete'),
   async (req, res, next) => {
     try {
-      const [current] = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT cleared_at, transfer_id, refund_of_id, refunded_by_id FROM transactions WHERE id = $1`,
-        [req.params.id],
-      );
-      if (!current) throw AppError('Transaction not found.', 404);
-      if (current.transfer_id)
-        throw AppError(
-          'This transaction is part of a transfer. Use the Transfer Money page to delete it.',
-          400,
-        );
-      if (current.cleared_at) throw AppError('Cleared transactions cannot be deleted.', 400);
-      if (current.refunded_by_id)
-        throw AppError(
-          'This transaction has been refunded. Delete the refund transaction first.',
-          400,
-        );
-
-      // If this is a refund transaction, clear the refunded_by_id on the original
-      if (current.refund_of_id) {
-        await tenantQuery(
-          req.user.tenantSlug,
-          `UPDATE transactions SET refunded_by_id = NULL, updated_at = now() WHERE id = $1`,
-          [current.refund_of_id],
-        );
-      }
-
-      await tenantQuery(req.user.tenantSlug, `DELETE FROM transactions WHERE id = $1`, [
-        req.params.id,
-      ]);
-      res.json({ message: 'Transaction deleted.' });
+      const result = await deleteTransaction(req.user.tenantSlug, req.params.id);
+      res.json(result);
     } catch (err) {
       next(err);
     }
@@ -610,134 +165,11 @@ router.post(
   async (req, res, next) => {
     try {
       const data = refundSchema.parse(req.body);
-
-      // Load the original transaction
-      const [orig] = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT t.id, t.transaction_number, t.account_id, t.date, t.type, t.from_to,
-              t.amount::float, t.cleared_at, t.transfer_id, t.refund_of_id, t.refunded_by_id,
-              t.member_id_1, t.member_id_2, t.group_id,
-              t.gift_aid_claimed_at,
-              fa.enable_refunds
-       FROM transactions t
-       JOIN finance_accounts fa ON fa.id = t.account_id
-       WHERE t.id = $1`,
-        [req.params.id],
-      );
-      if (!orig) throw AppError('Transaction not found.', 404);
-      if (!orig.enable_refunds) throw AppError('Refunds are not enabled for this account.', 400);
-      if (orig.cleared_at)
-        throw AppError('Cleared transactions cannot be refunded. Un-clear it first.', 400);
-      if (orig.transfer_id) throw AppError('Transfer transactions cannot be refunded.', 400);
-      if (orig.refund_of_id) throw AppError('A refund transaction cannot itself be refunded.', 400);
-      if (orig.refunded_by_id) throw AppError('This transaction has already been refunded.', 400);
-      if (orig.gift_aid_claimed_at)
-        throw AppError('Transactions with claimed Gift Aid cannot be refunded.', 400);
-
-      // Validate refund date: must be after original date
-      if (data.date <= orig.date) {
-        throw AppError('Refund date must be after the original transaction date.', 400);
-      }
-
-      // Validate refund date is in the same financial year as the original
-      const [settings] = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT year_start_month, year_start_day FROM tenant_settings WHERE id = 'singleton'`,
-      );
-      const sm = settings.year_start_month;
-      const sd = settings.year_start_day;
-
-      // Find which financial year the original transaction belongs to
-      const origDate = new Date(orig.date + 'T00:00:00Z');
-      let origYear = origDate.getUTCFullYear();
-      const fyStartOrig = new Date(Date.UTC(origYear, sm - 1, sd));
-      if (origDate < fyStartOrig) origYear--;
-      const { yearStart: fyStart, yearEnd: fyEnd } = computeYearBounds(origYear, sm, sd);
-
-      if (data.date < fyStart || data.date > fyEnd) {
-        throw AppError(
-          'Refund date must be in the same financial year as the original transaction.',
-          400,
-        );
-      }
-
-      // Validate refund category amounts
-      const refundTotal = data.categories.reduce((s, c) => s + c.amount, 0);
-      if (refundTotal <= 0) throw AppError('Refund amount must be positive.', 400);
-      if (refundTotal > orig.amount)
-        throw AppError('Refund total cannot exceed the original transaction amount.', 400);
-
-      // Load original category amounts to validate per-category limits
-      const origCats = await tenantQuery(
-        req.user.tenantSlug,
-        `SELECT category_id, amount::float FROM transaction_categories WHERE transaction_id = $1`,
-        [orig.id],
-      );
-      const origCatMap = {};
-      for (const oc of origCats) origCatMap[oc.category_id] = oc.amount;
-
-      for (const rc of data.categories) {
-        if (rc.amount === 0) continue;
-        const origAmt = origCatMap[rc.category_id];
-        if (origAmt === undefined)
-          throw AppError(`Category not found on original transaction.`, 400);
-        if (rc.amount > origAmt + 0.001)
-          throw AppError(`Refund for category exceeds original amount.`, 400);
-      }
-
-      // Create the refund transaction (opposite type)
-      const refundType = orig.type === 'in' ? 'out' : 'in';
-      const [refundTxn] = await tenantQuery(
-        req.user.tenantSlug,
-        `INSERT INTO transactions
-         (account_id, date, type, from_to, amount, payment_method, payment_ref, detail, remarks,
-          member_id_1, member_id_2, group_id, pending, refund_of_id)
-       VALUES ($1, $2::date, $3, $4, $5::numeric, $6, $7, $8, $9, $10, $11, $12, false, $13)
-       RETURNING id, transaction_number`,
-        [
-          orig.account_id,
-          data.date,
-          refundType,
-          orig.from_to,
-          refundTotal,
-          data.payment_method ?? null,
-          data.payment_ref ?? null,
-          data.detail ?? null,
-          data.remarks ?? null,
-          orig.member_id_1,
-          orig.member_id_2,
-          orig.group_id,
-          orig.id,
-        ],
-      );
-
-      // Insert refund category splits (only non-zero amounts)
-      for (const cat of data.categories) {
-        if (cat.amount === 0) continue;
-        await tenantQuery(
-          req.user.tenantSlug,
-          `INSERT INTO transaction_categories (transaction_id, category_id, amount) VALUES ($1, $2, $3::numeric)`,
-          [refundTxn.id, cat.category_id, cat.amount],
-        );
-      }
-
-      // Link original to refund
-      await tenantQuery(
-        req.user.tenantSlug,
-        `UPDATE transactions SET refunded_by_id = $1, updated_at = now() WHERE id = $2`,
-        [refundTxn.id, orig.id],
-      );
-
-      logAudit(req.user.tenantSlug, {
+      const result = await refundTransaction(req.user.tenantSlug, req.params.id, data, {
         userId: req.user.userId,
-        userName: req.user.name,
-        action: 'create',
-        entityType: 'transaction',
-        entityId: refundTxn.id,
-        entityName: `Refund #${refundTxn.transaction_number} of #${orig.transaction_number}`,
+        name: req.user.name,
       });
-
-      res.status(201).json({ id: refundTxn.id, transaction_number: refundTxn.transaction_number });
+      res.status(201).json(result);
     } catch (err) {
       next(err);
     }

--- a/backend/src/services/transactionService.js
+++ b/backend/src/services/transactionService.js
@@ -1,0 +1,640 @@
+// beacon2/backend/src/services/transactionService.js
+// Business logic for finance transactions: list, single, create, bulk-pending,
+// update, delete, and refund. Routes (routes/finance/transactions.js) are thin
+// controllers that validate input (Zod) and delegate to these functions.
+//
+// Each function keeps tenant data access inside the service via tenantQuery and
+// throws AppError for business-rule violations, mirroring services/authService.js.
+
+import { tenantQuery } from '../utils/db.js';
+import { AppError } from '../middleware/errorHandler.js';
+import { logAudit } from '../utils/audit.js';
+import { computeYearBounds } from '../routes/finance/helpers.js';
+
+// ─── List ───────────────────────────────────────────────────────────────────
+
+/**
+ * List transactions filtered by one of accountId / categoryId / groupId /
+ * memberId / eventId (mutually exclusive, checked in that precedence order).
+ * Returns the response body shape expected by the client:
+ *  - `[]` when no filter is supplied;
+ *  - `{ transactions, openingBalance }` for the account view;
+ *  - `{ transactions, groupBf }` for the group view when per-group BF is on;
+ *  - a plain array of rows otherwise.
+ */
+export async function listTransactions(tenantSlug, query) {
+  const { accountId, categoryId, groupId, memberId, eventId, year } = query;
+  const yearNum = year ? parseInt(year, 10) : new Date().getFullYear();
+  const yearStart = `${yearNum}-01-01`;
+  const yearEnd = `${yearNum}-12-31`;
+
+  let sql, params;
+
+  // Common SELECT columns shared by all views
+  const commonCols = `
+             t.id, t.transaction_number, t.account_id, t.date, t.type,
+             t.from_to, t.amount::float, t.payment_method, t.payment_ref,
+             t.detail, t.remarks, t.cleared_at, t.pending,
+             t.member_id_1, t.member_id_2, t.group_id, t.event_id,
+             t.batch_id,
+             t.refund_of_id, t.refunded_by_id,
+             ref_orig.transaction_number AS refund_of_txn_number,
+             ref_by.transaction_number AS refunded_by_txn_number,
+             m1.forenames || ' ' || m1.surname AS member_1_name,
+             m1.membership_number AS member_1_no,
+             m2.forenames || ' ' || m2.surname AS member_2_name,
+             m2.membership_number AS member_2_no,
+             g.name AS group_name, g.short_name AS group_short_name, g.type AS group_type,
+             ge_ev.event_date AS event_date, ge_ev.topic AS event_topic,
+             COALESCE(ge_g.name, ge_et.name) AS event_label,
+             fa.name AS account_name,
+             cb.batch_ref AS batch_no,
+             cb.description AS batch_description`;
+  const commonJoins = `
+      LEFT JOIN members m1 ON m1.id = t.member_id_1
+      LEFT JOIN members m2 ON m2.id = t.member_id_2
+      LEFT JOIN groups g   ON g.id  = t.group_id
+      LEFT JOIN group_events ge_ev ON ge_ev.id = t.event_id
+      LEFT JOIN groups ge_g ON ge_g.id = ge_ev.group_id
+      LEFT JOIN event_types ge_et ON ge_et.id = ge_ev.event_type_id
+      LEFT JOIN finance_accounts fa ON fa.id = t.account_id
+      LEFT JOIN credit_batches cb ON cb.id = t.batch_id
+      LEFT JOIN transactions ref_orig ON ref_orig.id = t.refund_of_id
+      LEFT JOIN transactions ref_by   ON ref_by.id   = t.refunded_by_id
+      LEFT JOIN transaction_categories tc ON tc.transaction_id = t.id
+      LEFT JOIN finance_categories fc ON fc.id = tc.category_id`;
+  const categoriesAgg = `
+             COALESCE(
+               json_agg(json_build_object('category_id', tc.category_id, 'name', fc.name, 'amount', tc.amount::float))
+                 FILTER (WHERE tc.id IS NOT NULL), '[]'
+             ) AS categories`;
+  const commonGroupBy = `t.id, m1.forenames, m1.surname, m1.membership_number,
+               m2.forenames, m2.surname, m2.membership_number,
+               g.name, g.short_name, g.type,
+               ge_ev.event_date, ge_ev.topic, ge_g.name, ge_et.name,
+               fa.name, cb.batch_ref, cb.description,
+               ref_orig.transaction_number, ref_by.transaction_number`;
+
+  if (memberId) {
+    sql = `
+      SELECT ${commonCols},
+             ${categoriesAgg}
+      FROM transactions t
+      ${commonJoins}
+      WHERE (t.member_id_1 = $1 OR t.member_id_2 = $1)
+      GROUP BY ${commonGroupBy}
+      ORDER BY t.date, t.transaction_number`;
+    params = [memberId];
+  } else if (accountId) {
+    sql = `
+      SELECT ${commonCols},
+             ${categoriesAgg}
+      FROM transactions t
+      ${commonJoins}
+      WHERE t.account_id = $1 AND t.date BETWEEN $2::date AND $3::date
+      GROUP BY ${commonGroupBy}
+      ORDER BY t.date, t.transaction_number`;
+    params = [accountId, yearStart, yearEnd];
+  } else if (categoryId) {
+    sql = `
+      SELECT ${commonCols},
+             tc_this.amount::float AS category_amount,
+             ${categoriesAgg}
+      FROM transactions t
+      JOIN transaction_categories tc_this ON tc_this.transaction_id = t.id AND tc_this.category_id = $1
+      ${commonJoins}
+      WHERE t.date BETWEEN $2::date AND $3::date
+      GROUP BY ${commonGroupBy}, tc_this.amount
+      ORDER BY t.date, t.transaction_number`;
+    params = [categoryId, yearStart, yearEnd];
+  } else if (groupId) {
+    sql = `
+      SELECT ${commonCols},
+             ${categoriesAgg}
+      FROM transactions t
+      ${commonJoins}
+      WHERE ($1 = 'all' OR t.group_id = $1) AND t.date BETWEEN $2::date AND $3::date
+      GROUP BY ${commonGroupBy}
+      ORDER BY t.date, t.transaction_number`;
+    params = [groupId, yearStart, yearEnd];
+  } else if (eventId) {
+    sql = `
+      SELECT ${commonCols},
+             ${categoriesAgg}
+      FROM transactions t
+      ${commonJoins}
+      WHERE t.event_id = $1
+      GROUP BY ${commonGroupBy}
+      ORDER BY t.date, t.transaction_number`;
+    params = [eventId];
+  } else {
+    return [];
+  }
+
+  const rows = await tenantQuery(tenantSlug, sql, params);
+
+  // For account view, also compute the opening balance (BF + net of prior-year transactions)
+  if (accountId) {
+    const [acc] = await tenantQuery(
+      tenantSlug,
+      `SELECT balance_brought_forward::float FROM finance_accounts WHERE id = $1`,
+      [accountId],
+    );
+    const bf = acc?.balance_brought_forward ?? 0;
+    const [priorNet] = await tenantQuery(
+      tenantSlug,
+      `SELECT COALESCE(SUM(CASE WHEN type='in' THEN amount ELSE -amount END), 0)::float AS net
+       FROM transactions WHERE account_id = $1 AND date < $2::date AND pending = false`,
+      [accountId, yearStart],
+    );
+    const openingBalance = bf + (priorNet?.net ?? 0);
+    return { transactions: rows, openingBalance };
+  }
+
+  // For group view, compute per-group opening balances if group_bf_enabled
+  if (groupId) {
+    const [setting] = await tenantQuery(
+      tenantSlug,
+      `SELECT group_bf_enabled FROM tenant_settings WHERE id = 'singleton'`,
+    );
+    if (setting?.group_bf_enabled) {
+      let bfSql, bfParams;
+      if (groupId === 'all') {
+        bfSql = `
+          SELECT t.group_id, g.name AS group_name, g.short_name AS group_short_name, g.type AS group_type,
+                 COALESCE(SUM(CASE WHEN t.type='in' THEN t.amount ELSE -t.amount END), 0)::float AS balance
+          FROM transactions t
+          LEFT JOIN groups g ON g.id = t.group_id
+          WHERE t.group_id IS NOT NULL AND t.date < $1::date AND t.pending = false
+          GROUP BY t.group_id, g.name, g.short_name, g.type
+          HAVING SUM(CASE WHEN t.type='in' THEN t.amount ELSE -t.amount END) <> 0
+          ORDER BY g.name`;
+        bfParams = [yearStart];
+      } else {
+        bfSql = `
+          SELECT t.group_id, g.name AS group_name, g.short_name AS group_short_name, g.type AS group_type,
+                 COALESCE(SUM(CASE WHEN t.type='in' THEN t.amount ELSE -t.amount END), 0)::float AS balance
+          FROM transactions t
+          LEFT JOIN groups g ON g.id = t.group_id
+          WHERE t.group_id = $1 AND t.date < $2::date AND t.pending = false
+          GROUP BY t.group_id, g.name, g.short_name, g.type`;
+        bfParams = [groupId, yearStart];
+      }
+      const groupBfRows = await tenantQuery(tenantSlug, bfSql, bfParams);
+      return { transactions: rows, groupBf: groupBfRows };
+    }
+  }
+
+  return rows;
+}
+
+// ─── Single ─────────────────────────────────────────────────────────────────
+
+export async function getTransaction(tenantSlug, id) {
+  const [txn] = await tenantQuery(
+    tenantSlug,
+    `SELECT t.id, t.transaction_number, t.account_id, t.date, t.type,
+          t.from_to, t.amount::float, t.payment_method, t.payment_ref,
+          t.detail, t.remarks, t.cleared_at, t.pending, t.transfer_id,
+          t.member_id_1, t.member_id_2, t.group_id, t.event_id,
+          t.gift_aid_amount::float AS gift_aid_amount, t.gift_aid_claimed_at,
+          t.gift_aid_amount_2::float AS gift_aid_amount_2, t.gift_aid_claimed_at_2,
+          t.batch_id, cb.batch_ref,
+          t.refund_of_id, t.refunded_by_id,
+          ref_orig.transaction_number AS refund_of_txn_number,
+          ref_by.transaction_number AS refunded_by_txn_number,
+          ref_by.amount::float AS refunded_amount,
+          m1.forenames || ' ' || m1.surname AS member_1_name,
+          m2.forenames || ' ' || m2.surname AS member_2_name,
+          g.name AS group_name, g.short_name AS group_short_name, g.type AS group_type,
+          ge_ev.event_date AS event_date, ge_ev.topic AS event_topic,
+          COALESCE(ge_g.name, ge_et.name) AS event_label,
+          fa.name AS account_name,
+          fa.enable_refunds AS account_enable_refunds,
+          COALESCE(
+            json_agg(json_build_object('category_id', tc.category_id, 'name', fc.name, 'amount', tc.amount::float))
+              FILTER (WHERE tc.id IS NOT NULL), '[]'
+          ) AS categories
+   FROM transactions t
+   LEFT JOIN members m1 ON m1.id = t.member_id_1
+   LEFT JOIN members m2 ON m2.id = t.member_id_2
+   LEFT JOIN groups g   ON g.id  = t.group_id
+   LEFT JOIN group_events ge_ev ON ge_ev.id = t.event_id
+   LEFT JOIN groups ge_g ON ge_g.id = ge_ev.group_id
+   LEFT JOIN event_types ge_et ON ge_et.id = ge_ev.event_type_id
+   LEFT JOIN finance_accounts fa ON fa.id = t.account_id
+   LEFT JOIN credit_batches cb ON cb.id = t.batch_id
+   LEFT JOIN transactions ref_orig ON ref_orig.id = t.refund_of_id
+   LEFT JOIN transactions ref_by   ON ref_by.id   = t.refunded_by_id
+   LEFT JOIN transaction_categories tc ON tc.transaction_id = t.id
+   LEFT JOIN finance_categories fc ON fc.id = tc.category_id
+   WHERE t.id = $1
+   GROUP BY t.id, m1.forenames, m1.surname, m2.forenames, m2.surname, g.name, g.short_name, g.type,
+            ge_ev.event_date, ge_ev.topic, ge_g.name, ge_et.name,
+            fa.name, cb.batch_ref,
+            ref_orig.transaction_number, ref_by.transaction_number, ref_by.amount, fa.enable_refunds`,
+    [id],
+  );
+  if (!txn) throw AppError('Transaction not found.', 404);
+  return txn;
+}
+
+// ─── Create ─────────────────────────────────────────────────────────────────
+
+export async function createTransaction(tenantSlug, data) {
+  // Validate category amounts sum to transaction amount
+  const catTotal = data.categories.reduce((s, c) => s + c.amount, 0);
+  if (Math.abs(catTotal - data.amount) > 0.001) {
+    throw AppError(
+      `Category amounts (${catTotal.toFixed(2)}) must equal transaction amount (${data.amount.toFixed(2)}).`,
+      400,
+    );
+  }
+
+  // Determine pending status based on account config
+  let pending = data.pending ?? false;
+  const [acct] = await tenantQuery(
+    tenantSlug,
+    `SELECT pending_config, pending_types FROM finance_accounts WHERE id = $1`,
+    [data.account_id],
+  );
+  if (acct) {
+    if (acct.pending_config === 'disabled') {
+      pending = false;
+    } else if (acct.pending_config === 'by_type') {
+      const types = acct.pending_types ?? [];
+      pending = types.includes(data.payment_method ?? '');
+    }
+    // 'optional' — use whatever the client sent
+  }
+
+  const [txn] = await tenantQuery(
+    tenantSlug,
+    `INSERT INTO transactions
+       (account_id, date, type, from_to, amount, payment_method, payment_ref, detail, remarks, member_id_1, member_id_2, group_id, event_id, pending, gift_aid_amount, gift_aid_amount_2)
+     VALUES ($1, $2::date, $3, $4, $5::numeric, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::numeric, $16::numeric)
+     RETURNING id, transaction_number`,
+    [
+      data.account_id,
+      data.date,
+      data.type,
+      data.from_to ?? null,
+      data.amount,
+      data.payment_method ?? null,
+      data.payment_ref ?? null,
+      data.detail ?? null,
+      data.remarks ?? null,
+      data.member_id_1 ?? null,
+      data.member_id_2 ?? null,
+      data.group_id ?? null,
+      data.event_id ?? null,
+      pending,
+      data.gift_aid_amount ?? null,
+      data.gift_aid_amount_2 ?? null,
+    ],
+  );
+
+  for (const cat of data.categories) {
+    await tenantQuery(
+      tenantSlug,
+      `INSERT INTO transaction_categories (transaction_id, category_id, amount) VALUES ($1, $2, $3::numeric)`,
+      [txn.id, cat.category_id, cat.amount],
+    );
+  }
+
+  return { id: txn.id, transaction_number: txn.transaction_number };
+}
+
+// ─── Bulk pending ───────────────────────────────────────────────────────────
+
+export async function bulkSetPending(tenantSlug, ids, pending) {
+  // Validate: only non-cleared, non-transfer, non-batched transactions
+  const rows = await tenantQuery(
+    tenantSlug,
+    `SELECT id, cleared_at, transfer_id, batch_id FROM transactions WHERE id = ANY($1::text[])`,
+    [ids],
+  );
+
+  const errors = [];
+  for (const r of rows) {
+    if (r.cleared_at) errors.push(`Transaction ${r.id} is cleared.`);
+    if (r.transfer_id) errors.push(`Transaction ${r.id} is a transfer.`);
+    if (r.batch_id) errors.push(`Transaction ${r.id} is in a credit batch.`);
+  }
+  if (errors.length > 0) throw AppError(errors.join(' '), 400);
+
+  await tenantQuery(
+    tenantSlug,
+    `UPDATE transactions SET pending = $1, updated_at = now() WHERE id = ANY($2::text[])`,
+    [pending, ids],
+  );
+
+  return { message: `${ids.length} transaction(s) updated.`, count: ids.length };
+}
+
+// ─── Update ─────────────────────────────────────────────────────────────────
+
+export async function updateTransaction(tenantSlug, id, data) {
+  const [current] = await tenantQuery(
+    tenantSlug,
+    `SELECT id, amount::float AS amount, cleared_at, transfer_id, pending, refund_of_id, refunded_by_id FROM transactions WHERE id = $1`,
+    [id],
+  );
+  if (!current) throw AppError('Transaction not found.', 404);
+  if (current.transfer_id)
+    throw AppError(
+      'This transaction is part of a transfer. Use the Transfer Money page to edit it.',
+      400,
+    );
+  if (current.cleared_at) throw AppError('Cleared transactions cannot be changed.', 400);
+  if (current.refunded_by_id)
+    throw AppError(
+      'This transaction has been refunded and cannot be changed. Delete the refund first.',
+      400,
+    );
+  if (current.refund_of_id)
+    throw AppError(
+      'Refund transactions cannot be edited. Delete and re-create the refund instead.',
+      400,
+    );
+
+  // Transfers cannot be marked as pending
+  if (data.pending === true && current.transfer_id) {
+    throw AppError('Transfers cannot be marked as pending.', 400);
+  }
+
+  // If categories are being updated, validate sum
+  if (data.categories) {
+    const newAmount = data.amount ?? current.amount;
+    const catTotal = data.categories.reduce((s, c) => s + c.amount, 0);
+    if (Math.abs(catTotal - newAmount) > 0.001) {
+      throw AppError(
+        `Category amounts (${catTotal.toFixed(2)}) must equal transaction amount (${newAmount.toFixed(2)}).`,
+        400,
+      );
+    }
+  }
+
+  const fields = [];
+  const values = [];
+  let i = 1;
+  if (data.account_id !== undefined) {
+    fields.push(`account_id = $${i++}`);
+    values.push(data.account_id);
+  }
+  if (data.date !== undefined) {
+    fields.push(`date = $${i++}::date`);
+    values.push(data.date);
+  }
+  if (data.type !== undefined) {
+    fields.push(`type = $${i++}`);
+    values.push(data.type);
+  }
+  if (data.from_to !== undefined) {
+    fields.push(`from_to = $${i++}`);
+    values.push(data.from_to);
+  }
+  if (data.amount !== undefined) {
+    fields.push(`amount = $${i++}::numeric`);
+    values.push(data.amount);
+  }
+  if (data.payment_method !== undefined) {
+    fields.push(`payment_method = $${i++}`);
+    values.push(data.payment_method);
+  }
+  if (data.payment_ref !== undefined) {
+    fields.push(`payment_ref = $${i++}`);
+    values.push(data.payment_ref);
+  }
+  if (data.detail !== undefined) {
+    fields.push(`detail = $${i++}`);
+    values.push(data.detail);
+  }
+  if (data.remarks !== undefined) {
+    fields.push(`remarks = $${i++}`);
+    values.push(data.remarks);
+  }
+  if (data.member_id_1 !== undefined) {
+    fields.push(`member_id_1 = $${i++}`);
+    values.push(data.member_id_1);
+  }
+  if (data.member_id_2 !== undefined) {
+    fields.push(`member_id_2 = $${i++}`);
+    values.push(data.member_id_2);
+  }
+  if (data.group_id !== undefined) {
+    fields.push(`group_id = $${i++}`);
+    values.push(data.group_id);
+  }
+  if (data.event_id !== undefined) {
+    fields.push(`event_id = $${i++}`);
+    values.push(data.event_id);
+  }
+  if (data.batch_id !== undefined) {
+    fields.push(`batch_id = $${i++}`);
+    values.push(data.batch_id);
+  }
+  if (data.pending !== undefined) {
+    fields.push(`pending = $${i++}`);
+    values.push(data.pending);
+  }
+  if (data.gift_aid_amount !== undefined) {
+    fields.push(`gift_aid_amount = $${i++}::numeric`);
+    values.push(data.gift_aid_amount);
+  }
+  if (data.gift_aid_amount_2 !== undefined) {
+    fields.push(`gift_aid_amount_2 = $${i++}::numeric`);
+    values.push(data.gift_aid_amount_2);
+  }
+
+  if (fields.length > 0) {
+    fields.push(`updated_at = now()`);
+    values.push(id);
+    await tenantQuery(
+      tenantSlug,
+      `UPDATE transactions SET ${fields.join(', ')} WHERE id = $${i}`,
+      values,
+    );
+  }
+
+  if (data.categories) {
+    await tenantQuery(tenantSlug, `DELETE FROM transaction_categories WHERE transaction_id = $1`, [
+      id,
+    ]);
+    for (const cat of data.categories) {
+      await tenantQuery(
+        tenantSlug,
+        `INSERT INTO transaction_categories (transaction_id, category_id, amount) VALUES ($1, $2, $3::numeric)`,
+        [id, cat.category_id, cat.amount],
+      );
+    }
+  }
+
+  return { message: 'Transaction updated.' };
+}
+
+// ─── Delete ─────────────────────────────────────────────────────────────────
+
+export async function deleteTransaction(tenantSlug, id) {
+  const [current] = await tenantQuery(
+    tenantSlug,
+    `SELECT cleared_at, transfer_id, refund_of_id, refunded_by_id FROM transactions WHERE id = $1`,
+    [id],
+  );
+  if (!current) throw AppError('Transaction not found.', 404);
+  if (current.transfer_id)
+    throw AppError(
+      'This transaction is part of a transfer. Use the Transfer Money page to delete it.',
+      400,
+    );
+  if (current.cleared_at) throw AppError('Cleared transactions cannot be deleted.', 400);
+  if (current.refunded_by_id)
+    throw AppError('This transaction has been refunded. Delete the refund transaction first.', 400);
+
+  // If this is a refund transaction, clear the refunded_by_id on the original
+  if (current.refund_of_id) {
+    await tenantQuery(
+      tenantSlug,
+      `UPDATE transactions SET refunded_by_id = NULL, updated_at = now() WHERE id = $1`,
+      [current.refund_of_id],
+    );
+  }
+
+  await tenantQuery(tenantSlug, `DELETE FROM transactions WHERE id = $1`, [id]);
+  return { message: 'Transaction deleted.' };
+}
+
+// ─── Refund (doc 7.10.7) ────────────────────────────────────────────────────
+
+/**
+ * Create a refund for an existing transaction (doc 7.10.7).
+ * @param {object} actor - { userId, name } for the audit log entry.
+ */
+export async function refundTransaction(tenantSlug, id, data, actor) {
+  // Load the original transaction
+  const [orig] = await tenantQuery(
+    tenantSlug,
+    `SELECT t.id, t.transaction_number, t.account_id, t.date, t.type, t.from_to,
+          t.amount::float, t.cleared_at, t.transfer_id, t.refund_of_id, t.refunded_by_id,
+          t.member_id_1, t.member_id_2, t.group_id,
+          t.gift_aid_claimed_at,
+          fa.enable_refunds
+   FROM transactions t
+   JOIN finance_accounts fa ON fa.id = t.account_id
+   WHERE t.id = $1`,
+    [id],
+  );
+  if (!orig) throw AppError('Transaction not found.', 404);
+  if (!orig.enable_refunds) throw AppError('Refunds are not enabled for this account.', 400);
+  if (orig.cleared_at)
+    throw AppError('Cleared transactions cannot be refunded. Un-clear it first.', 400);
+  if (orig.transfer_id) throw AppError('Transfer transactions cannot be refunded.', 400);
+  if (orig.refund_of_id) throw AppError('A refund transaction cannot itself be refunded.', 400);
+  if (orig.refunded_by_id) throw AppError('This transaction has already been refunded.', 400);
+  if (orig.gift_aid_claimed_at)
+    throw AppError('Transactions with claimed Gift Aid cannot be refunded.', 400);
+
+  // Validate refund date: must be after original date
+  if (data.date <= orig.date) {
+    throw AppError('Refund date must be after the original transaction date.', 400);
+  }
+
+  // Validate refund date is in the same financial year as the original
+  const [settings] = await tenantQuery(
+    tenantSlug,
+    `SELECT year_start_month, year_start_day FROM tenant_settings WHERE id = 'singleton'`,
+  );
+  const sm = settings.year_start_month;
+  const sd = settings.year_start_day;
+
+  // Find which financial year the original transaction belongs to
+  const origDate = new Date(orig.date + 'T00:00:00Z');
+  let origYear = origDate.getUTCFullYear();
+  const fyStartOrig = new Date(Date.UTC(origYear, sm - 1, sd));
+  if (origDate < fyStartOrig) origYear--;
+  const { yearStart: fyStart, yearEnd: fyEnd } = computeYearBounds(origYear, sm, sd);
+
+  if (data.date < fyStart || data.date > fyEnd) {
+    throw AppError(
+      'Refund date must be in the same financial year as the original transaction.',
+      400,
+    );
+  }
+
+  // Validate refund category amounts
+  const refundTotal = data.categories.reduce((s, c) => s + c.amount, 0);
+  if (refundTotal <= 0) throw AppError('Refund amount must be positive.', 400);
+  if (refundTotal > orig.amount)
+    throw AppError('Refund total cannot exceed the original transaction amount.', 400);
+
+  // Load original category amounts to validate per-category limits
+  const origCats = await tenantQuery(
+    tenantSlug,
+    `SELECT category_id, amount::float FROM transaction_categories WHERE transaction_id = $1`,
+    [orig.id],
+  );
+  const origCatMap = {};
+  for (const oc of origCats) origCatMap[oc.category_id] = oc.amount;
+
+  for (const rc of data.categories) {
+    if (rc.amount === 0) continue;
+    const origAmt = origCatMap[rc.category_id];
+    if (origAmt === undefined) throw AppError(`Category not found on original transaction.`, 400);
+    if (rc.amount > origAmt + 0.001)
+      throw AppError(`Refund for category exceeds original amount.`, 400);
+  }
+
+  // Create the refund transaction (opposite type)
+  const refundType = orig.type === 'in' ? 'out' : 'in';
+  const [refundTxn] = await tenantQuery(
+    tenantSlug,
+    `INSERT INTO transactions
+       (account_id, date, type, from_to, amount, payment_method, payment_ref, detail, remarks,
+        member_id_1, member_id_2, group_id, pending, refund_of_id)
+     VALUES ($1, $2::date, $3, $4, $5::numeric, $6, $7, $8, $9, $10, $11, $12, false, $13)
+     RETURNING id, transaction_number`,
+    [
+      orig.account_id,
+      data.date,
+      refundType,
+      orig.from_to,
+      refundTotal,
+      data.payment_method ?? null,
+      data.payment_ref ?? null,
+      data.detail ?? null,
+      data.remarks ?? null,
+      orig.member_id_1,
+      orig.member_id_2,
+      orig.group_id,
+      orig.id,
+    ],
+  );
+
+  // Insert refund category splits (only non-zero amounts)
+  for (const cat of data.categories) {
+    if (cat.amount === 0) continue;
+    await tenantQuery(
+      tenantSlug,
+      `INSERT INTO transaction_categories (transaction_id, category_id, amount) VALUES ($1, $2, $3::numeric)`,
+      [refundTxn.id, cat.category_id, cat.amount],
+    );
+  }
+
+  // Link original to refund
+  await tenantQuery(
+    tenantSlug,
+    `UPDATE transactions SET refunded_by_id = $1, updated_at = now() WHERE id = $2`,
+    [refundTxn.id, orig.id],
+  );
+
+  logAudit(tenantSlug, {
+    userId: actor.userId,
+    userName: actor.name,
+    action: 'create',
+    entityType: 'transaction',
+    entityId: refundTxn.id,
+    entityName: `Refund #${refundTxn.transaction_number} of #${orig.transaction_number}`,
+  });
+
+  return { id: refundTxn.id, transaction_number: refundTxn.transaction_number };
+}


### PR DESCRIPTION
Two chunks from `docs/ImprovementPlan-2026-06-14.md`, both behaviour-preserving.

## Chunk 3 — Service-layer extraction (finance transactions)
Establishes the marquee maintainability pattern end-to-end on one route.

- New `backend/src/services/transactionService.js` holds all transaction business logic and tenant data access (`list`/`get`/`create`/`bulkSetPending`/`update`/`delete`/`refund`).
- `routes/finance/transactions.js` (**747 → 179 lines**) is now a thin controller: Zod validation at the route boundary, HTTP concerns at the route, everything else delegated — mirroring `services/authService.js`.
- The extraction preserves the exact `tenantQuery` call sequence the route tests sequence-mock, so existing finance tests pass unchanged.
- Documented the convention in `CLAUDE-STANDARDS.md`; recorded the two larger follow-up routes (`backup/restore.js`, `members/crud.js`) in `KNOWN-ISSUES.md`.

## Chunk 6 — Test coverage for security-critical paths
Per the methodology, re-verified the three paths the plan flagged as untested — **most were already covered** (lockout + refresh-token slug mismatch in `authService.test.js`, slug guards in `db.test.js`, role-escalation via `/users/:id/roles` in `users.test.js`). Added the two genuinely-missing branches:

- **`POST /users` escalation guard** — the third `assertActorHoldsRolePrivileges` call site (create user with `roleIds`): a role granting a privilege the actor lacks is rejected **403** and no `user_roles` row is written.
- **`loginUser` failure-counter reset** — a successful login clears `failed_login_count`/`locked_until`.

Both new tests were confirmed to **fail against a deliberately broken guard** (they bite). Also recorded a minor data-hygiene wart found in passing (`POST /users` runs the guard after the user `INSERT`) as `[OPEN]` in `KNOWN-ISSUES.md`.

## Verification
- Backend: **606 tests pass**; `lint` and `format:check` clean.
- Frontend untouched.

https://claude.ai/code/session_01DpcwbxXjvhgdNHm3Tb2hsE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpcwbxXjvhgdNHm3Tb2hsE)_