### PR TITLE
ci: skip Claude security review on Dependabot PRs

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   security-review:
     name: Claude security review
+    # Dependabot PRs run with a read-only token and do not receive repository
+    # secrets, so ANTHROPIC_API_KEY is empty and the action fails. They only
+    # touch dependency manifests/lockfiles, so skip the AI security review.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

The **Claude security review** check fails on every Dependabot PR (e.g. #447) with:

```
ANTHROPIC_API_KEY is not set. Please provide the claude-api-key input to the action.
```

This is not a code problem. GitHub runs Dependabot-triggered workflows with a read-only token and **does not pass repository Actions secrets to them**, so `secrets.ANTHROPIC_API_KEY` resolves to empty and the action exits 1. On #447 the actual dependency bump is fine — both Backend tests and Frontend tests pass; only this job fails, leaving the PR `unstable`.

## Fix

Skip the security-review job when the PR is opened by Dependabot:

```yaml
if: github.actor != 'dependabot[bot]'
```

Dependabot PRs only touch dependency manifests/lockfiles, so the AI security scan adds little there. Human-authored PRs are unaffected and still get the full review.

After this merges, re-run (or close/reopen) #447 and its security-review check will be skipped rather than failing.

https://claude.ai/code/session_01NP3JhQQN82wPXxceiqtriW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NP3JhQQN82wPXxceiqtriW)_