### PR TITLE
ImprovementPlan Chunks 7 & 9: completeness reconciliation + frontend polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 
 ## [Unreleased] — 2026-06-14
 
+### Changed
+- **Frontend polish — public pages (2026-06-14 review, Chunk 9)** —
+  - Migrated the six public pages (`PortalLogin`, `PortalRegister`,
+    `PortalResetPassword`, `PortalForgotPassword`, `JoinForm`,
+    `PortalPersonalDetails`) from inline Tailwind input/label strings to the
+    shared `inputCls` / `labelCls` constants (`components/ui/Input.jsx`),
+    removing two duplicated local style definitions.
+  - Added `htmlFor`/`id` label associations to every field on the four public
+    auth pages (`PortalLogin`, `PortalForgotPassword`, `PortalResetPassword`,
+    `PortalRegister`) for screen-reader and Playwright `getByLabel` support.
+
 ### Added
 - **Licensing & legal hygiene (2026-06-14 review, Chunk 1)** —
   - Root `LICENSE` declaring Beacon2 **proprietary / all rights reserved**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,32 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
   Both new tests were confirmed to fail against a deliberately broken guard
   (they bite).
 
+### Added
+- **Public u3a contact details on unauthenticated pages (2026-06-14 review,
+  Chunk 7)** — the `public_phone` / `public_email` / `home_page` System Settings
+  fields (previously stored but shown nowhere) now appear as a shared
+  "Need help? Contact us" block (`frontend/src/components/PublicContact.jsx`) on
+  the Members Portal sign-in page and the online Join form. Backed by a new
+  public `GET /:slug/info` endpoint and three extra fields on the join-config
+  response. Ref: UG 8.3.
+
 ### Changed
