### PR TITLE
Document lessons learned from the /api/v1 phase 1 work

### DIFF
--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -2107,6 +2107,19 @@ decisions below are not local implementation choices.
 - **No member data.** There is no members endpoint in v1 and none in the spec;
   `apiV1.test.js` asserts both. Adding one is a phase-4 decision (API keys plus
   an explicit scope), not a routine change.
+- **The spec cannot drift from the code.** A parity test walks the Express
+  router stacks, converts `/:slug/groups/:id` to `/{slug}/groups/{id}`, and
+  asserts the result equals the documented path list *both ways round* — an
+  undocumented route fails, and so does a documented path that does not exist.
+  A hand-written OpenAPI document is only worth having with this guard in
+  place. Both it and the key-set assertions were verified red against injected
+  drift on 2026-08-01; re-verify the same way if you rework them.
+- **Faculties sit slightly outside the public-parity rule, deliberately.**
+  They have no `group_info_config` entry, so nothing in Public Links governs
+  them. They are exposed (id and name only) on the narrower ground that a
+  faculty is pure taxonomy carrying no personal data. If that judgement is
+  revisited, `routes/api/faculties.js` and the `faculty`/`facultyId` fields in
+  `routes/api/groups.js` are the only two places to change.
 
 ### Configuration
 

--- a/CLAUDE-STANDARDS.md
+++ b/CLAUDE-STANDARDS.md
@@ -395,6 +395,29 @@ Every item below applies to every new feature — no exceptions.
 - [ ] **Multiple text instances** — if heading appears in NavBar breadcrumb AND `<h1>`,
   use `getAllByText` not `getByText` in tests.
 
