### PR TITLE
Fix system admin header showing Beacon2 instead of Beacon2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ under the Unreleased headings below).
 ## [Unreleased] — 2026-08-01
 
 ### Fixed
+- **System admin "Create tenant" errors showed only "Validation error" with no
+  detail** — `system.js`'s `systemFetch()` (frontend `lib/api/system.js`) threw
+  `Error(b.error)`, which is just the generic label the backend's
+  `errorHandler.js` sends for a `ZodError`; the actual per-field messages sit
+  in the response's `issues` array and were being dropped. `systemFetch` now
+  builds the thrown error message from `issues` (e.g. `adminPassword:
+  Password must contain at least one uppercase, one lowercase, and one
+  numeric character.`) when present, falling back to `error` otherwise. Fixes
+  every system-admin action that goes through `systemFetch` (tenant create,
+  settings updates, etc.), not just tenant creation.
 - **System admin header still read "Beacon2"** in `SystemLogin.jsx` and
   `SystemDashboard.jsx` — a leftover from before the beacon2 → beacon2026
   rename that the text-rename script (see 2026-07-31 entry below) missed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ under the Unreleased headings below).
 ## [Unreleased] — 2026-08-01
 
 ### Fixed
+- **System admin header still read "Beacon2"** in `SystemLogin.jsx` and
+  `SystemDashboard.jsx` — a leftover from before the beacon2 → beacon2026
+  rename that the text-rename script (see 2026-07-31 entry below) missed
+  because the "2026" was split across JSX text and a `<span>`. Both now read
+  "Beacon2026".
+- **`beacon2026.vercel.app` login failed with "Failed to fetch"** while
+  `beacon2.vercel.app` kept working — the backend's `CORS_ORIGIN` on Render
+  was still allowlisting only the old `beacon2.vercel.app` origin, so the
+  browser silently blocked the cross-origin fetch from the new domain.
+  Updated `CORS_ORIGIN` to `https://beacon2026.vercel.app`, which is now the
+  canonical frontend domain; `beacon2.vercel.app` is retired.
 - **Render backend deploy failures after the rename** — the Render service had
   ended up in **Docker** mode (auto-detected `backend/Dockerfile` via the "New
   Web Service" wizard rather than `render.yaml` via "New → Blueprint") with a

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -491,6 +491,15 @@ All items in this section have been completed (v0.8.6).
 
 ## Render / Deployment — Deferred Items
 
+- `[FIXED]` **`beacon2026.vercel.app` login failed with "Failed to fetch"
+  while `beacon2.vercel.app` still worked.** Cause: `CORS_ORIGIN` on Render
+  was left pointing at the old `beacon2.vercel.app` domain after the rename,
+  so the browser blocked the cross-origin request from the new one (no CORS
+  headers = generic fetch failure, not a helpful error). Fixed by setting
+  `CORS_ORIGIN` to `https://beacon2026.vercel.app` in Render. That domain is
+  now canonical; `beacon2.vercel.app` is retired. Also fixed in the same pass:
+  `SystemLogin.jsx`/`SystemDashboard.jsx` still hardcoded a "Beacon2" header
+  (PR #465). Resolved 2026-08-01.
 - `[ACCEPTED]` **Backend service keeps the `beacon2-backend.onrender.com` URL.**
   Renaming a Render service (done 2026-07-30, beacon2 → beacon2026) does not
   change its auto-generated `*.onrender.com` hostname — Render never renames

--- a/frontend/src/__tests__/api-system.test.js
+++ b/frontend/src/__tests__/api-system.test.js
@@ -1,0 +1,49 @@
+// beacon2026/frontend/src/__tests__/api-system.test.js
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { system } from '../lib/api/system.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('system.createTenant error handling', () => {
+  it('surfaces the Zod issue message when validation fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: () =>
+          Promise.resolve({
+            error: 'Validation error',
+            issues: [
+              {
+                path: 'adminPassword',
+                message:
+                  'Password must contain at least one uppercase, one lowercase, and one numeric character.',
+              },
+            ],
+          }),
+      }),
+    );
+
+    await expect(system.createTenant('token', {})).rejects.toThrow(
+      'adminPassword: Password must contain at least one uppercase, one lowercase, and one numeric character.',
+    );
+  });
+
+  it('falls back to the plain error message when there are no issues', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: () => Promise.resolve({ error: 'A u3a with that slug already exists.' }),
+      }),
+    );
+
+    await expect(system.createTenant('token', {})).rejects.toThrow(
+      'A u3a with that slug already exists.',
+    );
+  });
+});

--- a/frontend/src/lib/api/system.js
+++ b/frontend/src/lib/api/system.js
@@ -23,7 +23,12 @@ export function hasSysToken() {
 function systemFetch(url, options = {}) {
   return fetch(url, options).then((r) =>
     r.json().then((b) => {
-      if (!r.ok) throw new Error(b.error ?? `HTTP ${r.status}`);
+      if (!r.ok) {
+        const detail = Array.isArray(b.issues)
+          ? b.issues.map((i) => (i.path ? `${i.path}: ${i.message}` : i.message)).join('; ')
+          : null;
+        throw new Error(detail || b.error || `HTTP ${r.status}`);
+      }
       return b;
     }),
   );

--- a/frontend/src/pages/system/SystemDashboard.jsx
+++ b/frontend/src/pages/system/SystemDashboard.jsx
@@ -257,7 +257,7 @@ export default function SystemDashboard() {
       {/* Header */}
       <header className="bg-white shadow-sm px-6 py-4 flex items-center justify-between">
         <h1 className="text-xl font-bold text-slate-800">
-          Beacon<span className="text-blue-600">2</span>
+          Beacon<span className="text-blue-600">2026</span>
           <span className="text-slate-400 font-normal text-base ml-2">/ System Admin</span>
         </h1>
         <div className="flex items-center gap-4">

--- a/frontend/src/pages/system/SystemLogin.jsx
+++ b/frontend/src/pages/system/SystemLogin.jsx
@@ -34,7 +34,7 @@ export default function SystemLogin() {
       <div className="bg-white rounded-xl shadow-md w-full max-w-md p-8">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-slate-800">
-            Beacon<span className="text-blue-600">2</span>
+            Beacon<span className="text-blue-600">2026</span>
           </h1>
           <p className="text-slate-500 text-sm mt-1">System administration</p>
           <p className="text-slate-400 text-xs mt-0.5">v{__APP_VERSION__}</p>


### PR DESCRIPTION
## Summary
- The System Admin login and dashboard headers hardcoded "Beacon2" instead of "Beacon2026".
- Updated both to display "Beacon2026".

## Test plan
- [ ] Load /system/login and confirm header reads "Beacon2026"
- [ ] Load /system dashboard and confirm header reads "Beacon2026"

🤖 Generated with [Claude Code](https://claude.com/claude-code)