### PR TITLE
Fix password-change logout, audit login/logout/timeout, add demo bann…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,36 @@ under the Unreleased headings below).
 
 ## [Unreleased] — 2026-08-01
 
+### Added
+- **Login, logout, and session-timeout events are now written to the audit
+  log** — previously the tenant `audit_log` captured `login_failed`,
+  `login_locked`, `change_password` and `force_change_password`, but not a
+  successful login or a logout. `loginUser()` (`authService.js`) now logs
+  `action: 'login'` on success, `POST /auth/logout` logs `action: 'logout'`,
+  and a new `POST /auth/session-timeout` endpoint (called by `AuthContext.jsx`
+  when the client-side inactivity timer fires) logs `action: 'session_timeout'`
+  — the only one of the three that can only be detected in the browser.
+- **"Not available in this demo" banners** on the three features that aren't
+  wired up in this demo environment: sending email (`EmailCompose.jsx`), the
+  email unblocker (`EmailUnblocker.jsx`), and the "Online Payments (PayPal)"
+  panel in `SystemSettings.jsx`. New shared `DemoUnavailableBanner.jsx`
+  component.
+- **Temporary "NEW" badges on the main menu** next to Teams, Utilities, SQL
+  reports, Feature configuration and Event types — sections that don't exist
+  in the original Beacon, to help admins used to Beacon spot what's new in
+  beacon2026. Implemented as an `isNew` flag on the `Home.jsx` menu items;
+  see `KNOWN-ISSUES.md` for the removal note once this is no longer needed.
+
 ### Fixed
+- **Changing your password logged you out on the next screen** —
+  `POST /auth/change-password` and `POST /auth/force-change-password` revoke
+  all of the user's refresh tokens (correct, to kill other sessions) but
+  never issued a new one for the session making the request, unlike
+  `/auth/login` and `/auth/refresh`. The browser kept its now-revoked refresh
+  cookie, so the next token refresh failed with "Invalid refresh token." and
+  force-logged the user out. Both routes now call the new
+  `issueRefreshToken()` helper (`authService.js`) and set a fresh refresh
+  cookie, exactly like login/refresh do.
 - **System admin "Create tenant" errors showed only "Validation error" with no
   detail** — `system.js`'s `systemFetch()` (frontend `lib/api/system.js`) threw
   `Error(b.error)`, which is just the generic label the backend's

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -521,3 +521,14 @@ All items in this section have been completed (v0.8.6).
   `backend/Dockerfile` and Docker Build Context Directory = `.` in Render's
   service settings, without recreating the service. See
   `DEPLOYMENT.md` → Troubleshooting for the general fix if this recurs.
+
+## Temporary UI — Deferred Items
+
+- `[DEFERRED]` **Menu "NEW" badges are temporary and should be removed.**
+  Added 2026-08-01 to call out the sections that are genuinely new in
+  beacon2026 vs the original Beacon (Teams, Utilities, SQL reports, Feature
+  configuration, Event types) for admins who are used to Beacon. Implemented
+  as `isNew: true` on the relevant item objects in `Home.jsx`'s `sections`
+  array, rendered via the top-level `NewBadge()` function in the same file.
+  Once admins no longer need the callout, delete the `isNew` flags and the
+  `NewBadge` component/render calls.

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -30,6 +30,7 @@ vi.mock('../services/authService.js', () => ({
   logoutUser: vi.fn().mockResolvedValue(undefined),
   refreshTokens: vi.fn(),
   loginSysAdmin: vi.fn(),
+  issueRefreshToken: vi.fn().mockResolvedValue('new.refresh.token'),
 }));
 
 const { default: app } = await import('../app.js');

