### PR TITLE
Add public read API v1 (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,46 @@ under the Unreleased headings below).
 ## [Unreleased] — 2026-08-01
 
 ### Added
+- **Public read API (`/api/v1`) — phase 1.** A new versioned, read-only,
+  anonymous interface exposing a u3a's organisation details, interest areas
+  (faculties), venues, groups and calendar events, so a u3a's own website can
+  show its groups and what's on without anyone re-keying them. Design and
+  rationale are in [`docs/API-design.md`](docs/API-design.md).
+  - **Opt-in per u3a** via a new **Public read API** toggle under Set up →
+    Feature Configuration → Other. It defaults to **off**: a u3a that does
+    nothing is unaffected, and while it is off every `/api/v1` route returns
+    404.
+  - **It can never show more than your public web pages already do.** Field
+    visibility reuses the same Public Links toggles that drive the public
+    Groups and Calendar pages, and every one of them defaults to not-public.
+    A u3a that enables the API without ticking anything publishes only group
+    and event names, dates and times.
+  - **No member data at all.** There is no members endpoint in v1, and none
+    is described in the specification.
+  - Endpoints: `/api/v1/:slug/org`, `/faculties`, `/venues` (+ `/:id`),
+    `/groups` (+ `/:id`, `?faculty=`), `/events` (+ `/:id`, `?from=&to=&group=`).
+    All collections are paginated (`?limit=` max 200, `?offset=`) and return
+    `{ data, meta }`; errors return `{ error: { code, message } }`.
+  - Responses carry `Cache-Control: public, max-age=300` and an `ETag`, so a
+    website that honours them adds almost no load.
+  - Machine-readable specification (OpenAPI 3.1) at `/api/v1/openapi.json`.
+  - Interface owned by the Third Age Trust with a **six-month deprecation
+    notice period**, signalled in-band by `Deprecation`/`Sunset` headers
+    (RFC 8594) when `API_V1_SUNSET` is set. v1 is not deprecated, so no such
+    headers are sent today.
+
+### Changed
+- `/api/v1` is mounted ahead of the app-wide helmet, CORS and rate-limit
+  middleware and supplies its own: cross-origin reads are allowed (the shared
+  `CORS_ORIGIN` echoes a single configured origin to every caller, which would
+  refuse a u3a's own website), `Cross-Origin-Resource-Policy` is relaxed to
+  `cross-origin`, and the API gets its own rate-limit bucket
+  (`API_RATE_LIMIT_MAX`, default 600 per 15 minutes) so a busy u3a website
+  cannot exhaust the frontend's allowance.
+- Tenant-slug resolution for the public pages moved to
+  `backend/src/utils/resolveTenant.js` and is now shared with `/api/v1`, so
+  the two cannot drift from the slug guard in `utils/db.js`. No behaviour
+  change to the existing public routes.
 - **Login, logout, and session-timeout events are now written to the audit
   log** — previously the tenant `audit_log` captured `login_failed`,
   `login_locked`, `change_password` and `force_change_password`, but not a

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -34,6 +34,7 @@ Read `CLAUDE-STANDARDS.md` first for the cross-cutting checklist that applies to
 24. [Help Widget (Zendesk Web Widget)](#24-help-widget-zendesk-web-widget)
 25. [Feature Toggles](#25-feature-toggles)
 26. [Deployment and Infrastructure](#26-deployment-and-infrastructure)
+27. [Public read API (`/api/v1`)](#27-public-read-api-apiv1)
 
 ---
 
@@ -1893,11 +1894,11 @@ Per-tenant feature configuration allowing each u3a to choose which modules are a
 ### Storage
 
 Single JSONB column `feature_config` on `tenant_settings` (singleton row). Uses an
-**opt-out model** where most missing keys default to `true` (on). Three features default
-to `false` (off) when never set: `giftAid`, `groupLedger`, `siteworks`. See
-"Default-off features" below.
+**opt-out model** where most missing keys default to `true` (on). Four features default
+to `false` (off) when never set: `giftAid`, `groupLedger`, `siteworks`, `publicApi`.
+See "Default-off features" below.
 
-### Toggle inventory (25 toggles)
+### Toggle inventory (26 toggles)
 
 **Master toggles (6):** `groups`, `finance`, `email`, `portal`, `onlineJoining`, `events`
 
@@ -1914,7 +1915,8 @@ to `false` (off) when never set: `giftAid`, `groupLedger`, `siteworks`. See
 
 **Communications:** `letters` (compose/print PDF — no SendGrid dependency)
 
-**Other (2):** `reports` (SQL Reports), `publicPages` (Public Groups/Calendar)
+**Other (3):** `reports` (SQL Reports), `publicPages` (Public Groups/Calendar),
+`publicApi` (public read API at `/api/v1` — **default off**, see §27)
 
 All toggles are backend-enforced. Route files call `requireFeature(key)` (after
 `requireAuth`) or `isFeatureEnabled(slug, key)` for pre-auth public routes. A
@@ -1943,11 +1945,17 @@ individual route tests get a pass-through mock of this middleware from
 
 ### Default-off features
 
-Three features default to **off** when their key is missing from `feature_config`:
-`giftAid`, `groupLedger`, `siteworks`. Both `hasFeature()` and `requireFeature()`
-use a `FEATURE_DEFAULTS_OFF` set for these. All other features default to on (opt-out
-model). If you add a new feature that should default to off, add it to the set in
-**both** `AuthContext.jsx` and `requireFeature.js`.
+Four features default to **off** when their key is missing from `feature_config`:
+`giftAid`, `groupLedger`, `siteworks`, `publicApi`. Both `hasFeature()` and
+`requireFeature()` use the `FEATURE_DEFAULTS_OFF` set for these. All other features
+default to on (opt-out model).
+
+If you add a new feature that should default to off, add it to
+`FEATURE_DEFAULTS_OFF` in **`shared/constants.js`** — the single source of truth.
+Backend (`requireFeature.js`) and frontend (`AuthContext.jsx`, via
+`frontend/src/lib/constants.js`) both import it, so one edit covers both.
+(This note previously said to edit two separate copies; they were consolidated
+into `shared/constants.js` and no duplicate set remains.)
 
 ### Parent dependency chain
 
@@ -2045,5 +2053,67 @@ Vercel dashboard (frontend: `VITE_API_URL`, `VITE_ZENDESK_KEY`).
 **Database replacement** (e.g. free tier expiry): create a new Render PostgreSQL
 instance, update `DATABASE_URL` on the backend service, and save. Auto-migration
 on startup (see §1) handles the rest. Full instructions in `DEPLOYMENT.md`.
+
+[↑ Back to top](#contents)
+
+---
+
+## 27. Public read API (`/api/v1`)
+
+The **published, external** interface — as opposed to the internal API the React
+frontend uses. Read `docs/API-design.md` before changing anything here; the
+decisions below are not local implementation choices.
+
+### The two rules that constrain every change
+
+1. **v1 is a contract owned by the Third Age Trust, with six months' notice.**
+   Adding a field is free. Changing a field's meaning, removing one, or altering
+   a status code is a months-long process. When in doubt, leave a field out —
+   the asymmetry is entirely one way.
+2. **The anonymous tier can never expose more than the u3a's public web pages
+   already do.** Field visibility comes from the same `group_info_config` /
+   `calendar_config` toggles as the public Groups and Calendar pages, and every
+   toggle defaults to not-public.
+
+### Layout
+
+| File | Role |
+|------|------|
+| `routes/api/index.js` | Version router: deprecation headers, spec, tenant resolution, `publicApi` gate, resource mounts, 404 + error handler |
+| `routes/api/helpers.js` | Envelope, pagination, feature gating, visibility loading, `Deprecation`/`Sunset` |
+| `routes/api/{org,faculties,venues,groups,events}.js` | One module per resource |
+| `routes/api/openapi.json` | Hand-written OpenAPI 3.1, loaded via `createRequire` |
+| `utils/resolveTenant.js` | Slug → tenant, shared with `routes/public/` |
+
+### Things that will bite you
+
+- **Mount order in `app.js` is load-bearing.** `/api/v1` is mounted *before* the
+  app-wide `helmet()`, `cors()` and `generalLimiter` because it needs different
+  values for all three and whichever runs first wins. Moving it below them
+  silently breaks cross-origin reads. The comment in `app.js` explains each.
+- **`cors({ origin: CORS_ORIGIN })` does not match the request origin** — it
+  echoes the configured string to everyone, so the shared config would refuse a
+  u3a's own website. `/api/v1` uses `origin: '*'`.
+- **Helmet's default `Cross-Origin-Resource-Policy: same-origin`** blocks
+  cross-origin reads even when CORS is correct, and fails in a way that looks
+  like a CORS bug. Relaxed to `cross-origin` for this router only.
+- **Everything unavailable is a 404, never a 403.** A u3a that has not enabled
+  `publicApi`, a disabled module, a venue collection the u3a does not publish —
+  all 404. A 403 would confirm the u3a exists and merely declined.
+- **Projection functions are the only place fields are chosen.** The tests in
+  `apiV1.test.js` assert the *exact key set* of each anonymous response, so a
+  column added to a query cannot reach a response without a deliberate test
+  change. Keep it that way — that assertion is the leak guard.
+- **No member data.** There is no members endpoint in v1 and none in the spec;
+  `apiV1.test.js` asserts both. Adding one is a phase-4 decision (API keys plus
+  an explicit scope), not a routine change.
+
+### Configuration
+
+| Variable | Effect |
+|---|---|
+| `API_RATE_LIMIT_MAX` | Requests per 15 min per IP (default 600) |
+| `API_V1_SUNSET` | ISO date; when set, sends `Deprecation: true` + `Sunset`. Unset = not deprecated (the normal state) |
+| `API_V1_SUNSET_LINK` | Optional URL for the `Link: …; rel="sunset"` header |
 
 [↑ Back to top](#contents)

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -532,3 +532,50 @@ All items in this section have been completed (v0.8.6).
   array, rendered via the top-level `NewBadge()` function in the same file.
   Once admins no longer need the callout, delete the `isNew` flags and the
   `NewBadge` component/render calls.
+
+## Public read API (`/api/v1`) — deferred items
+
+Design, decisions and the phased plan are in
+[`docs/API-design.md`](docs/API-design.md). Phase 1 (anonymous read API) is
+built; the items below are deliberately out of it.
+
+1. `[DEFERRED]` **`events.ics` iCalendar feed (phase 2)** — RFC 5545 feed at
+   `/api/v1/:slug/events.ics` with a `?group=` filter, so members can subscribe
+   to the u3a calendar in Google/Apple/Outlook. Needs stable `UID`s derived
+   from event id + tenant so a subscriber's calendar updates events in place
+   rather than duplicating them. Small, and the highest value-per-line item
+   remaining.
+2. `[DEFERRED]` **Shared SiteWorks display plugin (phase 2b)** — one WordPress
+   plugin, used by every u3a, rendering groups and events from this API with
+   sensible caching. Separate codebase. It is the deliverable most u3as will
+   actually see, and the main defence against a per-u3a support load: the
+   common case should need no support at all.
+3. `[CONDITIONAL]` **API keys (phase 3)** — tenant-scoped keys, hashed at rest,
+   with scopes, an admin page and revocation. Deliberately *not* scheduled: the
+   settled decision is anonymous-first, and keys get built only if a consumer
+   appears that already-public data cannot serve. Do not build speculatively.
+4. `[CONDITIONAL]` **Member endpoints (phase 4)** — `/members/stats` (aggregate
+   counts) before any individual records, key plus explicit `members:read`
+   scope, never in a default role, never anonymous. A data-protection decision
+   for each u3a, not a routine feature.
+5. `[OPEN]` **Deprecation notice needs channels that do not depend on
+   identity.** Anonymous access is what lets this scale to every u3a, and the
+   price is that we cannot email integrators. In-band `Deprecation`/`Sunset`
+   headers are implemented; a Trust-owned changes page and an optional
+   voluntary notification list are not. Needed before v1 is publicised widely.
+6. `[OPEN]` **Trust agreement to own the interface (phase 0b).** Not code. It
+   gates *publishing* rather than building, and should be secured before the
+   API is advertised to other u3as.
+
+## Test flakiness
+
+1. `[OPEN]` **`TransferMoney.test.jsx > validates that a positive amount is
+   required` times out intermittently under load.** Observed twice on
+   2026-08-01 while the backend suite and other work were competing for CPU;
+   the assertion times out at ~5.4 s. Not reproducible in isolation (5/5 pass)
+   and passes consistently on an otherwise idle machine (checked against both a
+   clean tree and the `/api/v1` branch — 4 consecutive full-suite passes).
+   Environmental rather than a real defect, but the test is close enough to its
+   timeout that it will keep surfacing in CI; worth raising the timeout or
+   awaiting the button explicitly rather than relying on `findByRole` racing
+   the initial data load.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-backend",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",
@@ -761,9 +761,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -781,9 +778,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -801,9 +795,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -821,9 +812,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -841,9 +829,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -861,9 +846,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3597,9 +3579,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3621,9 +3600,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3645,9 +3621,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3669,9 +3642,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "beacon2026 API server",
   "type": "module",
   "main": "src/app.js",

--- a/backend/src/__tests__/apiV1.test.js
+++ b/backend/src/__tests__/apiV1.test.js
@@ -1,0 +1,465 @@
+// beacon2026/backend/src/__tests__/apiV1.test.js
+// Coverage for the public read API (routes/api/*) — see docs/API-design.md.
+//
+// The most important tests here are the exact-key-set assertions. This is a
+// published, anonymous, national interface, so the failure that matters is a
+// field appearing in a response that the u3a never chose to publish. Asserting
+// the whole key set (rather than the presence of individual fields) makes a
+// carelessly added column fail the build instead of shipping quietly.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { dbMock, redisMock } from './mocks.js';
+
+vi.mock('../utils/redis.js', () => redisMock());
+vi.mock('../utils/db.js', () => dbMock({ prisma: { sysTenant: { findUnique: vi.fn() } } }));
+
+const { default: app } = await import('../app.js');
+const { tenantQuery, prisma } = await import('../utils/db.js');
+
+const SLUG = 'demo';
+const BASE = `/api/v1/${SLUG}`;
+
+/** feature_config with publicApi on and everything else defaulting on. */
+const FEATURES_ON = [{ feature_config: { publicApi: true } }];
+
+/** Nothing ticked public — the default for a u3a that never opened Public Links. */
+const NOTHING_PUBLIC = [{ group_info_config: {}, calendar_config: {} }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.sysTenant.findUnique.mockResolvedValue({ slug: SLUG, active: true, name: 'Demo u3a' });
+});
+
+// ── Tenant resolution and opt-in ────────────────────────────────────────────
+
+describe('access control', () => {
+  it('rejects a slug with a hyphen, matching the db.js guard', async () => {
+    const res = await request(app).get('/api/v1/bad-slug/groups');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_slug');
+  });
+
+  it('404s an unknown u3a', async () => {
+    prisma.sysTenant.findUnique.mockResolvedValueOnce(null);
+    const res = await request(app).get('/api/v1/missing/groups');
+    expect(res.status).toBe(404);
+  });
+
+  it('404s an inactive u3a', async () => {
+    prisma.sysTenant.findUnique.mockResolvedValueOnce({ slug: SLUG, active: false, name: 'X' });
+    const res = await request(app).get(`${BASE}/groups`);
+    expect(res.status).toBe(404);
+  });
+
+  it('404s — not 403 — when the u3a has not enabled the API', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: {} }]);
+    const res = await request(app).get(`${BASE}/groups`);
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('not_found');
+  });
+
+  it('defaults publicApi to off when feature_config is empty', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: {} }]);
+    const res = await request(app).get(`${BASE}/org`);
+    expect(res.status).toBe(404);
+  });
+
+  it('404s an unknown path under a valid u3a', async () => {
+    tenantQuery.mockResolvedValueOnce(FEATURES_ON);
+    const res = await request(app).get(`${BASE}/nonsense`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toHaveProperty('code');
+  });
+});
+
+// ── Envelope, caching and headers ───────────────────────────────────────────
+
+describe('envelope and caching', () => {
+  it('wraps collections in data + meta and sets a public cache policy', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 7 }])
+      .mockResolvedValueOnce([]);
+    const res = await request(app).get(`${BASE}/groups`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: [], meta: { total: 7, limit: 50, offset: 0 } });
+    expect(res.headers['cache-control']).toBe('public, max-age=300');
+    expect(res.headers.etag).toBeDefined();
+  });
+
+  it('allows any origin, and permits cross-origin reads', async () => {
+    tenantQuery.mockResolvedValueOnce(FEATURES_ON).mockResolvedValueOnce([{}]);
+    const res = await request(app).get(`${BASE}/org`).set('Origin', 'https://a-u3a.example');
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+    expect(res.headers['cross-origin-resource-policy']).toBe('cross-origin');
+  });
+
+  it('sends no deprecation headers while v1 is current', async () => {
+    tenantQuery.mockResolvedValueOnce(FEATURES_ON).mockResolvedValueOnce([{}]);
+    const res = await request(app).get(`${BASE}/org`);
+    expect(res.headers.deprecation).toBeUndefined();
+    expect(res.headers.sunset).toBeUndefined();
+  });
+
+  it('signals deprecation in-band once a sunset date is set', async () => {
+    process.env.API_V1_SUNSET = '2027-06-30';
+    try {
+      tenantQuery.mockResolvedValueOnce(FEATURES_ON).mockResolvedValueOnce([{}]);
+      const res = await request(app).get(`${BASE}/org`);
+      expect(res.headers.deprecation).toBe('true');
+      expect(res.headers.sunset).toContain('2027');
+    } finally {
+      delete process.env.API_V1_SUNSET;
+    }
+  });
+
+  it('serves the specification without needing a u3a', async () => {
+    const res = await request(app).get('/api/v1/openapi.json');
+    expect(res.status).toBe(200);
+    expect(res.body.openapi).toBe('3.1.0');
+    expect(res.body.paths['/{slug}/groups']).toBeDefined();
+  });
+});
+
+// ── Pagination ──────────────────────────────────────────────────────────────
+
+describe('pagination', () => {
+  it('rejects a limit above the maximum', async () => {
+    tenantQuery.mockResolvedValueOnce(FEATURES_ON);
+    const res = await request(app).get(`${BASE}/groups?limit=500`);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('invalid_query');
+  });
+
+  it('rejects a negative offset', async () => {
+    tenantQuery.mockResolvedValueOnce(FEATURES_ON);
+    const res = await request(app).get(`${BASE}/groups?offset=-1`);
+    expect(res.status).toBe(400);
+  });
+
+  it('passes limit and offset through to the query', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 0 }])
+      .mockResolvedValueOnce([]);
+    const res = await request(app).get(`${BASE}/groups?limit=10&offset=20`);
+    expect(res.body.meta).toEqual({ total: 0, limit: 10, offset: 20 });
+    const params = tenantQuery.mock.calls.at(-1)[2];
+    expect(params).toEqual([10, 20]);
+  });
+});
+
+// ── Groups: the visibility invariant ────────────────────────────────────────
+
+const GROUP_ROW = {
+  id: 'g1',
+  name: 'Walking',
+  status: 'active',
+  when_text: '2nd Thursday',
+  start_time: '14:00',
+  end_time: '16:00',
+  enquiries: 'walk@demo.example',
+  information: 'Bring boots',
+  faculty_id: 'f1',
+  faculty_name: 'Outdoors',
+  venue_name: 'Village Hall',
+  venue_postcode: 'PE27 1AA',
+};
+
+describe('GET /groups', () => {
+  it('exposes only identity and timing fields when nothing is ticked public', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([GROUP_ROW]);
+    const res = await request(app).get(`${BASE}/groups`);
+    expect(res.status).toBe(200);
+    // Exact key set: a new field cannot appear without updating this test.
+    expect(Object.keys(res.body.data[0]).sort()).toEqual([
+      'endTime',
+      'faculty',
+      'facultyId',
+      'id',
+      'name',
+      'startTime',
+      'when',
+    ]);
+  });
+
+  it('never leaks enquiries, venue, information or status unless ticked', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([GROUP_ROW]);
+    const res = await request(app).get(`${BASE}/groups`);
+    const body = JSON.stringify(res.body);
+    expect(body).not.toContain('walk@demo.example');
+    expect(body).not.toContain('Village Hall');
+    expect(body).not.toContain('Bring boots');
+    expect(res.body.data[0].status).toBeUndefined();
+  });
+
+  it('includes the fields the u3a has ticked public', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce([
+        {
+          group_info_config: {
+            venue: { public: true },
+            detail: { public: true },
+            status: { public: true },
+          },
+          calendar_config: {},
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([GROUP_ROW]);
+    const res = await request(app).get(`${BASE}/groups`);
+    expect(res.body.data[0].venue).toBe('Village Hall');
+    expect(res.body.data[0].venuePostcode).toBe('PE27 1AA');
+    expect(res.body.data[0].information).toBe('Bring boots');
+    expect(res.body.data[0].status).toBe('active');
+  });
+
+  it('uses leader names for contact only when contacts are public', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce([
+        { group_info_config: { contact: { public: true } }, calendar_config: {} },
+      ])
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([GROUP_ROW])
+      .mockResolvedValueOnce([
+        { group_id: 'g1', forenames: 'Ann Marie', surname: 'Blake', known_as: null },
+      ]);
+    const res = await request(app).get(`${BASE}/groups`);
+    expect(res.body.data[0].contact).toBe('Ann Blake');
+  });
+
+  it('does not query members at all when contacts are not public', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([GROUP_ROW]);
+    await request(app).get(`${BASE}/groups`);
+    const sql = tenantQuery.mock.calls.map((c) => c[1]).join(' ');
+    expect(sql).not.toContain('group_members');
+  });
+
+  it('restricts to active interest groups, never teams', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 0 }])
+      .mockResolvedValueOnce([]);
+    await request(app).get(`${BASE}/groups`);
+    const sql = tenantQuery.mock.calls.at(-1)[1];
+    expect(sql).toContain("g.status = 'active'");
+    expect(sql).toContain("g.type = 'group'");
+  });
+
+  it('filters by faculty', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 0 }])
+      .mockResolvedValueOnce([]);
+    await request(app).get(`${BASE}/groups?faculty=f1`);
+    expect(tenantQuery.mock.calls.at(-1)[2]).toEqual(['f1', 50, 0]);
+  });
+
+  it('404s a group that is inactive or absent', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([]);
+    const res = await request(app).get(`${BASE}/groups/nope`);
+    expect(res.status).toBe(404);
+  });
+
+  it('404s the whole collection when the groups module is off', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: { publicApi: true, groups: false } }]);
+    const res = await request(app).get(`${BASE}/groups`);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Events ──────────────────────────────────────────────────────────────────
+
+const EVENT_ROW = {
+  id: 'e1',
+  event_date: '2026-09-10',
+  start_time: '10:00',
+  end_time: '12:00',
+  group_id: 'g1',
+  group_name: 'Walking',
+  event_type_name: null,
+  venue_name: 'Village Hall',
+  venue_postcode: 'PE27 1AA',
+  topic: 'Autumn walk',
+  contact: 'walk@demo.example',
+  details: 'Meet at the bridge',
+};
+
+describe('GET /events', () => {
+  it('exposes only identity and timing fields by default', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([EVENT_ROW]);
+    const res = await request(app).get(`${BASE}/events`);
+    expect(Object.keys(res.body.data[0]).sort()).toEqual([
+      'date',
+      'endTime',
+      'groupId',
+      'groupName',
+      'id',
+      'startTime',
+    ]);
+  });
+
+  it('never returns private events', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 0 }])
+      .mockResolvedValueOnce([]);
+    await request(app).get(`${BASE}/events`);
+    const sql = tenantQuery.mock.calls.at(-1)[1];
+    expect(sql).toContain('ge.is_private IS NOT TRUE');
+  });
+
+  it('applies from, to and group filters', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 0 }])
+      .mockResolvedValueOnce([]);
+    await request(app).get(`${BASE}/events?from=2026-09-01&to=2026-09-30&group=g1`);
+    expect(tenantQuery.mock.calls.at(-1)[2]).toEqual(['2026-09-01', '2026-09-30', 'g1', 50, 0]);
+  });
+
+  it('rejects a malformed date', async () => {
+    tenantQuery.mockResolvedValueOnce(FEATURES_ON);
+    const res = await request(app).get(`${BASE}/events?from=last-tuesday`);
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toMatch(/YYYY-MM-DD/);
+  });
+
+  it('falls back to the event type name for open meetings', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce(NOTHING_PUBLIC)
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([
+        { ...EVENT_ROW, group_id: null, group_name: null, event_type_name: 'Open Meeting' },
+      ]);
+    const res = await request(app).get(`${BASE}/events`);
+    expect(res.body.data[0].groupName).toBe('Open Meeting');
+  });
+});
+
+// ── Venues, faculties and org ───────────────────────────────────────────────
+
+describe('venues, faculties and org', () => {
+  it('404s venues when the u3a does not publish venues', async () => {
+    tenantQuery.mockResolvedValueOnce(FEATURES_ON).mockResolvedValueOnce(NOTHING_PUBLIC);
+    const res = await request(app).get(`${BASE}/venues`);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns name and postcode only when venues are public', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce([
+        { group_info_config: { venue: { public: true } }, calendar_config: {} },
+      ])
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([
+        { id: 'v1', name: 'Village Hall', postcode: 'PE27 1AA', address1: '1 High St' },
+      ]);
+    const res = await request(app).get(`${BASE}/venues`);
+    expect(Object.keys(res.body.data[0]).sort()).toEqual(['id', 'name', 'postcode']);
+    expect(JSON.stringify(res.body)).not.toContain('High St');
+  });
+
+  it('returns faculties as id and name only', async () => {
+    tenantQuery
+      .mockResolvedValueOnce(FEATURES_ON)
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([{ id: 'f1', name: 'Outdoors', created_at: 'x' }]);
+    const res = await request(app).get(`${BASE}/faculties`);
+    expect(res.body.data).toEqual([{ id: 'f1', name: 'Outdoors' }]);
+  });
+
+  it('returns the u3a public contact details', async () => {
+    tenantQuery.mockResolvedValueOnce(FEATURES_ON).mockResolvedValueOnce([
+      {
+        public_phone: '01480 000000',
+        public_email: 'info@demo.example',
+        home_page: 'https://demo.example',
+      },
+    ]);
+    const res = await request(app).get(`${BASE}/org`);
+    expect(res.body.data).toEqual({
+      slug: SLUG,
+      name: 'Demo u3a',
+      phone: '01480 000000',
+      email: 'info@demo.example',
+      homePage: 'https://demo.example',
+    });
+  });
+});
+
+// ── The specification must describe what actually exists ────────────────────
+// A hand-written spec is only worth having if it cannot drift from the code.
+// This is the guard: every route must be documented and every documented path
+// must exist, both ways round.
+
+describe('specification matches the routes', () => {
+  it('documents every route, and every documented path exists', async () => {
+    const modules = await Promise.all([
+      import('../routes/api/org.js'),
+      import('../routes/api/faculties.js'),
+      import('../routes/api/venues.js'),
+      import('../routes/api/groups.js'),
+      import('../routes/api/events.js'),
+    ]);
+
+    // '/:slug/groups/:id' (Express) → '/{slug}/groups/{id}' (OpenAPI)
+    const actual = modules
+      .flatMap((m) => m.default.stack.filter((l) => l.route).map((l) => l.route.path))
+      .map((p) => p.replace(/:([A-Za-z]+)/g, '{$1}'))
+      .sort();
+
+    const res = await request(app).get('/api/v1/openapi.json');
+    const documented = Object.keys(res.body.paths).sort();
+
+    // Guard against a vacuous pass if router introspection ever returns nothing.
+    expect(actual.length).toBeGreaterThanOrEqual(8);
+    expect(documented).toEqual(actual);
+  });
+});
+
+// ── No member data, ever ────────────────────────────────────────────────────
+
+describe('member data is unreachable', () => {
+  it('has no members endpoint in v1', async () => {
+    tenantQuery.mockResolvedValueOnce(FEATURES_ON);
+    const res = await request(app).get(`${BASE}/members`);
+    expect(res.status).toBe(404);
+  });
+
+  it('does not describe a members path in the specification', async () => {
+    const res = await request(app).get('/api/v1/openapi.json');
+    const paths = Object.keys(res.body.paths).join(' ');
+    expect(paths).not.toContain('member');
+  });
+});

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -41,6 +41,7 @@ import membershipCardRoutes from './routes/membershipCards.js';
 import letterRoutes from './routes/letters.js';
 import customFieldRoutes from './routes/customFields.js';
 import reportRoutes from './routes/reports.js';