+- **Completeness reconciliation (2026-06-14 review, Chunk 7)** —
+  - Aligned the Group/Team Cash description line to say "central ledger",
+    matching the "Central Ledger" shortcut button (KI UI Terminology).
+  - Reworded the no-op Calendar data-export placeholder to state accurately
+    that events are exported with the Groups export, rather than the misleading
+    "Calendar is not yet implemented" (owner decision: keep the placeholder).
+  - Corrected the `BeaconUG-Comparison.md` 4.2.4 row: the per-member
+    `hide_contact` flag is **not** actually enforced in the group members view
+    (was wrongly listed as "Built"). Re-verification found the scoped
+    group-leader privileges (`group_records_as_leader`/`as_member`) are seeded
+    but enforced nowhere, so correct contact-hiding depends first on that model
+    — captured as a clearer deferred note in `KNOWN-ISSUES.md`.
+  - Documented the correct pending-transaction bulk-action eligibility in
+    `docs/Beacon2UG/34-pending-transactions.md` (in-year, non-cleared,
+    non-batched), and added an editor's note to the faithful UG 7.10.5
+    transcription flagging the contradictory bullet in the original manual.
 - **Service-layer extraction for finance transactions (2026-06-14 review,
   Chunk 3)** — introduced the marquee maintainability pattern on one route
   end-to-end. New `backend/src/services/transactionService.js` now holds all

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -266,14 +266,14 @@ These are catalogued and re-verified in `docs/history/ImprovementPlan.md` (Chunk
 
 ## UI Terminology
 
-1. `[OPEN]` **Group/Team Cash — "Central Ledger" vs "Finance Ledger" wording** — The
-   shortcut button on the Group Cash and Team Cash tabs now says
-   **"Central Ledger"** (tooltip: *"View this group's/team's other transactions -
-   in the central ledger"*), while the description line above it and the
-   destination page's title still use **"Finance Ledger"**. The two refer to the
-   same thing but the inconsistency may confuse some users. Revisit if feedback
-   warrants — options: align the description to "central ledger", or rename the
-   button back to "Finance Ledger" (giving up the shorter label).
+1. `[FIXED]` **Group/Team Cash — "Central Ledger" vs "Finance Ledger" wording** — The
+   shortcut button on the Group Cash and Team Cash tabs says **"Central Ledger"**
+   (tooltip: *"View this group's/team's other transactions - in the central ledger"*).
+   The description line above it previously called the same destination the "Finance
+   Ledger", which was inconsistent. Resolved 2026-06-14 (ImprovementPlan Chunk 7): the
+   description line now reads "The central ledger shows different, complementary
+   transactions", matching the button. The destination page keeps its "Finance Ledger"
+   menu/page title (its own name); the tooltip already bridges the two terms.
 
 ---
 
@@ -300,18 +300,25 @@ These are catalogued and re-verified in `docs/history/ImprovementPlan.md` (Chunk
 
 ## Documentation Typos
 
-1. `[OPEN]` **Doc 7.10.5 — Pending Transactions bulk action eligibility** — The document says
-   transactions are eligible for bulk pending actions if they "Are not in the Current
-   financial year". This should read "Are in the Current financial year" — only
-   current-year transactions should be eligible for bulk pending changes.
+1. `[FIXED]` **Doc 7.10.5 — Pending Transactions bulk action eligibility** — The original
+   Beacon manual bullet says transactions are eligible if they "Are not in the Current
+   financial year", which contradicts its own footnote (out-of-year transactions must be
+   opened individually). Beacon2's actual behaviour is correct — bulk checkboxes appear
+   only on in-year, non-cleared, non-batched transactions. Resolved 2026-06-14
+   (ImprovementPlan Chunk 7): added an editor's note to the faithful BeaconUG
+   transcription flagging the source error (rather than silently rewriting the original),
+   and documented the correct eligibility in `docs/Beacon2UG/34-pending-transactions.md`.
 
 ---
 
 ## System Settings (doc 8.3) — Deferred Items
 
-1. `[DEFERRED]` **public_phone, public_email, home_page** — Stored in tenant_settings and editable
-   on the System Settings page, but not yet displayed anywhere to members (e.g. portal
-   login page, online joining form, confirmation emails). Ref: doc 8.3.
+1. `[FIXED]` **public_phone, public_email, home_page** — Now displayed to members as a
+   "Need help? Contact us" block (shared `frontend/src/components/PublicContact.jsx`)
+   on the Members Portal sign-in page and the online Join form, fed by the new public
+   `GET /:slug/info` endpoint and the extended join-config response. Resolved in the
+   2026-06-14 review, ImprovementPlan Chunk 7. (Confirmation-email inclusion remains a
+   possible future enhancement but was out of scope.) Ref: doc 8.3.
 
 ---
 
@@ -326,12 +333,24 @@ These are catalogued and re-verified in `docs/history/ImprovementPlan.md` (Chunk
 
 ## Group / Member Contact Hiding (doc 4.2.4)
 
-1. `[DEFERRED]` **Per-group `show_addresses` not wired into visibility logic** — The `show_addresses`
-   boolean field exists on the group record and is stored/retrieved via the API, but the
-   group members table in GroupRecord.jsx unconditionally renders address, telephone, and
-   mobile for every row. Neither `show_addresses` nor the per-member `hide_contact` flag
-   is checked when deciding what to display. The backend also returns all contact data
-   without filtering. Ref: doc 4.2.4.
+1. `[DEFERRED]` **`hide_contact` / `show_addresses` not enforced in the group members view** —
+   The per-member `hide_contact` and per-group `show_addresses` fields are stored and
+   editable, but the shared `EntityMembers.jsx` table (used by GroupRecord/TeamRecord)
+   unconditionally renders address, telephone and mobile for every row, and the backend
+   (`routes/groups/members.js`, `routes/teams/members.js`) returns all contact data
+   without filtering.
+
+   **Real blocker (re-verified 2026-06-14, ImprovementPlan Chunk 7):** correct
+   enforcement must hide contact *from group leaders only*, not from membership
+   admins (UG 4.2.4). Beacon2 has no runtime signal for "this viewer is a leader":
+   the scoped privileges `group_records_as_leader` / `group_records_as_member` are
+   **seeded** (`seed/privilegeResources.js`, `seed/defaultRoles.js`) **but enforced
+   nowhere** — every group members route is gated solely by `group_records_all`. A
+   naive "hide for everyone holding `group_records_all`" would wrongly hide contact
+   from admins. So this depends first on implementing the scoped group-leader access
+   model (a separate, larger piece of work). The previous comparison-doc claim that
+   `hide_contact` "hides email/phone in group members list" was inaccurate and has been
+   corrected to Partial. Ref: doc 4.2.4.
 
 2. `[DEFERRED]` **System-wide "Hide Address from Group Leaders" setting** — Doc 4.2.4(b) describes a
    global system setting that hides addresses of ALL members from ALL group leaders (unless
@@ -423,10 +442,13 @@ These are catalogued and re-verified in `docs/history/ImprovementPlan.md` (Chunk
    status). This is transient data that cannot be meaningfully restored, so it
    is deliberately excluded.
 
-3. `[OPEN]` **Calendar export type is a no-op** — the "Calendar" export button in Data Backup
-   currently just notes that events are in the Groups export. Consider removing the
-   Calendar export option entirely, or having it produce the same Group Events sheet
-   independently.
+3. `[ACCEPTED]` **Calendar export type is a placeholder** — the "Calendar" export in Data
+   Backup produces a single-row sheet noting that events are exported with the Groups
+   export (Group Events sheet). Owner decision (2026-06-14, ImprovementPlan Chunk 7):
+   **leave as-is** rather than removing the option or duplicating the events into a
+   second sheet. The placeholder message was reworded to state accurately where events
+   live (it previously said "Calendar is not yet implemented", which was misleading
+   since the calendar/events feature is fully built).
 
 4. `[DEFERRED]` **Beacon restore — group-tied calendar events not migrated** — `restoreBeacon()`
    now imports Open Meetings (Calendar rows with `gkey` empty) but skips group-tied

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -369,6 +369,10 @@ These are catalogued and re-verified in `docs/history/ImprovementPlan.md` (Chunk
    TransactionRefund, PersonalPreferences, and DateInput. Further pages fixed in
    ImprovementPlan Chunk 11 (June 2026): VenueEditor, MemberClassEditor (incl.
    `aria-label` on the monthly-fee grid inputs), ChangePassword, and RoleEditor.
+   Further pages fixed in ImprovementPlan Chunk 9 (2026-06-14): the public auth
+   pages PortalLogin, PortalForgotPassword, PortalResetPassword, and
+   PortalRegister now associate every `<label>` with its input via
+   `htmlFor`/`id`.
    Remaining lower-traffic pages should be fixed incrementally as E2E tests are
    written for each page.
 

--- a/backend/src/__tests__/public.test.js
+++ b/backend/src/__tests__/public.test.js
@@ -64,6 +64,37 @@ describe('GET /:slug/join-config', () => {
   });
 });
 
+// ── GET /:slug/info ─────────────────────────────────────────────────────────
+
+describe('GET /:slug/info', () => {
+  it('returns the u3a name and public contact details', async () => {
+    tenantQuery.mockResolvedValueOnce([
+      {
+        public_phone: '01234 567890',
+        public_email: 'info@demo.example',
+        home_page: 'https://demo.example',
+      },
+    ]);
+    const res = await request(app).get(`/public/${SLUG}/info`);
+    expect(res.status).toBe(200);
+    expect(res.body.u3aName).toBe('Demo u3a');
+    expect(res.body.publicPhone).toBe('01234 567890');
+    expect(res.body.publicEmail).toBe('info@demo.example');
+    expect(res.body.homePage).toBe('https://demo.example');
+  });
+
+  it('returns empty strings when contact details are unset', async () => {
+    tenantQuery.mockResolvedValueOnce([
+      { public_phone: null, public_email: null, home_page: null },
+    ]);
+    const res = await request(app).get(`/public/${SLUG}/info`);
+    expect(res.status).toBe(200);
+    expect(res.body.publicPhone).toBe('');
+    expect(res.body.publicEmail).toBe('');
+    expect(res.body.homePage).toBe('');
+  });
+});
+
 // ── POST /:slug/portal/register ─────────────────────────────────────────────
 
 describe('POST /:slug/portal/register', () => {

--- a/backend/src/routes/backup/export.js
+++ b/backend/src/routes/backup/export.js
@@ -453,7 +453,10 @@ export async function buildGroupsSheets(wb, slug) {
 export async function buildCalendarSheet(wb) {
   const ws = wb.addWorksheet('Calendar');
   ws.addRow(['note']);
-  ws.addRow(['Calendar is not yet implemented in Beacon2.']);
+  ws.addRow([
+    'Calendar events are exported with the Groups export (Group Events sheet), ' +
+      'not as a separate Calendar sheet.',
+  ]);
 }
 
 export async function buildSystemSheets(wb, slug) {

--- a/backend/src/routes/public/join.js
+++ b/backend/src/routes/public/join.js
@@ -33,7 +33,8 @@ router.get('/:slug/join-config', async (req, res, next) => {
     const [settings] = await tenantQuery(
       slug,
       `SELECT privacy_policy_url, paypal_email, default_town, default_county,
-              online_join_email, online_renew_email
+              online_join_email, online_renew_email,
+              public_phone, public_email, home_page
        FROM tenant_settings WHERE id = 'singleton'`,
     );
 
@@ -53,6 +54,9 @@ router.get('/:slug/join-config', async (req, res, next) => {
       defaultCounty: settings.default_county ?? '',
       onlineJoinEmail: settings.online_join_email ?? '',
       onlineRenewEmail: settings.online_renew_email ?? '',
+      publicPhone: settings.public_phone ?? '',
+      publicEmail: settings.public_email ?? '',
+      homePage: settings.home_page ?? '',
       classes,
     });
   } catch (err) {

--- a/backend/src/routes/public/read.js
+++ b/backend/src/routes/public/read.js
@@ -9,6 +9,28 @@ import { isFeatureEnabled } from '../../middleware/requireFeature.js';
 
 const router = Router();
 
+// GET /:slug/info — public u3a contact details (name + public phone/email/home
+// page from System Settings). Unauthenticated; used by the Members Portal sign-in
+// and online joining pages so prospective/returning members can make contact.
+router.get('/:slug/info', async (req, res, next) => {
+  try {
+    const slug = req.tenantSlug;
+    const [settings] = await tenantQuery(
+      slug,
+      `SELECT public_phone, public_email, home_page
+       FROM tenant_settings WHERE id = 'singleton'`,
+    );
+    res.json({
+      u3aName: req.tenant.name || slug,
+      publicPhone: settings?.public_phone ?? '',
+      publicEmail: settings?.public_email ?? '',
+      homePage: settings?.home_page ?? '',
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
 // GET /:slug/groups — public groups list
 router.get('/:slug/groups', async (req, res, next) => {
   try {

--- a/docs/Beacon2UG/34-pending-transactions.md
+++ b/docs/Beacon2UG/34-pending-transactions.md
@@ -72,6 +72,11 @@ status. In the **Ledger (by account)** view:
 This is much faster when you need to confirm a batch of transactions at once —
 for example, after a bank deposit has cleared.
 
+The bulk checkboxes appear only on transactions that **are in the selected
+financial year** and are **not cleared** and **not part of a credit batch**.
+Transactions outside the selected year (or that are cleared or batched) must be
+opened individually to change their pending status.
+
 ---
 
 ## Tips for using pending transactions

--- a/docs/BeaconUG-Comparison.md
+++ b/docs/BeaconUG-Comparison.md
@@ -9,7 +9,7 @@
 > - **Not started** — feature not yet implemented
 > - **Beacon2 extra** — functionality in Beacon2 that is not in the original Beacon
 >
-> **Last updated:** 2026-04-13
+> **Last updated:** 2026-06-14
 
 ---
 
@@ -143,9 +143,18 @@
 
 | Aspect | Status | Notes |
 |--------|--------|-------|
-| Per-member "hide contact details" checkbox | Built | `hide_contact` field on member record; hides email/phone in group members list |
-| Per-group "show addresses to group leader" toggle | Partial | `show_addresses` field stored on group record, but **not yet wired into visibility logic** — currently only `hide_contact` is checked |
+| Per-member "hide contact details" checkbox | Partial | `hide_contact` field stored/editable, but **not yet enforced** in the group members view — see note below |
+| Per-group "show addresses to group leader" toggle | Partial | `show_addresses` field stored on group record, but **not yet wired into visibility logic** — see note below |
 | System-wide "hide address from group leaders" | Not started | Global setting from doc 4.2.4(b) not yet implemented |
+
+> **Why contact-hiding is deferred:** correct enforcement needs to distinguish a
+> *group leader* viewer from a *membership-admin* viewer (UG 4.2.4 hides contact
+> from leaders only). In Beacon2 the scoped privileges `group_records_as_leader` /
+> `group_records_as_member` are **seeded but not enforced anywhere** — every group
+> members view is gated solely by `group_records_all`, so there is no runtime
+> signal for "this viewer is a leader". Wiring `hide_contact`/`show_addresses`
+> therefore depends first on implementing the scoped group-leader access model.
+> Tracked in `KNOWN-ISSUES.md` → Group / Member Contact Hiding.
 
 ---
 
@@ -763,7 +772,7 @@
 | Aspect | Status | Notes |
 |--------|--------|-------|
 | All fields from Beacon doc 8.3 | Built | Stored and editable |
-| public_phone, public_email, home_page | Partial | Stored but not yet displayed to members (portal, joining form) |
+| public_phone, public_email, home_page | Built | Displayed as a "Need help? Contact us" block on the Members Portal sign-in page and the online Join form (shared `PublicContact` component, fed by the public `/:slug/info` and join-config endpoints) |
 | email_cards | Partial | Stored but auto-attach logic not wired |
 | gift_aid_online_renewals | Built | Controls Gift Aid checkboxes on portal renewal page |
 | online_renew_email | Built | Shown on portal renewal page as contact email |
@@ -1106,7 +1115,7 @@ These are features or architectural aspects of Beacon2 that have no counterpart 
 ### Key differences from Beacon
 
 1. **Login**: Both use username-based login; Beacon2 adds email fallback for legacy users
-2. **Hide address**: Beacon2 has both per-member `hide_contact` checkbox AND per-group `show_addresses` toggle (but `show_addresses` is stored, not yet wired into visibility logic — see KNOWN-ISSUES.md)
+2. **Hide address**: Beacon2 has both a per-member `hide_contact` checkbox AND a per-group `show_addresses` toggle, but **neither is yet enforced** in the group members view — enforcement depends first on implementing the scoped group-leader access model (`group_records_as_leader`), which is seeded but unused. See KNOWN-ISSUES.md → Group / Member Contact Hiding.
 3. **Financial year**: Configurable via `year_start_month` / `year_start_day` (default January = calendar year); same concept as Beacon
 4. **Architecture**: Both are multi-tenant; Beacon2 uses schema-per-tenant PostgreSQL; the UG describes a single tenant's view
 5. **Auth**: JWT + refresh token (vs Beacon's session-based auth)

--- a/docs/BeaconUG/7.10.5 Pending Transactions – u3a Beacon/input.md
+++ b/docs/BeaconUG/7.10.5 Pending Transactions – u3a Beacon/input.md
@@ -92,6 +92,12 @@ Bulk action tick-boxes are only present on Transactions that are:
 >
 > Are not in the Current financial year \*
 
+> *[Editor's note — transcribed verbatim from the original Beacon manual. This
+> bullet contradicts its own footnote below: bulk tick-boxes are present for
+> transactions that **are in** the current financial year, while those outside
+> it must be opened individually. Beacon2 follows the corrected behaviour. See
+> `docs/Beacon2UG/34-pending-transactions.md`.]*
+
 **\*** **This** **means** **that** **the** **Treasurer** **needs**
 **to** **confirm** **Pending** **for** **Transactions** **that** **are**
 **outside** **the** **current** **financial** **year** **by**

--- a/docs/ImprovementPlan-2026-06-14.md
+++ b/docs/ImprovementPlan-2026-06-14.md
@@ -220,12 +220,25 @@ and ends with the standard wrap-up (tests, lint, CHANGELOG, KNOWN-ISSUES).
   `assertActorHoldsRolePrivileges` escalation guard.
 - Reuse: `backend/src/__tests__/mocks.js`, existing setup patterns.
 
-### Chunk 7 — Completeness reconciliation *(medium; partly a decision task)*
+### Chunk 7 — Completeness reconciliation *(medium; partly a decision task)* — **DONE (2026-06-14)**
 - Build one authoritative parity-gap list; sync `docs/Beacon2UG-Comparison.md`.
 - Then pick the low-cost gaps to close now: wire `show_addresses`/`hide_contact`
   visibility, display `public_phone`/`public_email`, resolve the Calendar-export
   no-op, fix the doc 7.10.5 typo and the Ledger wording.
 - Larger gaps (PayPal, shared-email portal UX) stay deferred with explicit notes.
+
+**Outcome:** Closed: displayed `public_phone`/`public_email`/`home_page` on the
+Portal sign-in + Join form (new `PublicContact` component + `GET /:slug/info`);
+fixed the doc 7.10.5 eligibility wording (Beacon2 doc + editor's note on the UG
+transcription); aligned the "Central Ledger" wording. Owner decisions: Calendar
+export left as-is (placeholder message made accurate); `hide_contact`/
+`show_addresses` visibility **deferred with a clearer note** — re-verification
+showed it is bigger than assumed (the scoped group-leader privileges
+`group_records_as_leader`/`as_member` are seeded but enforced nowhere, so there
+is no runtime "viewer is a leader" signal; a naive version would wrongly hide
+contact from admins). Also corrected an inaccurate "Built" claim for
+`hide_contact` in the comparison doc. Larger gaps (PayPal, shared-email portal
+UX, system-wide hide-address) remain deferred.
 
 ### Chunk 8 — Documentation readability *(small)*
 - Add a TOC and/or split `CLAUDE-REFERENCE.md` by module; trim/archive old

--- a/docs/ImprovementPlan-2026-06-14.md
+++ b/docs/ImprovementPlan-2026-06-14.md
@@ -246,10 +246,17 @@ UX, system-wide hide-address) remain deferred.
   Claude-tooling-docs separation is obvious from the top of each file.
 - Fix the stale `App.jsx:132` comment (KI #26).
 
-### Chunk 9 — Frontend polish *(small; incremental)*
+### Chunk 9 — Frontend polish *(small; incremental)* — **IN PROGRESS (2026-06-14)**
 - Migrate a batch of pages from inline Tailwind to `inputCls`/`labelCls`
   constants; audit `react-hooks/exhaustive-deps` warnings (fix or annotate);
   add `htmlFor`/`id` to a batch of remaining lower-traffic pages.
+
+**Increment 1 (2026-06-14):** migrated the six **public** pages to the shared
+`inputCls`/`labelCls` constants (removing two local style dupes) and added
+`htmlFor`/`id` to the four public auth pages. Still open for future increments:
+the ~40 remaining pages on inline Tailwind, the ~30 `react-hooks/exhaustive-deps`
+warnings (KI Linting #2 — risky per-effect judgement, deferred), and the
+remaining lower-traffic pages lacking `htmlFor`/`id` (KI Accessibility #1).
 
 ### Chunk 10 — Tooling & dependency hygiene *(small/medium)*
 - Add `.nvmrc` / `engines` Node pin; bring `shared/` under lint/format.

--- a/frontend/src/__tests__/PortalLogin.test.jsx
+++ b/frontend/src/__tests__/PortalLogin.test.jsx
@@ -8,6 +8,12 @@ import PortalLogin from '../pages/public/PortalLogin.jsx';
 vi.mock('../lib/api.js', () => ({
   publicApi: {
     portalLogin: vi.fn(),
+    getPublicInfo: vi.fn().mockResolvedValue({
+      u3aName: 'Test u3a',
+      publicPhone: '',
+      publicEmail: '',
+      homePage: '',
+    }),
   },
 }));
 

--- a/frontend/src/components/PublicContact.jsx
+++ b/frontend/src/components/PublicContact.jsx
@@ -1,0 +1,42 @@
+// beacon2/frontend/src/components/PublicContact.jsx
+// Small footer block showing a u3a's public contact details (phone / email /
+// home page) on unauthenticated pages (Members Portal sign-in, online joining).
+// Renders nothing when none of the details are configured.
+
+export default function PublicContact({ phone, email, homePage, className = '' }) {
+  if (!phone && !email && !homePage) return null;
+
+  return (
+    <div className={`text-center text-xs text-slate-500 ${className}`}>
+      <p className="mb-1 font-medium text-slate-600">Need help? Contact us</p>
+      <ul className="space-y-0.5">
+        {phone && (
+          <li>
+            <a href={`tel:${phone}`} className="text-blue-700 hover:underline">
+              {phone}
+            </a>
+          </li>
+        )}
+        {email && (
+          <li>
+            <a href={`mailto:${email}`} className="text-blue-700 hover:underline">
+              {email}
+            </a>
+          </li>
+        )}
+        {homePage && (
+          <li>
+            <a
+              href={homePage}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-700 hover:underline"
+            >
+              Visit our website
+            </a>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/public.js
+++ b/frontend/src/lib/api/public.js
@@ -74,6 +74,8 @@ export const publicApi = {
     }),
 
   // Public information pages (unauthenticated)
+  getPublicInfo: (slug) => publicFetch(`${BASE}/public/${slug}/info`),
+
   getPublicGroups: (slug) => publicFetch(`${BASE}/public/${slug}/groups`),
 
   getPublicCalendar: (slug, params = {}) => {

--- a/frontend/src/pages/groups/GroupLedger.jsx
+++ b/frontend/src/pages/groups/GroupLedger.jsx
@@ -163,7 +163,7 @@ export default function GroupLedger({ groupId }) {
     <div>
       <h2 className="text-lg font-semibold mb-1">Group Cash</h2>
       <p className="text-xs text-slate-600 mb-3">
-        The group's own cash record — not linked to the u3a's central accounts. The Finance Ledger
+        The group's own cash record — not linked to the u3a's central accounts. The central ledger
         shows different, complementary transactions.
       </p>
 

--- a/frontend/src/pages/public/JoinForm.jsx
+++ b/frontend/src/pages/public/JoinForm.jsx
@@ -10,6 +10,7 @@ import { scrollToFirstFieldError } from '../../lib/scrollToError.js';
 import PortalVersion from '../../components/PortalVersion.jsx';
 import { UK_POSTCODE_RE } from '../../lib/constants.js';
 import FormError from '../../components/FormError.jsx';
+import PublicContact from '../../components/PublicContact.jsx';
 
 export default function JoinForm() {
   const { slug } = useParams();
@@ -612,6 +613,13 @@ export default function JoinForm() {
                 : `Make Payment${displayFee ? ` — £${displayFee.toFixed(2)}` : ''}`}
             </button>
           </form>
+
+          <PublicContact
+            phone={config?.publicPhone}
+            email={config?.publicEmail}
+            homePage={config?.homePage}
+            className="mt-6 pt-4 border-t border-slate-200"
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/public/JoinForm.jsx
+++ b/frontend/src/pages/public/JoinForm.jsx
@@ -11,6 +11,7 @@ import PortalVersion from '../../components/PortalVersion.jsx';
 import { UK_POSTCODE_RE } from '../../lib/constants.js';
 import FormError from '../../components/FormError.jsx';
 import PublicContact from '../../components/PublicContact.jsx';
+import { inputCls, labelCls } from '../../components/ui/Input.jsx';
 
 export default function JoinForm() {
   const { slug } = useParams();
@@ -225,7 +226,7 @@ export default function JoinForm() {
                 name="classId"
                 value={form.classId}
                 onChange={(e) => handleChange('classId', e.target.value)}
-                className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className={`${inputCls} w-full`}
               >
                 <option value="">— Select membership type —</option>
                 {config?.classes.map((c) => (
@@ -254,10 +255,7 @@ export default function JoinForm() {
               </legend>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
-                  <label
-                    htmlFor="join-title"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-title" className={labelCls}>
                     Title
                   </label>
                   <input
@@ -267,15 +265,12 @@ export default function JoinForm() {
                     value={form.title}
                     onChange={(e) => handleChange('title', e.target.value)}
                     placeholder="Mr, Mrs, Ms, Dr..."
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                   <FormError error={fieldErrors.title} />
                 </div>
                 <div>
-                  <label
-                    htmlFor="join-forenames"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-forenames" className={labelCls}>
                     First name <RequiredMark />
                   </label>
                   <input
@@ -284,15 +279,12 @@ export default function JoinForm() {
                     name="forenames"
                     value={form.forenames}
                     onChange={(e) => handleChange('forenames', e.target.value)}
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                   <FormError error={fieldErrors.forenames} />
                 </div>
                 <div>
-                  <label
-                    htmlFor="join-surname"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-surname" className={labelCls}>
                     Surname <RequiredMark />
                   </label>
                   <input
@@ -301,15 +293,12 @@ export default function JoinForm() {
                     name="surname"
                     value={form.surname}
                     onChange={(e) => handleChange('surname', e.target.value)}
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                   <FormError error={fieldErrors.surname} />
                 </div>
                 <div>
-                  <label
-                    htmlFor="join-email"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-email" className={labelCls}>
                     Email <RequiredMark />
                   </label>
                   <input
@@ -318,15 +307,12 @@ export default function JoinForm() {
                     name="email"
                     value={form.email}
                     onChange={(e) => handleChange('email', e.target.value)}
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                   <FormError error={fieldErrors.email} />
                 </div>
                 <div>
-                  <label
-                    htmlFor="join-mobile"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-mobile" className={labelCls}>
                     Mobile
                   </label>
                   <input
@@ -335,7 +321,7 @@ export default function JoinForm() {
                     name="mobile"
                     value={form.mobile}
                     onChange={(e) => handleChange('mobile', e.target.value)}
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                 </div>
               </div>
@@ -347,10 +333,7 @@ export default function JoinForm() {
                 <legend className="text-sm font-bold text-slate-700 mb-2">Second Person</legend>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
-                    <label
-                      htmlFor="join2-title"
-                      className="block text-sm font-medium text-slate-700 mb-1"
-                    >
+                    <label htmlFor="join2-title" className={labelCls}>
                       Title
                     </label>
                     <input
@@ -360,15 +343,12 @@ export default function JoinForm() {
                       value={form.p2Title}
                       onChange={(e) => handleChange('p2Title', e.target.value)}
                       placeholder="Mr, Mrs, Ms, Dr..."
-                      className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className={`${inputCls} w-full`}
                     />
                     <FormError error={fieldErrors.p2Title} />
                   </div>
                   <div>
-                    <label
-                      htmlFor="join2-forenames"
-                      className="block text-sm font-medium text-slate-700 mb-1"
-                    >
+                    <label htmlFor="join2-forenames" className={labelCls}>
                       First name <RequiredMark />
                     </label>
                     <input
@@ -377,15 +357,12 @@ export default function JoinForm() {
                       name="p2Forenames"
                       value={form.p2Forenames}
                       onChange={(e) => handleChange('p2Forenames', e.target.value)}
-                      className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className={`${inputCls} w-full`}
                     />
                     <FormError error={fieldErrors.p2Forenames} />
                   </div>
                   <div>
-                    <label
-                      htmlFor="join2-surname"
-                      className="block text-sm font-medium text-slate-700 mb-1"
-                    >
+                    <label htmlFor="join2-surname" className={labelCls}>
                       Surname <RequiredMark />
                     </label>
                     <input
@@ -394,15 +371,12 @@ export default function JoinForm() {
                       name="p2Surname"
                       value={form.p2Surname}
                       onChange={(e) => handleChange('p2Surname', e.target.value)}
-                      className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className={`${inputCls} w-full`}
                     />
                     <FormError error={fieldErrors.p2Surname} />
                   </div>
                   <div>
-                    <label
-                      htmlFor="join2-email"
-                      className="block text-sm font-medium text-slate-700 mb-1"
-                    >
+                    <label htmlFor="join2-email" className={labelCls}>
                       Email
                     </label>
                     <input
@@ -411,15 +385,12 @@ export default function JoinForm() {
                       name="p2Email"
                       value={form.p2Email}
                       onChange={(e) => handleChange('p2Email', e.target.value)}
-                      className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className={`${inputCls} w-full`}
                     />
                     <FormError error={fieldErrors.p2Email} />
                   </div>
                   <div>
-                    <label
-                      htmlFor="join2-mobile"
-                      className="block text-sm font-medium text-slate-700 mb-1"
-                    >
+                    <label htmlFor="join2-mobile" className={labelCls}>
                       Mobile
                     </label>
                     <input
@@ -428,7 +399,7 @@ export default function JoinForm() {
                       name="p2Mobile"
                       value={form.p2Mobile}
                       onChange={(e) => handleChange('p2Mobile', e.target.value)}
-                      className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className={`${inputCls} w-full`}
                     />
                   </div>
                 </div>
@@ -442,10 +413,7 @@ export default function JoinForm() {
               </legend>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
-                  <label
-                    htmlFor="join-house-no"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-house-no" className={labelCls}>
                     House no / name
                   </label>
                   <input
@@ -459,10 +427,7 @@ export default function JoinForm() {
                   <FormError error={fieldErrors.houseNo} size="xs" />
                 </div>
                 <div>
-                  <label
-                    htmlFor="join-street"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-street" className={labelCls}>
                     Street
                   </label>
                   <input
@@ -471,14 +436,11 @@ export default function JoinForm() {
                     name="street"
                     value={form.street}
                     onChange={(e) => handleChange('street', e.target.value)}
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                 </div>
                 <div>
-                  <label
-                    htmlFor="join-town"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-town" className={labelCls}>
                     Town
                   </label>
                   <input
@@ -487,14 +449,11 @@ export default function JoinForm() {
                     name="town"
                     value={form.town}
                     onChange={(e) => handleChange('town', e.target.value)}
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                 </div>
                 <div>
-                  <label
-                    htmlFor="join-county"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-county" className={labelCls}>
                     County
                   </label>
                   <input
@@ -503,14 +462,11 @@ export default function JoinForm() {
                     name="county"
                     value={form.county}
                     onChange={(e) => handleChange('county', e.target.value)}
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                 </div>
                 <div>
-                  <label
-                    htmlFor="join-postcode"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-postcode" className={labelCls}>
                     Postcode <RequiredMark />
                   </label>
                   <input
@@ -519,15 +475,12 @@ export default function JoinForm() {
                     name="postcode"
                     value={form.postcode}
                     onChange={(e) => handleChange('postcode', e.target.value.toUpperCase())}
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                   <FormError error={fieldErrors.postcode} />
                 </div>
                 <div>
-                  <label
-                    htmlFor="join-telephone"
-                    className="block text-sm font-medium text-slate-700 mb-1"
-                  >
+                  <label htmlFor="join-telephone" className={labelCls}>
                     Telephone
                   </label>
                   <input
@@ -536,7 +489,7 @@ export default function JoinForm() {
                     name="telephone"
                     value={form.telephone}
                     onChange={(e) => handleChange('telephone', e.target.value)}
-                    className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className={`${inputCls} w-full`}
                   />
                 </div>
               </div>

--- a/frontend/src/pages/public/PortalForgotPassword.jsx
+++ b/frontend/src/pages/public/PortalForgotPassword.jsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { publicApi } from '../../lib/api.js';
 import PortalVersion from '../../components/PortalVersion.jsx';
+import { inputCls, labelCls } from '../../components/ui/Input.jsx';
 
 export default function PortalForgotPassword() {
   const { slug } = useParams();
@@ -63,13 +64,16 @@ export default function PortalForgotPassword() {
         )}
         <form onSubmit={handleSubmit} noValidate>
           <div className="mb-4">
-            <label className="block text-sm font-medium text-slate-700 mb-1">Email address</label>
+            <label htmlFor="portal-forgot-email" className={labelCls}>
+              Email address
+            </label>
             <input
+              id="portal-forgot-email"
               type="email"
               name="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className={`${inputCls} w-full`}
               autoComplete="email"
             />
           </div>

--- a/frontend/src/pages/public/PortalLogin.jsx
+++ b/frontend/src/pages/public/PortalLogin.jsx
@@ -7,6 +7,7 @@ import { publicApi, setPortalToken } from '../../lib/api.js';
 import PortalVersion from '../../components/PortalVersion.jsx';
 import PasswordInput from '../../components/PasswordInput.jsx';
 import PublicContact from '../../components/PublicContact.jsx';
+import { inputCls, labelCls } from '../../components/ui/Input.jsx';
 import { SS_PORTAL_MEMBER, SS_PORTAL_SLUG } from '../../lib/storageKeys.js';
 
 export default function PortalLogin() {
@@ -61,24 +62,30 @@ export default function PortalLogin() {
 
         <form onSubmit={handleSubmit} noValidate>
           <div className="mb-4">
-            <label className="block text-sm font-medium text-slate-700 mb-1">Email address</label>
+            <label htmlFor="portal-login-email" className={labelCls}>
+              Email address
+            </label>
             <input
+              id="portal-login-email"
               type="email"
               name="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className={`${inputCls} w-full`}
               autoComplete="email"
             />
           </div>
 
           <div className="mb-6">
-            <label className="block text-sm font-medium text-slate-700 mb-1">Password</label>
+            <label htmlFor="portal-login-password" className={labelCls}>
+              Password
+            </label>
             <PasswordInput
+              id="portal-login-password"
               name="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className={`${inputCls} w-full`}
               autoComplete="current-password"
             />
           </div>

--- a/frontend/src/pages/public/PortalLogin.jsx
+++ b/frontend/src/pages/public/PortalLogin.jsx
@@ -1,11 +1,12 @@
 // beacon2/frontend/src/pages/public/PortalLogin.jsx
 // Members Portal sign-in page (public, unauthenticated).
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { publicApi, setPortalToken } from '../../lib/api.js';
 import PortalVersion from '../../components/PortalVersion.jsx';
 import PasswordInput from '../../components/PasswordInput.jsx';
+import PublicContact from '../../components/PublicContact.jsx';
 import { SS_PORTAL_MEMBER, SS_PORTAL_SLUG } from '../../lib/storageKeys.js';
 
 export default function PortalLogin() {
@@ -15,6 +16,14 @@ export default function PortalLogin() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [info, setInfo] = useState(null);
+
+  useEffect(() => {
+    publicApi
+      .getPublicInfo(slug)
+      .then(setInfo)
+      .catch(() => setInfo(null));
+  }, [slug]);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -100,6 +109,15 @@ export default function PortalLogin() {
             Not a member? Join online
           </Link>
         </div>
+
+        {info && (
+          <PublicContact
+            phone={info.publicPhone}
+            email={info.publicEmail}
+            homePage={info.homePage}
+            className="mt-6 pt-4 border-t border-slate-200"
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/public/PortalPersonalDetails.jsx
+++ b/frontend/src/pages/public/PortalPersonalDetails.jsx
@@ -8,6 +8,7 @@ import PortalVersion from '../../components/PortalVersion.jsx';
 import PasswordInput from '../../components/PasswordInput.jsx';
 import { SS_PORTAL_MEMBER } from '../../lib/storageKeys.js';
 import FormError from '../../components/FormError.jsx';
+import { inputCls as sharedInputCls, labelCls } from '../../components/ui/Input.jsx';
 
 export default function PortalPersonalDetails() {
   const { slug } = useParams();
@@ -260,9 +261,7 @@ export default function PortalPersonalDetails() {
     );
   }
 
-  const inputCls =
-    'w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
-  const labelCls = 'block text-sm font-medium text-slate-700 mb-1';
+  const inputCls = `${sharedInputCls} w-full`;
 
   return (
     <div className="relative min-h-screen bg-gradient-to-br from-blue-50 to-slate-100 px-4 py-8">

--- a/frontend/src/pages/public/PortalRegister.jsx
+++ b/frontend/src/pages/public/PortalRegister.jsx
@@ -9,6 +9,7 @@ import { scrollToFirstFieldError } from '../../lib/scrollToError.js';
 import PortalVersion from '../../components/PortalVersion.jsx';
 import PasswordInput from '../../components/PasswordInput.jsx';
 import FormError from '../../components/FormError.jsx';
+import { inputCls, labelCls } from '../../components/ui/Input.jsx';
 
 export default function PortalRegister() {
   const { slug } = useParams();
@@ -98,8 +99,7 @@ export default function PortalRegister() {
     );
   }
 
-  const fieldCss =
-    'w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
+  const fieldCss = `${inputCls} w-full`;
 
   return (
     <div className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-slate-100 px-4 py-8">
@@ -119,10 +119,11 @@ export default function PortalRegister() {
         <form onSubmit={handleSubmit} noValidate>
           <div className="space-y-3 mb-6">
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="pr-membership-number" className={labelCls}>
                 Membership number <RequiredMark />
               </label>
               <input
+                id="pr-membership-number"
                 type="number"
                 name="membershipNumber"
                 value={form.membershipNumber}
@@ -132,10 +133,11 @@ export default function PortalRegister() {
               <FormError error={fieldErrors.membershipNumber} />
             </div>
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="pr-forename" className={labelCls}>
                 Forename <RequiredMark />
               </label>
               <input
+                id="pr-forename"
                 type="text"
                 name="forename"
                 value={form.forename}
@@ -145,10 +147,11 @@ export default function PortalRegister() {
               <FormError error={fieldErrors.forename} />
             </div>
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="pr-surname" className={labelCls}>
                 Surname <RequiredMark />
               </label>
               <input
+                id="pr-surname"
                 type="text"
                 name="surname"
                 value={form.surname}
@@ -158,10 +161,11 @@ export default function PortalRegister() {
               <FormError error={fieldErrors.surname} />
             </div>
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="pr-postcode" className={labelCls}>
                 Postcode <RequiredMark />
               </label>
               <input
+                id="pr-postcode"
                 type="text"
                 name="postcode"
                 value={form.postcode}
@@ -171,10 +175,11 @@ export default function PortalRegister() {
               <FormError error={fieldErrors.postcode} />
             </div>
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="pr-email" className={labelCls}>
                 Email address <RequiredMark />
               </label>
               <input
+                id="pr-email"
                 type="email"
                 name="email"
                 value={form.email}
@@ -193,10 +198,11 @@ export default function PortalRegister() {
             </p>
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">
+                <label htmlFor="pr-password" className={labelCls}>
                   Password <RequiredMark />
                 </label>
                 <PasswordInput
+                  id="pr-password"
                   name="password"
                   value={form.password}
                   onChange={(e) => handleChange('password', e.target.value)}
@@ -206,10 +212,11 @@ export default function PortalRegister() {
                 <FormError error={fieldErrors.password} />
               </div>
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">
+                <label htmlFor="pr-confirm-password" className={labelCls}>
                   Confirm password <RequiredMark />
                 </label>
                 <PasswordInput
+                  id="pr-confirm-password"
                   name="confirmPassword"
                   value={form.confirmPassword}
                   onChange={(e) => handleChange('confirmPassword', e.target.value)}

--- a/frontend/src/pages/public/PortalResetPassword.jsx
+++ b/frontend/src/pages/public/PortalResetPassword.jsx
@@ -5,6 +5,7 @@ import { useParams, useSearchParams, Link } from 'react-router-dom';
 import { publicApi } from '../../lib/api.js';
 import PortalVersion from '../../components/PortalVersion.jsx';
 import PasswordInput from '../../components/PasswordInput.jsx';
+import { inputCls, labelCls } from '../../components/ui/Input.jsx';
 
 export default function PortalResetPassword() {
   const { slug } = useParams();
@@ -82,24 +83,28 @@ export default function PortalResetPassword() {
         )}
         <form onSubmit={handleSubmit} noValidate>
           <div className="mb-3">
-            <label className="block text-sm font-medium text-slate-700 mb-1">New password</label>
+            <label htmlFor="portal-reset-password" className={labelCls}>
+              New password
+            </label>
             <PasswordInput
+              id="portal-reset-password"
               name="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className={`${inputCls} w-full`}
               autoComplete="new-password"
             />
           </div>
           <div className="mb-6">
-            <label className="block text-sm font-medium text-slate-700 mb-1">
+            <label htmlFor="portal-reset-confirm" className={labelCls}>
               Confirm password
             </label>
             <PasswordInput
+              id="portal-reset-confirm"
               name="confirm"
               value={confirm}
               onChange={(e) => setConfirm(e.target.value)}
-              className="w-full border border-slate-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className={`${inputCls} w-full`}
               autoComplete="new-password"
             />
           </div>

--- a/frontend/src/pages/teams/TeamLedger.jsx
+++ b/frontend/src/pages/teams/TeamLedger.jsx
@@ -166,7 +166,7 @@ export default function TeamLedger({ teamId }) {
     <div>
       <h2 className="text-lg font-semibold mb-1">Team Cash</h2>
       <p className="text-xs text-slate-600 mb-3">
-        The team's own cash record — not linked to the u3a's central accounts. The Finance Ledger
+        The team's own cash record — not linked to the u3a's central accounts. The central ledger
         shows different, complementary transactions.
       </p>
 


### PR DESCRIPTION
Two sessions of work from `docs/ImprovementPlan-2026-06-14.md`, each re-verifying its findings before editing.

## Chunk 7 — Completeness reconciliation
**Closed:**
- **Public u3a contact details** — `public_phone`/`public_email`/`home_page` (stored but shown nowhere) now render as a shared "Need help? Contact us" block (`PublicContact.jsx`) on the Members Portal sign-in page and the online Join form. Backed by a new public `GET /:slug/info` endpoint + three extra join-config fields.
- **Doc 7.10.5 typo** — documented the correct pending-transaction bulk eligibility (in-year, non-cleared, non-batched) in the Beacon2 guide; added an editor's note to the faithful UG transcription flagging the contradictory bullet in the original manual.
- **Ledger wording** — aligned the Group/Team Cash description line to "central ledger", matching the "Central Ledger" button.

**Owner decisions:**
- **Calendar export** → left as-is; placeholder message reworded to accurately state events export with the Groups sheet.
- **`hide_contact`/`show_addresses` visibility** → deferred with a clearer note. Re-verification found it is bigger than the plan assumed: the scoped group-leader privileges (`group_records_as_leader`/`as_member`) are seeded but **enforced nowhere**, so there's no runtime "viewer is a leader" signal — correct contact-hiding depends first on that model. Also corrected an inaccurate "Built" claim for `hide_contact` in the comparison doc.

## Chunk 9 — Frontend polish (increment 1)
- Migrated the six **public** pages (`PortalLogin`, `PortalRegister`, `PortalResetPassword`, `PortalForgotPassword`, `JoinForm`, `PortalPersonalDetails`) from inline Tailwind input/label strings to the shared `inputCls`/`labelCls` constants, removing two duplicated local style definitions.
- Added `htmlFor`/`id` label associations to every field on the four public auth pages (screen-reader + Playwright `getByLabel` support).

Remaining incremental work (inline Tailwind on ~40 pages, `exhaustive-deps` warnings, more `htmlFor` pages) is left for future increments and tracked in `KNOWN-ISSUES.md`.

## Verification
- Backend: **608 tests pass** (added `/:slug/info` coverage).
- Frontend: **196 tests pass**.
- Lint **0 errors** (only pre-existing `exhaustive-deps` warnings), format clean, both packages.

## Docs
`CHANGELOG.md`, `KNOWN-ISSUES.md` (items moved to FIXED/ACCEPTED, contact-hiding note rewritten, a11y item updated), `docs/BeaconUG-Comparison.md` (status corrections + deferral note), and `docs/ImprovementPlan-2026-06-14.md` (Chunk 7 DONE, Chunk 9 IN PROGRESS).

https://claude.ai/code/session_01S1ium6x8FokEtEjy8JA2i8

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1ium6x8FokEtEjy8JA2i8)_