+- [ ] **Prove a guard test can fail before trusting it.** When a test exists to
+  stop something bad reaching production — a leak guard, a spec-vs-code parity
+  check, an invariant assertion — deliberately break the thing it guards, watch
+  it go red, then restore. A guard that silently passes because it asserts two
+  empty arrays against each other is worse than none, because it buys
+  confidence it has not earned. Add a cheap non-vacuity assertion too (e.g.
+  `expect(actual.length).toBeGreaterThanOrEqual(8)`). Done for the `/api/v1`
+  key-set and OpenAPI parity tests on 2026-08-01; both were verified red on
+  injected drift.
+
+- [ ] **Assert the exact key set for anything published externally.** For
+  responses whose whole safety property is "only these fields", assert
+  `Object.keys(x).sort()` equals the full expected list rather than checking
+  individual fields are present or absent. A field added to a query then fails
+  the build instead of shipping quietly. See `apiV1.test.js`.
+
+- [ ] **Investigate an intermittent failure before dismissing it.** Do not
+  assume a flake is pre-existing. Establish a mechanism (is there even a
+  dependency path from the change to the test?) and get evidence — run the test
+  in isolation, run the suite repeatedly, and `git stash` the change to compare
+  against a clean tree. Then record the finding in `KNOWN-ISSUES.md` so the next
+  session does not repeat the investigation.
+
 ## Reports, design notes, and estimates
 
 - [ ] **State the basis for every effort estimate.** Never give a bare

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,15 @@ After a PR merges, delete the branch both locally and on GitHub
 (`git branch -D <branch>` / `gh pr merge --delete-branch`, or the "Delete
 branch" button on the merged PR) before starting the next one.
 
+**If PR B references a file added by unmerged PR A, merge A first.** Branching
+fresh off `origin/main` (correctly) means B does not contain A's files, so any
+link or code comment in B pointing at them dangles until A lands. This happened
+on 2026-08-01: `docs/API-design.md` (#472) was referenced from ten places in the
+phase-1 implementation (#473). Merging in order fixed it with no code change —
+but merging B first would have shipped ten broken references, including two
+Markdown links that 404 on GitHub. Check for cross-PR references before merging,
+not after.
+
 The "if a document is missing" flow below (`git merge origin/main --no-edit`)
 is only for pulling newly-uploaded reference docs into the *current* branch
 mid-task — it is not a substitute for starting the *next* task from a fresh
@@ -179,6 +188,32 @@ cd frontend && npm run lint && npm run format:check
 ESLint 9 (flat config, `eslint.config.js`) and Prettier (root `.prettierrc.json`)
 are configured in both packages. CI (`ci.yml`) runs `lint` and `format:check` for
 each, so both must pass. Use `npm run lint:fix` and `npm run format` to auto-fix.
+
+### `format:check` on Windows reports ~146 false failures — do not "fix" them
+
+`.prettierrc.json` sets `endOfLine: "lf"`, but a Windows checkout with
+`core.autocrlf=true` has CRLF in the working tree. Prettier therefore flags
+**every file it checks** (~146: `backend/src`, `frontend/src`, `shared`) on line
+endings alone. It looks like the codebase is catastrophically unformatted. It is
+not, and CI (Linux, LF) passes fine.
+
+**Never run `npm run format` to clear it** — that rewrites ~146 untouched files
+and buries your actual change in the diff.
+
+To check only the files you touched, compare with line endings normalised on
+**both** sides — prettier's own output is not reliably LF here either, and
+normalising only the input produces false "differs" results:
+
+```bash
+diff <(tr -d '\r' < path/to/file.js) <(npx prettier path/to/file.js | tr -d '\r')
+```
+
+No output means the file is correctly formatted and differs only by line
+endings. For files you created in this session (already LF), plain
+`npx prettier --check <file>` works normally.
+
+Note `format:check` globs only `src/**/*.js(x)` and `shared/**/*.js` — root
+Markdown (`CLAUDE*.md`, `README.md`, `docs/`) is not checked by CI at all.
 Lint must be **error-free**; `react-hooks/exhaustive-deps` is a warning only.
 The frontend deliberately stays on `eslint-plugin-react-hooks` **v5** — do not
 upgrade to v7 without budgeting for the refactors its new rules require (see

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -566,6 +566,15 @@ built; the items below are deliberately out of it.
 6. `[OPEN]` **Trust agreement to own the interface (phase 0b).** Not code. It
    gates *publishing* rather than building, and should be secured before the
    API is advertised to other u3as.
+7. `[OPEN]` **`/api/v1` has never run against a real database.** The 35 tests in
+   `apiV1.test.js` mock the DB layer, as every other route test here does, so
+   the SQL itself is unexercised — column names, the `= ANY($1)` leader lookup,
+   and the `::date` casts in the event filters are all verified by inspection
+   only. Merged 2026-08-01 (#473) in that state deliberately: the feature is off
+   by default, so nothing is exposed until a u3a opts in. **Before enabling it
+   for any u3a**, enable `publicApi` on the demo tenant and hit
+   `/api/v1/demo2/{org,faculties,venues,groups,events}` — a few minutes' work
+   that closes the gap.
 
 ## Test flakiness
 

--- a/docs/API-design.md
+++ b/docs/API-design.md
@@ -103,6 +103,23 @@ not return the venue, for the same reason the public groups page does
 not show it. There is no new judgement call for a u3a to make and no
 new way to leak.
 
+**One deliberate exception, recorded during phase 1.** Faculties
+(interest areas) have no entry in `group_info_config`, so nothing in
+Public Links governs them and they are not covered by the rule as
+stated. They are exposed anyway — `id` and `name` only — on the
+narrower ground that a faculty is pure taxonomy: a label a u3a
+invented to categorise its own groups, carrying no personal data of
+any kind, and the organising axis that makes a website's groups page
+useful at all. The same reasoning covers the `faculty` / `facultyId`
+fields on a group.
+
+The exception is noted here rather than left in a code comment because
+it slightly weakens a rule the rest of this design leans on, and
+anyone auditing that rule should meet the exception at the same time
+as the rule. If it is ever revisited, `routes/api/faculties.js` and
+the faculty fields in `routes/api/groups.js` are the only two places
+to change.
+
 This tier alone satisfies the website use case.
 
 ### Tier 2 — API key


### PR DESCRIPTION
Docs-only. Closes five gaps where something learned during the `/api/v1`
phase 1 work (#472, #473) lived only in a PR body, a code comment, or nowhere
at all — so a cold start would have had to rediscover it.

## What was undocumented

| Lesson | Now in |
|---|---|
| `format:check` reports ~146 **false** failures on Windows (CRLF vs `endOfLine: "lf"`), and `npm run format` must not be used to "fix" it | `CLAUDE.md` |
| Merge a design PR before an implementation PR that references it | `CLAUDE.md` |
| Prove a guard test can fail before trusting it; assert exact key sets; investigate flakes properly | `CLAUDE-STANDARDS.md` → Testing |
| The OpenAPI parity test, and faculties sitting outside the public-parity rule | `CLAUDE-REFERENCE.md` §27 |
| `/api/v1` has never run against a real database | `KNOWN-ISSUES.md` |

## The two worth reading

**The Windows formatting trap.** `CLAUDE.md` currently says "run
`npm run format:check` before committing" with no caveat. On this machine that
reports ~146 files failing — essentially the whole checked codebase — purely on
line endings. It looks alarming and it is not real; CI on Linux passes. Without
the note, the obvious response is `npm run format`, which rewrites 146 untouched
files and buries the actual change.

**Never smoke-tested against a real database.** The 35 tests in `apiV1.test.js`
mock the DB layer as every route test here does, so the SQL itself — column
names, the `= ANY($1)` leader lookup, the `::date` casts — is verified only by
inspection. That was fine to merge (the feature is off by default, so nothing is
exposed), but it must not stay invisible: it is now an explicit `[OPEN]` item
with the exact commands to close it.

## Corrections to my own first draft

Both caught by testing the advice rather than assuming it:

- the Windows note claimed "every file in the repo" — `format:check` actually
  globs only `src/**` and `shared/**`, and root Markdown is unchecked by CI;
- the documented `diff` normalised line endings on **one** side only, which
  produced a false "differs" on `CLAUDE-STANDARDS.md`. Prettier's own output is
  not reliably LF here either. Fixed to normalise both sides, then re-verified
  all five files clean.

No code, no CHANGELOG entry, no version bump (per `CONTRIBUTING.md`, docs-only
changes skip the bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