+import apiV1Routes from './routes/api/index.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 // Refuse to start in production without CORS_ORIGIN — otherwise the cors
@@ -56,6 +57,35 @@ if (process.env.NODE_ENV === 'production' && !process.env.CORS_ORIGIN) {
 const app = express();
 
 app.set('trust proxy', 1); // trust Render's load balancer
+
+// ─── Public read API (/api/v1) ────────────────────────────────────────────
+// Mounted BEFORE the app-wide helmet/cors/rate-limit middleware, because it
+// needs different values for all three and whichever runs first wins:
+//
+//  • CORS — `cors({ origin: CORS_ORIGIN })` echoes that one configured origin
+//    to every caller rather than matching it against the request, so a u3a's
+//    own website would be refused. This API is public and needs `*`.
+//  • Helmet — the default `Cross-Origin-Resource-Policy: same-origin` blocks
+//    cross-origin reads even when CORS is correct, which fails in a way that
+//    looks like a CORS bug and is not.
+//  • Rate limit — `generalLimiter` is per-IP and shared with the frontend. A
+//    u3a website is a single IP, so without its own bucket a busy site could
+//    exhaust the allowance and take the frontend down with it.
+//
+// No `express.json()` either: v1 is read-only and parses no bodies.
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: parseInt(process.env.API_RATE_LIMIT_MAX || '600', 10),
+  message: { error: { code: 'rate_limited', message: 'Too many requests, please slow down.' } },
+});
+
+app.use(
+  '/api/v1',
+  helmet({ crossOriginResourcePolicy: { policy: 'cross-origin' } }),
+  cors({ origin: '*' }),
+  apiLimiter,
+  apiV1Routes,
+);
 
 app.use(helmet());
 app.use(

--- a/backend/src/routes/api/events.js
+++ b/backend/src/routes/api/events.js
@@ -1,0 +1,134 @@
+// beacon2026/backend/src/routes/api/events.js
+// GET /api/v1/:slug/events  and  /events/:id — the public calendar.
+//
+// Field parity with the public calendar page (routes/public/read.js).
+// Private events are excluded outright; every optional field is gated on the
+// matching `calendar_config` public toggle, all of which default to false.
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { tenantQuery } from '../../utils/db.js';
+import {
+  sendCollection,
+  sendOne,
+  pagination,
+  requireFeatures,
+  visibility,
+  visible,
+  apiFail,
+} from './helpers.js';
+
+const router = Router();
+
+const isoDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'dates must be in YYYY-MM-DD format')
+  .optional();
+
+const filterSchema = z.object({
+  from: isoDate,
+  to: isoDate,
+  group: z.string().max(64).optional(),
+});
+
+/** All event field-visibility lives here — see the note in groups.js. */
+function projectEvent(ev, cfg) {
+  return {
+    id: ev.id,
+    date: ev.event_date,
+    startTime: ev.start_time || null,
+    endTime: ev.end_time || null,
+    groupId: ev.group_id || null,
+    groupName: ev.group_name || ev.event_type_name || 'Open Meeting',
+    ...(visible(cfg, 'venue') && {
+      venue: ev.venue_name || null,
+      venuePostcode: ev.venue_postcode || null,
+    }),
+    ...(visible(cfg, 'topic') && { topic: ev.topic || null }),
+    ...(visible(cfg, 'enquiries') && { contact: ev.contact || null }),
+    ...(visible(cfg, 'detail') && { details: ev.details || null }),
+  };
+}
+
+const SELECT_EVENT = `
+  SELECT ge.id, ge.event_date, ge.start_time, ge.end_time,
+         ge.group_id, g.name AS group_name,
+         et.name AS event_type_name,
+         v.name AS venue_name, v.postcode AS venue_postcode,
+         ge.topic, ge.contact, ge.details
+  FROM group_events ge
+  LEFT JOIN groups g       ON g.id  = ge.group_id
+  LEFT JOIN venues v       ON v.id  = ge.venue_id
+  LEFT JOIN event_types et ON et.id = ge.event_type_id`;
+
+// ─── GET /:slug/events ────────────────────────────────────────────────────
+
+router.get('/:slug/events', async (req, res, next) => {
+  try {
+    if (!(await requireFeatures(req, res, ['events']))) return;
+    const { limit, offset } = pagination(req.query);
+    const { from, to, group } = filterSchema.parse(req.query);
+    const cfg = (await visibility(req)).calendar;
+
+    const where = [`ge.is_private IS NOT TRUE`];
+    const params = [];
+    if (from) {
+      params.push(from);
+      where.push(`ge.event_date >= $${params.length}::date`);
+    }
+    if (to) {
+      params.push(to);
+      where.push(`ge.event_date <= $${params.length}::date`);
+    }
+    if (group) {
+      params.push(group);
+      where.push(`ge.group_id = $${params.length}`);
+    }
+    const whereSQL = `WHERE ${where.join(' AND ')}`;
+
+    const [[count], rows] = await Promise.all([
+      tenantQuery(
+        req.tenantSlug,
+        `SELECT COUNT(*)::int AS total FROM group_events ge ${whereSQL}`,
+        params,
+      ),
+      tenantQuery(
+        req.tenantSlug,
+        `${SELECT_EVENT} ${whereSQL}
+         ORDER BY ge.event_date, ge.start_time, g.name
+         LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+        [...params, limit, offset],
+      ),
+    ]);
+
+    return sendCollection(
+      res,
+      rows.map((ev) => projectEvent(ev, cfg)),
+      { total: count?.total ?? 0, limit, offset },
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── GET /:slug/events/:id ────────────────────────────────────────────────
+
+router.get('/:slug/events/:id', async (req, res, next) => {
+  try {
+    if (!(await requireFeatures(req, res, ['events']))) return;
+    const cfg = (await visibility(req)).calendar;
+
+    const [row] = await tenantQuery(
+      req.tenantSlug,
+      `${SELECT_EVENT} WHERE ge.id = $1 AND ge.is_private IS NOT TRUE`,
+      [req.params.id],
+    );
+    if (!row) return apiFail(res, 404, 'not_found', 'Not found.');
+
+    return sendOne(res, projectEvent(row, cfg));
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/api/faculties.js
+++ b/backend/src/routes/api/faculties.js
@@ -1,0 +1,45 @@
+// beacon2026/backend/src/routes/api/faculties.js
+// GET /api/v1/:slug/faculties — interest areas.
+//
+// Visibility note. Faculties have no entry in group_info_config, so strictly
+// they are not covered by the "never more than the public pages already
+// show" rule. They are included here on the narrower ground that a faculty
+// is pure taxonomy — a name a u3a invented to categorise its own groups,
+// carrying no personal data of any kind — and that the organising axis for
+// a website's groups page is precisely what makes that page useful.
+//
+// Only `id` and `name` are exposed. If that judgement is ever revisited,
+// this endpoint and the `faculty` field on groups are the only two places
+// to change.
+
+import { Router } from 'express';
+import { tenantQuery } from '../../utils/db.js';
+import { sendCollection, pagination, requireFeatures } from './helpers.js';
+
+const router = Router();
+
+router.get('/:slug/faculties', async (req, res, next) => {
+  try {
+    if (!(await requireFeatures(req, res, ['groups', 'faculties']))) return;
+    const { limit, offset } = pagination(req.query);
+
+    const [[count], rows] = await Promise.all([
+      tenantQuery(req.tenantSlug, `SELECT COUNT(*)::int AS total FROM faculties`),
+      tenantQuery(
+        req.tenantSlug,
+        `SELECT id, name FROM faculties ORDER BY name LIMIT $1 OFFSET $2`,
+        [limit, offset],
+      ),
+    ]);
+
+    return sendCollection(
+      res,
+      rows.map((f) => ({ id: f.id, name: f.name })),
+      { total: count?.total ?? 0, limit, offset },
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/api/groups.js
+++ b/backend/src/routes/api/groups.js
@@ -1,0 +1,159 @@
+// beacon2026/backend/src/routes/api/groups.js
+// GET /api/v1/:slug/groups  and  /groups/:id — the primary use case.
+//
+// Field parity with the public groups page (routes/public/read.js): the
+// always-visible fields are the group's identity and when it meets; every
+// other field is gated on the matching `group_info_config` public toggle,
+// all of which default to false.
+//
+// Only active interest groups are returned. Teams (type = 'team') are
+// internal committee structures and are never public.
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { tenantQuery } from '../../utils/db.js';
+import {
+  sendCollection,
+  sendOne,
+  pagination,
+  requireFeatures,
+  visibility,
+  visible,
+  apiFail,
+} from './helpers.js';
+
+const router = Router();
+
+const filterSchema = z.object({
+  faculty: z.string().max(64).optional(),
+});
+
+/**
+ * Project one group row for the anonymous tier.
+ *
+ * All group field-visibility lives here. A new column added to the queries
+ * below does not appear in a response unless it is added here too, which is
+ * the point — the apiV1 tests assert the exact key set, so a field added
+ * carelessly fails the build rather than shipping quietly.
+ */
+function projectGroup(g, cfg, leaders) {
+  return {
+    id: g.id,
+    name: g.name,
+    facultyId: g.faculty_id || null,
+    faculty: g.faculty_name || null,
+    when: g.when_text || null,
+    startTime: g.start_time || null,
+    endTime: g.end_time || null,
+    ...(visible(cfg, 'status') && { status: g.status }),
+    ...(visible(cfg, 'venue') && {
+      venue: g.venue_name || null,
+      venuePostcode: g.venue_postcode || null,
+    }),
+    ...(visible(cfg, 'contact') && {
+      contact: (leaders?.get(g.id) || []).join(', ') || g.enquiries || null,
+    }),
+    ...(visible(cfg, 'enquiries') && { enquiries: g.enquiries || null }),
+    ...(visible(cfg, 'detail') && { information: g.information || null }),
+  };
+}
+
+const SELECT_GROUP = `
+  SELECT g.id, g.name, g.status, g.when_text, g.start_time, g.end_time,
+         g.enquiries, g.information, g.faculty_id,
+         f.name AS faculty_name,
+         v.name AS venue_name, v.postcode AS venue_postcode
+  FROM groups g
+  LEFT JOIN venues v    ON v.id = g.venue_id
+  LEFT JOIN faculties f ON f.id = g.faculty_id`;
+
+/** Leader display names, loaded only when the u3a publishes contacts. */
+async function loadLeaders(slug, groupIds) {
+  if (groupIds.length === 0) return new Map();
+  const rows = await tenantQuery(
+    slug,
+    `SELECT gm.group_id, m.forenames, m.surname, m.known_as
+     FROM group_members gm
+     JOIN members m ON m.id = gm.member_id
+     WHERE gm.is_leader = true AND gm.group_id = ANY($1)`,
+    [groupIds],
+  );
+  const map = new Map();
+  for (const row of rows) {
+    const first = row.known_as || row.forenames?.split(' ')[0] || row.forenames;
+    const display = `${first ?? ''} ${row.surname ?? ''}`.trim();
+    if (!map.has(row.group_id)) map.set(row.group_id, []);
+    map.get(row.group_id).push(display);
+  }
+  return map;
+}
+
+// ─── GET /:slug/groups ────────────────────────────────────────────────────
+
+router.get('/:slug/groups', async (req, res, next) => {
+  try {
+    if (!(await requireFeatures(req, res, ['groups']))) return;
+    const { limit, offset } = pagination(req.query);
+    const { faculty } = filterSchema.parse(req.query);
+    const cfg = (await visibility(req)).group;
+
+    const where = [`g.status = 'active'`, `g.type = 'group'`];
+    const params = [];
+    if (faculty) {
+      params.push(faculty);
+      where.push(`g.faculty_id = $${params.length}`);
+    }
+    const whereSQL = `WHERE ${where.join(' AND ')}`;
+
+    const [[count], rows] = await Promise.all([
+      tenantQuery(
+        req.tenantSlug,
+        `SELECT COUNT(*)::int AS total FROM groups g ${whereSQL}`,
+        params,
+      ),
+      tenantQuery(
+        req.tenantSlug,
+        `${SELECT_GROUP} ${whereSQL} ORDER BY g.name LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+        [...params, limit, offset],
+      ),
+    ]);
+
+    const leaders = visible(cfg, 'contact')
+      ? await loadLeaders(
+          req.tenantSlug,
+          rows.map((g) => g.id),
+        )
+      : null;
+
+    return sendCollection(
+      res,
+      rows.map((g) => projectGroup(g, cfg, leaders)),
+      { total: count?.total ?? 0, limit, offset },
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── GET /:slug/groups/:id ────────────────────────────────────────────────
+
+router.get('/:slug/groups/:id', async (req, res, next) => {
+  try {
+    if (!(await requireFeatures(req, res, ['groups']))) return;
+    const cfg = (await visibility(req)).group;
+
+    const [row] = await tenantQuery(
+      req.tenantSlug,
+      `${SELECT_GROUP} WHERE g.id = $1 AND g.status = 'active' AND g.type = 'group'`,
+      [req.params.id],
+    );
+    if (!row) return apiFail(res, 404, 'not_found', 'Not found.');
+
+    const leaders = visible(cfg, 'contact') ? await loadLeaders(req.tenantSlug, [row.id]) : null;
+    return sendOne(res, projectGroup(row, cfg, leaders));
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/api/helpers.js
+++ b/backend/src/routes/api/helpers.js
@@ -1,0 +1,180 @@
+// beacon2026/backend/src/routes/api/helpers.js
+// Shared machinery for the public read API (/api/v1). See docs/API-design.md.
+//
+// Every field-visibility decision for the anonymous tier lives in this file
+// and in the per-resource projection functions that use `visible()`. Keeping
+// them in one place is deliberate: it means there is exactly one thing to
+// review when asking "can this leak?", and exactly one thing to test.
+
+import { z } from 'zod';
+import { tenantQuery } from '../../utils/db.js';
+import { FEATURE_DEPS, isOn } from '../../../../shared/constants.js';
+
+// ─── Error envelope ───────────────────────────────────────────────────────
+
+/** Public-API errors are `{ error: { code, message } }`, not the internal shape. */
+export function apiFail(res, status, code, message) {
+  return res.status(status).json({ error: { code, message } });
+}
+
+/** Router-level error handler, mounted at the end of the v1 router. */
+export function apiErrorHandler(err, req, res, _next) {
+  if (err?.name === 'ZodError') {
+    return apiFail(res, 400, 'invalid_query', err.errors.map((e) => e.message).join('; '));
+  }
+  if (err?.status && err?.message) {
+    return apiFail(res, err.status, err.code ?? 'error', err.message);
+  }
+  // Deliberately opaque: this surface is public, so it never leaks internals.
+  req.log?.error?.(err);
+  return apiFail(res, 500, 'internal_error', 'An unexpected error occurred.');
+}
+
+// ─── Success envelope ─────────────────────────────────────────────────────
+
+const MAX_AGE_SECONDS = 300;
+
+/**
+ * Send a cacheable public response. Express generates the ETag and answers
+ * a matching `If-None-Match` with a 304 by itself; all we add is the
+ * caching policy that makes integrators' caches actually work.
+ */
+function sendPublic(res, payload) {
+  res.set('Cache-Control', `public, max-age=${MAX_AGE_SECONDS}`);
+  return res.json(payload);
+}
+
+/** Collection response: `{ data: [...], meta: { total, limit, offset } }`. */
+export function sendCollection(res, rows, { total, limit, offset }) {
+  return sendPublic(res, { data: rows, meta: { total, limit, offset } });
+}
+
+/** Single-resource response: `{ data: {...} }`. */
+export function sendOne(res, row) {
+  return sendPublic(res, { data: row });
+}
+
+// ─── Pagination ───────────────────────────────────────────────────────────
+
+export const MAX_LIMIT = 200;
+export const DEFAULT_LIMIT = 50;
+
+const paginationSchema = z.object({
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1, 'limit must be between 1 and 200')
+    .max(MAX_LIMIT, 'limit must be between 1 and 200')
+    .default(DEFAULT_LIMIT),
+  offset: z.coerce.number().int().min(0, 'offset must be 0 or greater').default(0),
+});
+
+/** Parse and validate `?limit=&offset=`. Throws ZodError on bad input. */
+export function pagination(query) {
+  return paginationSchema.parse({
+    limit: query.limit ?? undefined,
+    offset: query.offset ?? undefined,
+  });
+}
+
+// ─── Feature gating ───────────────────────────────────────────────────────
+
+/**
+ * Load a tenant's feature_config once per request. Cached on `req` so a
+ * handler that checks two features does not make two round trips.
+ */
+export async function featureConfig(req) {
+  if (!req._featureConfig) {
+    const [row] = await tenantQuery(
+      req.tenantSlug,
+      `SELECT feature_config FROM tenant_settings WHERE id = 'singleton'`,
+    );
+    req._featureConfig = row?.feature_config ?? {};
+  }
+  return req._featureConfig;
+}
+
+/** Is a feature on for this tenant, honouring its master-toggle dependency? */
+export function featureOn(config, key) {
+  const parent = FEATURE_DEPS[key];
+  return isOn(config, key) && (!parent || isOn(config, parent));
+}
+
+/**
+ * Guard a resource behind a feature toggle. Returns true if the caller may
+ * proceed; otherwise it has already sent a 404.
+ *
+ * 404 rather than 403 is deliberate. To an anonymous caller, a resource a
+ * u3a has not enabled should be indistinguishable from one that does not
+ * exist — a 403 would confirm the u3a exists and merely declined.
+ */
+export async function requireFeatures(req, res, keys) {
+  const config = await featureConfig(req);
+  for (const key of keys) {
+    if (!featureOn(config, key)) {
+      apiFail(res, 404, 'not_found', 'Not found.');
+      return false;
+    }
+  }
+  return true;
+}
+
+// ─── Field visibility ─────────────────────────────────────────────────────
+
+/**
+ * Load the tenant's public-field configuration.
+ *
+ * This is the same `group_info_config` / `calendar_config` that drives the
+ * public Groups and Calendar pages. Reusing it is the core of the design:
+ * the anonymous API can never expose a field the u3a has not already chosen
+ * to publish on the open web.
+ */
+export async function visibility(req) {
+  if (!req._visibility) {
+    const [row] = await tenantQuery(
+      req.tenantSlug,
+      `SELECT group_info_config, calendar_config FROM tenant_settings WHERE id = 'singleton'`,
+    );
+    req._visibility = {
+      group: row?.group_info_config ?? {},
+      calendar: row?.calendar_config ?? {},
+    };
+  }
+  return req._visibility;
+}
+
+/**
+ * Is one configured field public? Everything defaults to *not* public, so a
+ * u3a that has never opened the Public Links page publishes nothing beyond
+ * the always-visible identity fields.
+ */
+export function visible(config, field) {
+  return config?.[field]?.public === true;
+}
+
+// ─── Deprecation signalling ───────────────────────────────────────────────
+
+/**
+ * The Third Age Trust owns this interface and has committed to six months'
+ * notice before any v1 field or endpoint changes meaning or is withdrawn
+ * (docs/API-design.md). Notice is signalled in-band with RFC 8594 headers as
+ * well as on the published documentation page, because anonymous access
+ * means we have no list of integrators to email.
+ *
+ * Inert until `API_V1_SUNSET` is set to an ISO date, which is the intended
+ * steady state: v1 is not deprecated.
+ */
+export function deprecationHeaders(_req, res, next) {
+  const sunset = process.env.API_V1_SUNSET;
+  if (sunset) {
+    const date = new Date(sunset);
+    if (!Number.isNaN(date.getTime())) {
+      res.set('Deprecation', 'true');
+      res.set('Sunset', date.toUTCString());
+      if (process.env.API_V1_SUNSET_LINK) {
+        res.set('Link', `<${process.env.API_V1_SUNSET_LINK}>; rel="sunset"`);
+      }
+    }
+  }
+  next();
+}

--- a/backend/src/routes/api/index.js
+++ b/backend/src/routes/api/index.js
@@ -1,0 +1,80 @@
+// beacon2026/backend/src/routes/api/index.js
+// The public read API, version 1. See docs/API-design.md.
+//
+// This is a *published* interface owned by the Third Age Trust, with a
+// six-month deprecation notice period. It is not the internal API the React
+// frontend uses: routes here are versioned and additive-only, and nothing in
+// v1 changes meaning without notice. Adding a field is free; changing or
+// removing one is a commitment measured in months.
+//
+// Read-only, anonymous, and opt-in per u3a via the `publicApi` feature.
+
+import { Router } from 'express';
+import { createRequire } from 'module';
+import { makeResolveTenant } from '../../utils/resolveTenant.js';
+import {
+  apiFail,
+  apiErrorHandler,
+  deprecationHeaders,
+  featureConfig,
+  featureOn,
+} from './helpers.js';
+import orgRoutes from './org.js';
+import facultyRoutes from './faculties.js';
+import venueRoutes from './venues.js';
+import groupRoutes from './groups.js';
+import eventRoutes from './events.js';
+
+const require = createRequire(import.meta.url);
+const openapi = require('./openapi.json');
+
+const router = Router();
+
+router.use(deprecationHeaders);
+
+// ─── Specification ────────────────────────────────────────────────────────
+// Declared before the `/:slug` middleware so it is never mistaken for a
+// tenant slug. (It would be rejected by the slug guard anyway, but a 400 on
+// the documentation URL would be a poor first impression.)
+
+router.get('/openapi.json', (_req, res) => {
+  res.set('Cache-Control', 'public, max-age=300');
+  res.json(openapi);
+});
+
+// ─── Tenant resolution ────────────────────────────────────────────────────
+// Shared with the public pages via utils/resolveTenant.js, with this API's
+// own error envelope substituted.
+
+router.use('/:slug', makeResolveTenant(apiFail));
+
+// ─── Feature gate ─────────────────────────────────────────────────────────
+
+router.use('/:slug', async (req, res, next) => {
+  try {
+    const config = await featureConfig(req);
+    if (!featureOn(config, 'publicApi')) {
+      // 404, not 403: to an anonymous caller a u3a that has not opted in
+      // should look no different from one that does not exist.
+      return apiFail(res, 404, 'not_found', 'Not found.');
+    }
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── Resources ────────────────────────────────────────────────────────────
+
+router.use('/', orgRoutes);
+router.use('/', facultyRoutes);
+router.use('/', venueRoutes);
+router.use('/', groupRoutes);
+router.use('/', eventRoutes);
+
+// ─── Fallbacks ────────────────────────────────────────────────────────────
+
+router.use((_req, res) => apiFail(res, 404, 'not_found', 'Not found.'));
+router.use(apiErrorHandler);
+
+export default router;

--- a/backend/src/routes/api/openapi.json
+++ b/backend/src/routes/api/openapi.json
@@ -1,0 +1,427 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "beacon2026 public read API",
+    "version": "1.0.0",
+    "summary": "Read-only access to a u3a's published groups, events, venues and interest areas.",
+    "description": "A read-only interface to the information a u3a has chosen to publish. It never exposes more than that u3a's own public web pages already show, and it never exposes member data.\n\nThe interface is owned by the Third Age Trust. No field or endpoint in v1 will be withdrawn, or change meaning, with less than six months' published notice. Notice is signalled on affected responses with the `Deprecation` and `Sunset` headers (RFC 8594) as well as on the published documentation page — please have your integration surface those headers somewhere a human will see them.\n\nNew fields may be added to any response at any time. Clients must ignore fields they do not recognise.\n\nAccess is anonymous: no key, no registration. Each u3a opts in individually, so a 404 may mean the u3a has not enabled the API rather than that it does not exist. Please cache responses — they carry `Cache-Control` and `ETag`, and honouring them keeps the service fast for everyone.",
+    "contact": {
+      "name": "Third Age Trust"
+    },
+    "license": { "name": "See repository LICENSE" }
+  },
+  "servers": [{ "url": "/api/v1", "description": "This beacon2026 instance" }],
+  "tags": [
+    { "name": "Organisation" },
+    { "name": "Groups" },
+    { "name": "Events" },
+    { "name": "Venues" },
+    { "name": "Interest areas" }
+  ],
+  "paths": {
+    "/{slug}/org": {
+      "get": {
+        "tags": ["Organisation"],
+        "summary": "The u3a's name and public contact details",
+        "parameters": [{ "$ref": "#/components/parameters/slug" }],
+        "responses": {
+          "200": {
+            "description": "The organisation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "data": { "$ref": "#/components/schemas/Org" } }
+                }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/{slug}/faculties": {
+      "get": {
+        "tags": ["Interest areas"],
+        "summary": "Interest areas used to categorise groups",
+        "parameters": [
+          { "$ref": "#/components/parameters/slug" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of interest areas",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/Collection" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Faculty" }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/{slug}/venues": {
+      "get": {
+        "tags": ["Venues"],
+        "summary": "Venues where groups meet",
+        "description": "Returns 404 unless the u3a publishes venues on its public groups page.",
+        "parameters": [
+          { "$ref": "#/components/parameters/slug" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of venues",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/Collection" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Venue" }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/{slug}/venues/{id}": {
+      "get": {
+        "tags": ["Venues"],
+        "summary": "One venue",
+        "parameters": [
+          { "$ref": "#/components/parameters/slug" },
+          { "$ref": "#/components/parameters/id" }
+        ],
+        "responses": {
+          "200": {
+            "description": "The venue",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "data": { "$ref": "#/components/schemas/Venue" } }
+                }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/{slug}/groups": {
+      "get": {
+        "tags": ["Groups"],
+        "summary": "Active interest groups",
+        "description": "Only active interest groups are returned. Which optional fields appear depends on what the u3a has chosen to publish, so a field being absent is normal and clients must not depend on it.",
+        "parameters": [
+          { "$ref": "#/components/parameters/slug" },
+          {
+            "name": "faculty",
+            "in": "query",
+            "description": "Filter to one interest area, by its id.",
+            "schema": { "type": "string", "maxLength": 64 }
+          },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of groups",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/Collection" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Group" }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/{slug}/groups/{id}": {
+      "get": {
+        "tags": ["Groups"],
+        "summary": "One active interest group",
+        "parameters": [
+          { "$ref": "#/components/parameters/slug" },
+          { "$ref": "#/components/parameters/id" }
+        ],
+        "responses": {
+          "200": {
+            "description": "The group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "data": { "$ref": "#/components/schemas/Group" } }
+                }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/{slug}/events": {
+      "get": {
+        "tags": ["Events"],
+        "summary": "Public calendar events",
+        "description": "Events the u3a has not marked private. Which optional fields appear depends on what the u3a has chosen to publish.",
+        "parameters": [
+          { "$ref": "#/components/parameters/slug" },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Earliest event date, inclusive (YYYY-MM-DD).",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "Latest event date, inclusive (YYYY-MM-DD).",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "group",
+            "in": "query",
+            "description": "Filter to one group, by its id.",
+            "schema": { "type": "string", "maxLength": 64 }
+          },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/Collection" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Event" }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/{slug}/events/{id}": {
+      "get": {
+        "tags": ["Events"],
+        "summary": "One public event",
+        "parameters": [
+          { "$ref": "#/components/parameters/slug" },
+          { "$ref": "#/components/parameters/id" }
+        ],
+        "responses": {
+          "200": {
+            "description": "The event",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "data": { "$ref": "#/components/schemas/Event" } }
+                }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "slug": {
+        "name": "slug",
+        "in": "path",
+        "required": true,
+        "description": "The u3a's identifier. Lower-case letters, digits and underscores only.",
+        "schema": { "type": "string", "pattern": "^[a-z0-9_]+$" }
+      },
+      "id": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": { "type": "string" }
+      },
+      "limit": {
+        "name": "limit",
+        "in": "query",
+        "description": "Page size, 1–200.",
+        "schema": { "type": "integer", "minimum": 1, "maximum": 200, "default": 50 }
+      },
+      "offset": {
+        "name": "offset",
+        "in": "query",
+        "schema": { "type": "integer", "minimum": 0, "default": 0 }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "The query string was not valid.",
+        "content": {
+          "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+        }
+      },
+      "NotFound": {
+        "description": "No such u3a or resource — or the u3a has not enabled this API.",
+        "content": {
+          "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" }
+            },
+            "required": ["code", "message"]
+          }
+        }
+      },
+      "Collection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "type": "object",
+            "properties": {
+              "total": { "type": "integer" },
+              "limit": { "type": "integer" },
+              "offset": { "type": "integer" }
+            },
+            "required": ["total", "limit", "offset"]
+          }
+        }
+      },
+      "Org": {
+        "type": "object",
+        "properties": {
+          "slug": { "type": "string" },
+          "name": { "type": "string" },
+          "phone": { "type": ["string", "null"] },
+          "email": { "type": ["string", "null"] },
+          "homePage": { "type": ["string", "null"] }
+        },
+        "required": ["slug", "name"]
+      },
+      "Faculty": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" }
+        },
+        "required": ["id", "name"]
+      },
+      "Venue": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "postcode": { "type": ["string", "null"] }
+        },
+        "required": ["id", "name"]
+      },
+      "Group": {
+        "type": "object",
+        "description": "Fields beyond the required ones appear only if the u3a publishes them.",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "facultyId": { "type": ["string", "null"] },
+          "faculty": { "type": ["string", "null"] },
+          "when": {
+            "type": ["string", "null"],
+            "description": "Free text, e.g. \"2nd Thursday at 2:00pm\"."
+          },
+          "startTime": { "type": ["string", "null"] },
+          "endTime": { "type": ["string", "null"] },
+          "status": { "type": "string" },
+          "venue": { "type": ["string", "null"] },
+          "venuePostcode": { "type": ["string", "null"] },
+          "contact": { "type": ["string", "null"] },
+          "enquiries": { "type": ["string", "null"] },
+          "information": { "type": ["string", "null"] }
+        },
+        "required": ["id", "name", "facultyId", "faculty", "when", "startTime", "endTime"]
+      },
+      "Event": {
+        "type": "object",
+        "description": "Fields beyond the required ones appear only if the u3a publishes them.",
+        "properties": {
+          "id": { "type": "string" },
+          "date": { "type": "string", "format": "date" },
+          "startTime": { "type": ["string", "null"] },
+          "endTime": { "type": ["string", "null"] },
+          "groupId": { "type": ["string", "null"] },
+          "groupName": { "type": "string" },
+          "venue": { "type": ["string", "null"] },
+          "venuePostcode": { "type": ["string", "null"] },
+          "topic": { "type": ["string", "null"] },
+          "contact": { "type": ["string", "null"] },
+          "details": { "type": ["string", "null"] }
+        },
+        "required": ["id", "date", "startTime", "endTime", "groupId", "groupName"]
+      }
+    }
+  }
+}

--- a/backend/src/routes/api/org.js
+++ b/backend/src/routes/api/org.js
@@ -1,0 +1,33 @@
+// beacon2026/backend/src/routes/api/org.js
+// GET /api/v1/:slug/org — the u3a's own public identity and contact details.
+//
+// Field parity: these are exactly the fields already served unauthenticated
+// by GET /public/:slug/info, which the Members Portal sign-in and online
+// joining pages show to prospective members.
+
+import { Router } from 'express';
+import { tenantQuery } from '../../utils/db.js';
+import { sendOne } from './helpers.js';
+
+const router = Router();
+
+router.get('/:slug/org', async (req, res, next) => {
+  try {
+    const [settings] = await tenantQuery(
+      req.tenantSlug,
+      `SELECT public_phone, public_email, home_page
+       FROM tenant_settings WHERE id = 'singleton'`,
+    );
+    return sendOne(res, {
+      slug: req.tenantSlug,
+      name: req.tenant.name || req.tenantSlug,
+      phone: settings?.public_phone || null,
+      email: settings?.public_email || null,
+      homePage: settings?.home_page || null,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/api/venues.js
+++ b/backend/src/routes/api/venues.js
@@ -1,0 +1,78 @@
+// beacon2026/backend/src/routes/api/venues.js
+// GET /api/v1/:slug/venues  and  /venues/:id — where groups meet.
+//
+// Gated on the tenant's `venue` public toggle: a u3a that has chosen not to
+// show venues on its public groups page does not expose them here either,
+// and the whole collection 404s.
+//
+// Only `name` and `postcode` are exposed — the same two fields the public
+// groups page renders. Address lines are deliberately not included; the
+// postcode is enough to link to a map, which is the actual use case.
+
+import { Router } from 'express';
+import { tenantQuery } from '../../utils/db.js';
+import {
+  sendCollection,
+  sendOne,
+  pagination,
+  requireFeatures,
+  visibility,
+  visible,
+  apiFail,
+} from './helpers.js';
+
+const router = Router();
+
+/** Venues are only public at all if the u3a publishes venues on its groups page. */
+async function venuesArePublic(req, res) {
+  if (!(await requireFeatures(req, res, ['groups', 'venues']))) return false;
+  const vis = await visibility(req);
+  if (!visible(vis.group, 'venue')) {
+    apiFail(res, 404, 'not_found', 'Not found.');
+    return false;
+  }
+  return true;
+}
+
+router.get('/:slug/venues', async (req, res, next) => {
+  try {
+    if (!(await venuesArePublic(req, res))) return;
+    const { limit, offset } = pagination(req.query);
+
+    const [[count], rows] = await Promise.all([
+      tenantQuery(req.tenantSlug, `SELECT COUNT(*)::int AS total FROM venues`),
+      tenantQuery(
+        req.tenantSlug,
+        `SELECT id, name, postcode FROM venues ORDER BY name LIMIT $1 OFFSET $2`,
+        [limit, offset],
+      ),
+    ]);
+
+    return sendCollection(
+      res,
+      rows.map((v) => ({ id: v.id, name: v.name, postcode: v.postcode || null })),
+      { total: count?.total ?? 0, limit, offset },
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/:slug/venues/:id', async (req, res, next) => {
+  try {
+    if (!(await venuesArePublic(req, res))) return;
+
+    const [row] = await tenantQuery(
+      req.tenantSlug,
+      `SELECT id, name, postcode FROM venues WHERE id = $1`,
+      [req.params.id],
+    );
+    if (!row) return apiFail(res, 404, 'not_found', 'Not found.');
+
+    return sendOne(res, { id: row.id, name: row.name, postcode: row.postcode || null });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/public/index.js
+++ b/backend/src/routes/public/index.js
@@ -7,7 +7,7 @@
 // pages) and the authenticated portal app router.
 
 import { Router } from 'express';
-import { prisma } from '../../utils/db.js';
+import { resolveTenant } from '../../utils/resolveTenant.js';
 import joinRouter from './join.js';
 import portalAuthRouter from './portalAuth.js';
 import readRouter from './read.js';
@@ -16,26 +16,8 @@ import portalRoutes from '../portal/index.js';
 const router = Router();
 
 // ─── Middleware: resolve tenant from slug ────────────────────────────────
-
-async function resolveTenant(req, res, next) {
-  const { slug } = req.params;
-  // Keep this identical to the guard in utils/db.js so a slug that the edge
-  // accepts can never 500 inside tenantQuery (schema names cannot contain `-`).
-  if (!slug || !/^[a-z0-9_]+$/.test(slug)) {
-    return res.status(400).json({ error: 'Invalid tenant slug.' });
-  }
-  try {
-    const tenant = await prisma.sysTenant.findUnique({ where: { slug } });
-    if (!tenant || !tenant.active) {
-      return res.status(404).json({ error: 'Organisation not found.' });
-    }
-    req.tenant = tenant;
-    req.tenantSlug = slug;
-    next();
-  } catch (err) {
-    next(err);
-  }
-}
+// Shared with /api/v1 via utils/resolveTenant.js — see the note there about
+// keeping the slug guard identical to utils/db.js.
 
 router.use('/:slug', resolveTenant);
 

--- a/backend/src/utils/resolveTenant.js
+++ b/backend/src/utils/resolveTenant.js
@@ -1,0 +1,46 @@
+// beacon2026/backend/src/utils/resolveTenant.js
+// Shared tenant-from-slug resolution middleware.
+//
+// Extracted from routes/public/index.js so the public pages and the public
+// read API (/api/v1) cannot drift apart. The slug guard here must stay
+// byte-identical to the one in utils/db.js: a slug the edge accepts but
+// tenantQuery rejects would surface as a 500 instead of a 400.
+
+import { prisma } from './db.js';
+
+/** The one true slug shape. Schema names cannot contain `-`. */
+export const SLUG_RE = /^[a-z0-9_]+$/;
+
+/**
+ * Express middleware factory. Resolves `:slug` to an active tenant and
+ * attaches `req.tenant` / `req.tenantSlug`.
+ *
+ * @param {(res: import('express').Response, status: number, code: string, message: string) => void} [respond]
+ *   Optional error responder, so callers can choose their error envelope.
+ *   Defaults to the `{ error: '...' }` shape used by the public pages.
+ */
+export function makeResolveTenant(respond) {
+  const fail =
+    respond ?? ((res, status, _code, message) => res.status(status).json({ error: message }));
+
+  return async function resolveTenant(req, res, next) {
+    const { slug } = req.params;
+    if (!slug || !SLUG_RE.test(slug)) {
+      return fail(res, 400, 'invalid_slug', 'Invalid tenant slug.');
+    }
+    try {
+      const tenant = await prisma.sysTenant.findUnique({ where: { slug } });
+      if (!tenant || !tenant.active) {
+        return fail(res, 404, 'not_found', 'Organisation not found.');
+      }
+      req.tenant = tenant;
+      req.tenantSlug = slug;
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+/** Default instance, matching the historic public-pages behaviour. */
+export const resolveTenant = makeResolveTenant();

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -1,7 +1,7 @@
 # beacon2026 — Project Definition (last reviewed 2026-06-14)
 
 > **Note:** This document describes the *current* state of the project as of
-> 2026-06-14 (version 0.11.1). It is the canonical inventory of modules, routes,
+> 2026-06-14 (version 0.12.0). It is the canonical inventory of modules, routes,
 > and pages; for a contributor-oriented repo map and quickstart see
 > [`README.md`](README.md). Read it alongside `CLAUDE.md`, `CLAUDE-STANDARDS.md`,
 > and `CLAUDE-REFERENCE.md` in the repository root, which contain coding
@@ -26,7 +26,7 @@ beacon2026 is a ground-up rebuild with these goals:
 
 ---
 
-## What has been built (as of version 0.11.1)
+## What has been built (as of version 0.12.0)
 
 ### Infrastructure and platform
 - Full multi-tenant architecture (PostgreSQL schema-per-tenant)
@@ -252,6 +252,25 @@ beacon2026 is a ground-up rebuild with these goals:
   Named `:param` placeholders are substituted with positional `$N` server-side.
   Results render as a table; Excel download via ExcelJS. Every run is audited.
 
+### Public read API (beacon2026 extra)
+- **`/api/v1` — versioned, read-only, anonymous** interface for a u3a's own
+  website and other external consumers. Owned by the Third Age Trust with a
+  six-month deprecation notice period; design in `docs/API-design.md`.
+  Distinct from the internal API the React frontend uses, which stays private
+  and unversioned.
+- Resources: `org`, `faculties`, `venues` (+ `/:id`), `groups` (+ `/:id`,
+  `?faculty=`), `events` (+ `/:id`, `?from=&to=&group=`). Collections are
+  paginated and return `{ data, meta }`; errors are `{ error: { code, message } }`
+- **Opt-in per u3a** behind the `publicApi` feature toggle (defaults **off** —
+  the only feature besides `giftAid`, `groupLedger` and `siteworks` to do so)
+- **Field visibility reuses `group_info_config` / `calendar_config`**, so the
+  API can never expose more than the u3a's public Groups and Calendar pages.
+  **No member data exists in v1** — no endpoint, none in the specification
+- Cacheable (`Cache-Control` + `ETag`), own rate-limit bucket, CORS `*` and
+  relaxed `Cross-Origin-Resource-Policy`; mounted before the app-wide
+  helmet/cors/limiter in `app.js`, which is load-bearing (see the comment there)
+- OpenAPI 3.1 document served at `/api/v1/openapi.json`
+
 ### Admin / Misc module
 - **Audit log** — date-filtered view + delete-before-date; clickable When → Audit Record detail; clickable Record → entity view
 - **Gift Aid log** — date-filtered view of Gift Aid consent given/withdrawn; member filter dropdown
@@ -315,6 +334,9 @@ backend/
                            addressExport  email  giftAid  systemMessages
                            publicLinks  public  portal  calendar  eventTypes
                            letters  membershipCards  officers  customFields  audit
+      api/                 Public read API v1 — index (tenant + feature gate),
+                           helpers (envelope, pagination, visibility),
+                           org  faculties  venues  groups  events  openapi.json
     services/              authService
     utils/                 db  jwt  password  redis  migrate  audit  emailTokens  paypal
     seed/                  index  createTenant  privilegeResources  defaultRoles

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-frontend",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.27.3",
         "@tiptap/extension-text-style": "^3.27.3",
@@ -790,9 +790,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -810,9 +807,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -830,9 +824,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -850,9 +841,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -870,9 +858,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -890,9 +875,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/settings/FeatureConfig.jsx
+++ b/frontend/src/pages/settings/FeatureConfig.jsx
@@ -241,6 +241,12 @@ const SECTIONS = [
         defaultValue: true,
         tip: 'Public Groups and Public Calendar pages visible without login',
       },
+      {
+        key: 'publicApi',
+        label: 'Public read API',
+        defaultValue: false,
+        tip: 'Lets your website read your groups, events, venues and interest areas. It only ever shows what you have already ticked as public below — and never member details.',
+      },
     ],
   },
 ];

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -23,7 +23,15 @@ export const FEATURE_DEPS = {
 
 // Features that default to OFF when the key is missing from feature_config.
 // All other features default to ON (opt-out model).
-export const FEATURE_DEFAULTS_OFF = new Set(['giftAid', 'groupLedger', 'siteworks']);
+export const FEATURE_DEFAULTS_OFF = new Set([
+  'giftAid',
+  'groupLedger',
+  'siteworks',
+  // The public read API is a published external interface. A u3a that has
+  // never heard of it must be unaffected by it, so it defaults off and is
+  // opted into deliberately — see docs/API-design.md.
+  'publicApi',
+]);
 
 /** Is a single feature key on, considering its default? */
 export function isOn(config, key) {
@@ -70,7 +78,13 @@ export const ALL_FEATURE_KEYS = Object.freeze([
   // Other
   'reports',
   'publicPages',
+  'publicApi',
 ]);
+
+// ── Public read API ─────────────────────────────────────────────────────
+// The version served at /api/v1. Bumping this is a deliberate act with a
+// six-month notice period attached — see docs/API-design.md.
+export const API_VERSION = 'v1';
 
 // ── Standard Beacon Implementations ─────────────────────────────────────
 // Named presets for the full feature_config JSON.  An entry is applied to a


### PR DESCRIPTION
Implements **phase 1** of [`docs/API-design.md`](docs/API-design.md) (design
note in #472): a versioned, read-only, anonymous API at `/api/v1`, so a u3a's
own website can show its groups and what's on without anyone re-keying them.

## What a u3a sees

A new **Public read API** toggle under Set up → Feature Configuration → Other,
**default off**. While it is off, every `/api/v1` route 404s. Turning it on
publishes only what the u3a has already ticked public in Public Links.

## Endpoints

```
GET /api/v1/:slug/org
GET /api/v1/:slug/faculties
GET /api/v1/:slug/venues        (+ /:id)
GET /api/v1/:slug/groups        (+ /:id, ?faculty=)
GET /api/v1/:slug/events        (+ /:id, ?from=&to=&group=)
GET /api/v1/openapi.json
```

Collections paginated (`?limit=` max 200, `?offset=`) returning
`{ data, meta }`; errors `{ error: { code, message } }`; responses carry
`Cache-Control: public, max-age=300` and an `ETag`.

## The two invariants, both test-enforced

1. **The anonymous tier can never expose more than the u3a's public web pages
   already do.** Visibility reuses the same `group_info_config` /
   `calendar_config` toggles as the public Groups and Calendar pages, every one
   defaulting to not-public. The tests assert the **exact key set** of each
   response, so a column added to a query cannot reach a response without a
   deliberate test change — a careless field fails the build rather than
   shipping quietly.
2. **No member data exists in v1** — no endpoint, none in the specification,
   both asserted.

Everything unavailable returns **404, not 403**: a u3a that has not opted in
should be indistinguishable from one that does not exist.

## Reviewer's attention

- **Mount order in `app.js` is load-bearing.** `/api/v1` goes in *before* the
  app-wide `helmet()`, `cors()` and `generalLimiter`, because it needs
  different values for all three and whichever runs first wins.
  `cors({ origin: CORS_ORIGIN })` echoes one configured origin to every caller
  rather than matching the request (so it would refuse a u3a's own website),
  and helmet's default `Cross-Origin-Resource-Policy` blocks cross-origin reads
  even when CORS is correct. It also gets its own rate-limit bucket so a busy
  u3a website cannot exhaust the frontend's allowance.
- **Faculties are a judgement call worth checking.** They have no
  `group_info_config` entry, so strictly they sit outside invariant 1. Included
  on the narrower ground that a faculty is pure taxonomy with no personal data,
  and is the organising axis that makes a website's groups page useful. Only
  `id` and `name` are exposed. Reasoning is in `routes/api/faculties.js`.
- **Spec-vs-routes parity test.** A hand-written OpenAPI document is only worth
  having if it cannot drift, so a test compares documented paths against the
  Express router stack both ways round. Verified it fails on injected drift.
- `utils/resolveTenant.js` is extracted and shared with `routes/public/` so the
  slug guard cannot drift from `utils/db.js`. No behaviour change there.

## Deprecation plumbing

The Trust owns this interface with six months' notice.
`Deprecation`/`Sunset` headers (RFC 8594) are implemented and inert — they
appear only when `API_V1_SUNSET` is set, which is the intended steady state.

## Verification

Backend **643 tests pass** (35 new), frontend **198**, lint clean both sides
(the 31 frontend warnings are pre-existing `exhaustive-deps`). Version bumped
0.11.1 → 0.12.0 per `CONTRIBUTING.md`.

Not verified against a live database — the new tests mock the DB layer as every
other route test here does. Worth a smoke test against staging after merge.

A pre-existing `TransferMoney.test.jsx` flake surfaced twice during this work;
investigated, reproduced only under heavy concurrent load, ruled out as related
(no dependency path, 4 consecutive clean full-suite runs with these changes),
and recorded in `KNOWN-ISSUES.md` rather than left as folklore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
