### PR TITLE
Fix system admin header showing "Beacon2" instead of "Beacon2026"

### DIFF
--- a/frontend/src/pages/system/SystemDashboard.jsx
+++ b/frontend/src/pages/system/SystemDashboard.jsx
@@ -257,7 +257,7 @@ export default function SystemDashboard() {
       {/* Header */}
       <header className="bg-white shadow-sm px-6 py-4 flex items-center justify-between">
         <h1 className="text-xl font-bold text-slate-800">
-          Beacon<span className="text-blue-600">2</span>
+          Beacon<span className="text-blue-600">2026</span>
           <span className="text-slate-400 font-normal text-base ml-2">/ System Admin</span>
         </h1>
         <div className="flex items-center gap-4">

--- a/frontend/src/pages/system/SystemLogin.jsx
+++ b/frontend/src/pages/system/SystemLogin.jsx
@@ -34,7 +34,7 @@ export default function SystemLogin() {
       <div className="bg-white rounded-xl shadow-md w-full max-w-md p-8">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-slate-800">
-            Beacon<span className="text-blue-600">2</span>
+            Beacon<span className="text-blue-600">2026</span>
           </h1>
           <p className="text-slate-500 text-sm mt-1">System administration</p>
           <p className="text-slate-400 text-xs mt-0.5">v{__APP_VERSION__}</p>


### PR DESCRIPTION
## Summary
- The System Admin login and dashboard headers hardcoded "Beacon2" instead of "Beacon2026".
- Updated both to display "Beacon2026".

## Test plan
- [ ] Load /system/login and confirm header reads "Beacon2026"
- [ ] Load /system dashboard and confirm header reads "Beacon2026"