--- a/backend/src/__tests__/authService.test.js
+++ b/backend/src/__tests__/authService.test.js
@@ -153,8 +153,13 @@ describe('loginUser — failed-login lockout (H2)', () => {
     expect(resetCall).toBeTruthy();
     expect(resetCall[2]).toEqual(['u1']);
 
-    // A successful login is not an audit "failed/locked" event.
-    expect(logAudit).not.toHaveBeenCalled();
+    // A successful login is audited as 'login', not a failed/locked event.
+    expect(logAudit).toHaveBeenCalledWith(
+      TENANT,
+      expect.objectContaining({
+        action: 'login',
+      }),
+    );
   });
 
   it('does not touch the counter when the user does not exist', async () => {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -4,7 +4,13 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import sgMail from '@sendgrid/mail';
-import { loginUser, logoutUser, refreshTokens, loginSysAdmin } from '../services/authService.js';
+import {
+  loginUser,
+  logoutUser,
+  refreshTokens,
+  loginSysAdmin,
+  issueRefreshToken,
+} from '../services/authService.js';
 import { requireAuth } from '../middleware/auth.js';
 import { tenantQuery, prisma } from '../utils/db.js';
 import { verifyPassword, hashPassword } from '../utils/password.js';
@@ -89,8 +95,38 @@ router.post('/logout', requireAuth, async (req, res, next) => {
     const refreshToken = req.cookies?.[COOKIE_NAME];
     await logoutUser(req.user.tenantSlug, refreshToken);
 
+    logAudit(req.user.tenantSlug, {
+      userId: req.user.userId,
+      userName: req.user.name,
+      action: 'logout',
+      entityType: 'user',
+      entityId: req.user.userId,
+      entityName: req.user.name,
+    });
+
     res.clearCookie(COOKIE_NAME);
     res.json({ message: 'Logged out successfully.' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── POST /auth/session-timeout ───────────────────────────────────────────
+// Fired by the frontend when a session ends due to inactivity, purely so the
+// event is recorded — the frontend has already cleared its own state by the
+// time this call is made (fire-and-forget).
+
+router.post('/session-timeout', requireAuth, async (req, res, next) => {
+  try {
+    logAudit(req.user.tenantSlug, {
+      userId: req.user.userId,
+      userName: req.user.name,
+      action: 'session_timeout',
+      entityType: 'user',
+      entityId: req.user.userId,
+      entityName: req.user.name,
+    });
+    res.json({ message: 'Recorded.' });
   } catch (err) {
     next(err);
   }
@@ -179,11 +215,16 @@ router.post('/change-password', requireAuth, async (req, res, next) => {
     // Revoke all other refresh tokens for this user and mark sessions
     // invalidated in Redis so any access tokens still in flight stop working
     // at their next request. The caller's current access token continues to
-    // work until it expires (matches admin password-change behaviour).
+    // work until it expires (matches admin password-change behaviour). A
+    // fresh refresh token is then issued for THIS session so the caller isn't
+    // logged out the next time their access token needs refreshing.
     await tenantQuery(slug, `UPDATE refresh_tokens SET revoked = true WHERE user_id = $1`, [
       user.id,
     ]);
     await invalidateUserSessions(slug, user.id);
+
+    const newRefreshToken = await issueRefreshToken(slug, user.id);
+    res.cookie(COOKIE_NAME, newRefreshToken, cookieOptions);
 
     logAudit(slug, {
       userId: req.user.userId,
@@ -398,6 +439,9 @@ router.post('/force-change-password', requireAuth, async (req, res, next) => {
       req.user.userId,
     ]);
     await invalidateUserSessions(slug, req.user.userId);
+
+    const newRefreshToken = await issueRefreshToken(slug, req.user.userId);
+    res.cookie(COOKIE_NAME, newRefreshToken, cookieOptions);
 
     logAudit(slug, {
       userId: req.user.userId,

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -110,6 +110,15 @@ export async function loginUser(tenantSlug, username, password) {
   // 6. Update last_login
   await tenantQuery(tenantSlug, `UPDATE users SET last_login = now() WHERE id = $1`, [user.id]);
 
+  await logAudit(tenantSlug, {
+    userId: user.id,
+    userName: user.name,
+    action: 'login',
+    entityType: 'user',
+    entityId: user.id,
+    entityName: user.name,
+  });
+
   return {
     accessToken,
     refreshToken,
@@ -209,6 +218,34 @@ export async function refreshTokens(tenantSlug, refreshToken) {
       mustChangePassword: user.must_change_password || false,
     },
   };
+}
+
+// ─── Refresh token issuance ───────────────────────────────────────────────
+
+/**
+ * Sign and store a new refresh token for a user, outside of the normal
+ * login/refresh flow (e.g. after a password change that revokes the
+ * caller's other sessions but must keep the current one alive).
+ *
+ * @param {string} tenantSlug
+ * @param {string} userId
+ * @returns {Promise<string>} the raw refresh token (caller sets the cookie)
+ */
+export async function issueRefreshToken(tenantSlug, userId) {
+  const refreshToken = signRefreshToken({ userId, tenantSlug });
+  const tokenHash = hashToken(refreshToken);
+  const expiresAt = new Date();
+  expiresAt.setDate(
+    expiresAt.getDate() + parseInt(process.env.JWT_REFRESH_EXPIRES_DAYS ?? '30', 10),
+  );
+
+  await tenantQuery(
+    tenantSlug,
+    `INSERT INTO refresh_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)`,
+    [userId, tokenHash, expiresAt],
+  );
+
+  return refreshToken;
 }
 
 // ─── Logout ───────────────────────────────────────────────────────────────

--- a/frontend/src/components/DemoUnavailableBanner.jsx
+++ b/frontend/src/components/DemoUnavailableBanner.jsx
@@ -1,0 +1,14 @@
+// beacon2026/frontend/src/components/DemoUnavailableBanner.jsx
+// Warns that a piece of functionality isn't wired up in this demo
+// environment (e.g. no SendGrid/PayPal credentials configured).
+
+export default function DemoUnavailableBanner({ feature }) {
+  return (
+    <div
+      role="alert"
+      className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-800"
+    >
+      <strong>Not available in this demo:</strong> {feature} is not yet configured.
+    </div>
+  );
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -66,8 +66,10 @@ export function AuthProvider({ children }) {
     const minutes = getPreferences().inactivityTimeout;
     inactivityTimer.current = setTimeout(
       () => {
-        // Fire auth:expired to trigger logout
-        window.dispatchEvent(new Event('auth:expired'));
+        // Fire auth:expired to trigger logout; mark the reason so the
+        // handler below can audit-log it as a timeout rather than a
+        // generic session expiry (e.g. a revoked/expired refresh token).
+        window.dispatchEvent(new CustomEvent('auth:expired', { detail: { reason: 'timeout' } }));
       },
       minutes * 60 * 1000,
     );
@@ -89,7 +91,12 @@ export function AuthProvider({ children }) {
 
   // Listen for auth:expired events fired by the API client or inactivity timer
   useEffect(() => {
-    const handler = () => {
+    const handler = (e) => {
+      if (e?.detail?.reason === 'timeout') {
+        // Best-effort — the access token is still valid at this point
+        // (only the idle timer fired), so this call can still authenticate.
+        authApi.sessionTimeout().catch(() => {});
+      }
       setUser(null);
       setTenant(null);
       setPrivs([]);

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -34,6 +34,7 @@ export const auth = {
       body: JSON.stringify({ tenantSlug, username, password }),
     }),
   logout: () => request('/auth/logout', { method: 'POST' }),
+  sessionTimeout: () => request('/auth/session-timeout', { method: 'POST' }),
   refresh: () => request('/auth/refresh', { method: 'POST' }),
   changePassword: (currentPassword, newPassword) =>
     request('/auth/change-password', {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -8,6 +8,18 @@ import { settings as settingsApi, calendar as calendarApi } from '../lib/api.js'
 import PageHeader from '../components/PageHeader.jsx';
 import { getPreferences, savePreferences } from '../hooks/usePreferences.js';
 
+// TEMPORARY: flags menu items that are new in beacon2026 vs the original
+// Beacon, so admins familiar with Beacon can spot them at a glance. Remove
+// the `isNew` markers below (and this badge) once no longer needed — see
+// KNOWN-ISSUES.md.
+function NewBadge() {
+  return (
+    <span className="ml-1 align-super text-[9px] font-bold text-amber-700 bg-amber-100 rounded px-1">
+      NEW
+    </span>
+  );
+}
+
 export default function Home() {
   const { user, tenant, logout, can, hasFeature } = useAuth();
   const navigate = useNavigate();
@@ -162,6 +174,7 @@ export default function Home() {
           tip: 'View and manage teams',
           to: can('groups_list', 'view') ? '/teams' : null,
           f: 'teams',
+          isNew: true,
         },
       ],
     },
@@ -268,12 +281,14 @@ export default function Home() {
           label: 'Utilities',
           tip: 'Administrative utilities',
           to: can('utilities', 'view') ? '/utilities' : null,
+          isNew: true,
         },
         {
           label: 'SQL reports',
           tip: 'Run saved SQL reports and ad-hoc queries',
           to: can('reports', 'view') ? '/reports' : null,
           f: 'reports',
+          isNew: true,
         },
       ],
     },
@@ -285,6 +300,7 @@ export default function Home() {
           label: 'Feature configuration',
           tip: 'Choose which modules are available for your u3a',
           to: can('feature_config', 'view') ? '/feature-config' : null,
+          isNew: true,
         },
         {
           label: 'System users',
@@ -346,6 +362,7 @@ export default function Home() {
           tip: 'Define event types for non-group events',
           to: can('event_types', 'view') ? '/event-types' : null,
           f: 'eventTypes',
+          isNew: true,
         },
       ],
     },
@@ -465,6 +482,7 @@ export default function Home() {
                         {item.label}
                       </span>
                     )}
+                    {item.isNew && <NewBadge />}
                   </li>
                 ))}
               </ul>
@@ -505,6 +523,7 @@ export default function Home() {
                         {item.label}
                       </span>
                     )}
+                    {item.isNew && <NewBadge />}
                   </li>
                 ))}
               </ul>

--- a/frontend/src/pages/email/EmailCompose.jsx
+++ b/frontend/src/pages/email/EmailCompose.jsx
@@ -9,6 +9,7 @@ import { useAuth } from '../../context/AuthContext.jsx';
 import { hasOptionalCookieConsent } from '../../hooks/useCookieConsent.js';
 import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
+import DemoUnavailableBanner from '../../components/DemoUnavailableBanner.jsx';
 import {
   SS_EMAIL_COMPOSE_MEMBER_IDS,
   SS_EMAIL_GIFT_AID_DATES,
@@ -251,6 +252,8 @@ export default function EmailCompose() {
 
       <div className="max-w-5xl mx-auto px-4 py-4">
         <h1 className="text-xl font-bold text-center mb-4">Send Email</h1>
+
+        <DemoUnavailableBanner feature="Sending email" />
 
         {error && (
           <div className="rounded-md bg-red-50 border border-red-300 px-4 py-3 text-red-700 text-sm font-medium text-center mb-4">

--- a/frontend/src/pages/email/EmailUnblocker.jsx
+++ b/frontend/src/pages/email/EmailUnblocker.jsx
@@ -7,6 +7,7 @@ import { email as emailApi } from '../../lib/api.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
+import DemoUnavailableBanner from '../../components/DemoUnavailableBanner.jsx';
 
 export default function EmailUnblocker() {
   const { tenant } = useAuth();
@@ -40,6 +41,8 @@ export default function EmailUnblocker() {
 
       <div className="max-w-xl mx-auto px-4 py-8">
         <h1 className="text-xl font-bold text-center mb-6">Email Unblocker</h1>
+
+        <DemoUnavailableBanner feature="Email unblocker" />
 
         <div className="bg-white/90 rounded-lg shadow-sm p-6">
           <p className="text-sm text-slate-600 mb-4">

--- a/frontend/src/pages/settings/SystemSettings.jsx
+++ b/frontend/src/pages/settings/SystemSettings.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useAuth } from '../../context/AuthContext.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
 import NavBar from '../../components/NavBar.jsx';
+import DemoUnavailableBanner from '../../components/DemoUnavailableBanner.jsx';
 import { settings as settingsApi } from '../../lib/api.js';
 import { useUnsavedChanges } from '../../hooks/useUnsavedChanges.js';
 import { SETTINGS_PAYMENT_METHODS as PAYMENT_METHODS } from '../../lib/constants.js';
@@ -493,6 +494,7 @@ export default function SystemSettings() {
             {/* ── Online Payments (PayPal) ── */}
             <section className="bg-white/90 rounded-lg shadow-sm p-4 sm:p-6 space-y-4">
               <SectionHeading>Online Payments (PayPal)</SectionHeading>
+              <DemoUnavailableBanner feature="Online payments (PayPal)" />
               <Field label="PayPal account email" htmlFor="settings-paypal-email">
                 <input
                   id="settings-paypal-email"


### PR DESCRIPTION
…ers and NEW menu badges

- Reissue refresh-token cookie on change-password/force-change-password so the caller isn't logged out on the next screen (was revoking all refresh tokens without replacing the current session's).
- Audit-log successful login, logout, and inactivity-timeout events (new POST /auth/session-timeout endpoint for the client-detected timeout case).
- Add a "Not available in this demo" banner to Email compose, Email unblocker, and the PayPal panel in System Settings.
- Add temporary "NEW" badges on the main menu next to Teams, Utilities, SQL reports, Feature configuration and Event types (removal noted in KNOWN-ISSUES.md).