### PR TITLE
Document branch and version-bump hygiene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,30 @@ If the user refers to a document you cannot find, run `git fetch origin main` an
 
 All work goes on a branch whose name starts with `claude/`. Never push directly to `main`.
 
+**Start every new task/PR from a fresh branch off current `origin/main`** —
+never branch off an existing `claude/*` branch, and never keep adding new work
+to a branch whose PR has already merged:
+
+```bash
+git fetch origin main
+git checkout -b claude/short-task-name origin/main
+```
+
+PRs here are squash-merged, so a merged branch never shows as "merged" by SHA
+ancestry — reusing it (or repeatedly merging `main` back into it) causes real
+duplication: changes get silently re-applied or revert earlier fixes, not just
+a cosmetic "ahead of main" count. (This happened for real on 2026-08-01 with
+PRs #464/#465, which re-applied and dropped CHANGELOG content.)
+
+After a PR merges, delete the branch both locally and on GitHub
+(`git branch -D <branch>` / `gh pr merge --delete-branch`, or the "Delete
+branch" button on the merged PR) before starting the next one.
+
+The "if a document is missing" flow below (`git merge origin/main --no-edit`)
+is only for pulling newly-uploaded reference docs into the *current* branch
+mid-task — it is not a substitute for starting the *next* task from a fresh
+branch.
+
 ---
 
 ## Reviewing the codebase (lessons from past reviews)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,11 @@ This updates both `package.json` files, refreshes both `package-lock.json`
 files, and updates the version line in `beacon2026 Project Definition.md`.
 Do not edit the version fields by hand.
 
+**Only bump when `backend/` or `frontend/` source actually changed** — i.e.
+something that changes runtime behaviour. Skip the bump for PRs that touch
+only docs (`*.md`, `docs/`), CI/config files, or `CHANGELOG.md`/
+`KNOWN-ISSUES.md` entries with no accompanying code change.
+
 ## Licensing
 
 This project is **proprietary** — see the root [`LICENSE`](LICENSE). The code is


### PR DESCRIPTION
## Summary
- CLAUDE.md: every new task/PR must branch fresh off `origin/main` — never reuse or re-merge into an old `claude/*` branch. PRs here are squash-merged, so reusing a branch was silently re-applying/reverting changes (the #464/#465 CHANGELOG duplication incident).
- CONTRIBUTING.md: `bump-version` should only run for PRs that change `backend/`/`frontend/` source, not for docs-only or config-only changes.

## Test plan
- Docs-only change, no code affected — nothing to run.