### PR TITLE
docs: record Render Docker-build fix and confirm DATABASE_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ under the Unreleased headings below).
 
 ---
 
+## [Unreleased] — 2026-08-01
+
+### Fixed
+- **Render backend deploy failures after the rename** — the Render service had
+  ended up in **Docker** mode (auto-detected `backend/Dockerfile` via the "New
+  Web Service" wizard rather than `render.yaml` via "New → Blueprint") with a
+  build context that didn't match what that Dockerfile expects, breaking every
+  deploy (`COPY backend/ ./backend/: not found`). Fixed in Render's dashboard
+  by setting Dockerfile Path = `backend/Dockerfile` and Docker Build Context
+  Directory = `.`, without recreating the service or its database link. See
+  `DEPLOYMENT.md` → Troubleshooting and `KNOWN-ISSUES.md` → Render / Deployment.
+- Confirmed `DATABASE_URL` on Render holds the real connection string (not
+  just a copied label).
+
 ## [Unreleased] — 2026-07-31
 
 ### Fixed

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -152,6 +152,27 @@ Then go to the `beacon2026-backend` service and click **Manual Deploy → Deploy
 The app will restart and, if no admin exists, create a new one. If one already exists,
 delete the user record from the database first via Render's database dashboard.
 
+**Render build fails with `COPY backend/ ./backend/: ... not found` (or similar for `shared/`)**
+This means the service was set up as a **Docker** environment instead of **Node**, most
+likely because it was created via Render's "New Web Service" wizard (which auto-detects
+[`backend/Dockerfile`](backend/Dockerfile) and defaults to Docker) rather than via
+**New → Blueprint** pointing at `render.yaml` (see Step 2 — this is the supported path
+and always creates a correctly-configured Node service). `backend/Dockerfile` is for local
+dev/E2E only and expects a repo-root build context; a wizard-created Docker service
+normally has its Root Directory set to `backend`, which breaks that Dockerfile's `COPY`
+paths.
+
+Render does not let you switch an existing service's environment (Docker ↔ Node) after
+creation. Two ways out, without needing to recreate the service and re-link the database:
+- In **Settings → Build & Deploy**, set **Dockerfile Path** to `backend/Dockerfile` and
+  **Docker Build Context Directory** to `.` (repo root) — this makes the existing Docker
+  service build correctly instead of switching it to Node.
+- Or recreate the service via **New → Blueprint** (the Step 2 path) if you're able to
+  re-link to the existing database (`beacon2_a89s`) cleanly — riskier, only do this if the
+  Docker-context fix above doesn't work.
+
+(This happened once, 2026-08-01, after renaming the Render service — see CHANGELOG.)
+
 ---
 
 ## Replacing the database (e.g. free tier expiry)

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -499,7 +499,16 @@ All items in this section have been completed (v0.8.6).
   database itself also can't be renamed, it stays `beacon2_a89s`) or add a
   custom domain. Left as-is for now since it's cosmetic only; revisit if a
   custom domain is wanted before general availability.
-- `[OPEN]` **Verify `DATABASE_URL` on Render is the actual connection string**,
-  not just a copied label — worth a quick visual check in the dashboard before
-  going live, since this wasn't independently confirmed during the 2026-07-31
-  rename clean-up session (see CHANGELOG).
+- `[FIXED]` **`DATABASE_URL` on Render confirmed correct** — checked in the
+  dashboard 2026-08-01, holds the real internal connection string, not just a
+  label.
+- `[FIXED]` **Render backend service was in Docker mode with the wrong build
+  context, breaking every deploy** (`COPY backend/ ./backend/: not found`).
+  Happened because the service was recreated via Render's "New Web Service"
+  wizard rather than "New → Blueprint" against `render.yaml`, so it
+  auto-detected `backend/Dockerfile` and defaulted to Docker with Root
+  Directory `backend` — but that Dockerfile expects a repo-root build
+  context. Fixed 2026-08-01 by setting Dockerfile Path =
+  `backend/Dockerfile` and Docker Build Context Directory = `.` in Render's
+  service settings, without recreating the service. See
+  `DEPLOYMENT.md` → Troubleshooting for the general fix if this recurs.


### PR DESCRIPTION
## Summary
- Documents the Render Docker-vs-Node build-context issue hit after the rename, and its fix, in DEPLOYMENT.md's troubleshooting section and KNOWN-ISSUES.md.
- Confirms DATABASE_URL was verified correct in the Render dashboard.

Docs-only change, no code touched.