### PR TITLE
Add the events.ics iCalendar feed (/api/v1 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,28 @@ under the Unreleased headings below).
     (RFC 8594) when `API_V1_SUNSET` is set. v1 is not deprecated, so no such
     headers are sent today.
 
+- **Subscribable calendar feed (`/api/v1/:slug/events.ics`) — phase 2 of the
+  public read API.** The u3a's public calendar as an iCalendar (RFC 5545) feed,
+  so a member can paste the URL into Google Calendar, Apple Calendar or Outlook
+  once and have the programme keep itself up to date. No key, no registration
+  and nothing to install — the URL *is* the integration.
+  - `?group=<id>` narrows it to a single group, for a member who only wants
+    their own group's meetings in their calendar. A filtered feed is named
+    after the group, so two subscriptions are easy to tell apart.
+  - **Shows exactly what `/events` shows** — the same Public Links toggles
+    decide whether venue, topic, details and enquiries appear, and all of them
+    default to not-public. Private events are never included.
+  - Each event carries a permanent identifier, so a subscriber's calendar
+    updates a changed event in place instead of collecting duplicates, and
+    times are published in the `Europe/London` timezone so they read correctly
+    for someone abroad and across the summer-time change. Events with no start
+    time appear as all-day events.
+  - The feed covers the last 180 days onwards, with no end date, up to 5000
+    events — a calendar application fetches the whole file every time, so
+    unlike the JSON endpoints it is bounded rather than paginated.
+  - Needs the same **Public read API** feature toggle; it is 404 until a u3a
+    turns that on.
+
 ### Changed
 - `/api/v1` is mounted ahead of the app-wide helmet, CORS and rate-limit
   middleware and supplies its own: cross-origin reads are allowed (the shared

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -2082,6 +2082,7 @@ decisions below are not local implementation choices.
 | `routes/api/index.js` | Version router: deprecation headers, spec, tenant resolution, `publicApi` gate, resource mounts, 404 + error handler |
 | `routes/api/helpers.js` | Envelope, pagination, feature gating, visibility loading, `Deprecation`/`Sunset` |
 | `routes/api/{org,faculties,venues,groups,events}.js` | One module per resource |
+| `routes/api/ics.js` | The `events.ics` iCalendar feed — a second serialisation of `events.js`, not a second data source |
 | `routes/api/openapi.json` | Hand-written OpenAPI 3.1, loaded via `createRequire` |
 | `utils/resolveTenant.js` | Slug → tenant, shared with `routes/public/` |
 
@@ -2120,6 +2121,42 @@ decisions below are not local implementation choices.
   faculty is pure taxonomy carrying no personal data. If that judgement is
   revisited, `routes/api/faculties.js` and the `faculty`/`facultyId` fields in
   `routes/api/groups.js` are the only two places to change.
+
+### The iCalendar feed (`ics.js`)
+
+`GET /api/v1/:slug/events.ics?group=` is the same rows as `GET /events`, put
+through `calendar_config` in the same way and then serialised as RFC 5545.
+**If you add a field to one, decide deliberately whether it belongs in the
+other** — they are two representations of one resource, and a field that is
+public in JSON but missing from the feed is a bug, not a safety margin.
+
+- **The leak guard is `veventProps()` in `apiV1.test.js`**, which asserts the
+  exact set of VEVENT property names, and a list of values that must not appear
+  anywhere in the body. Same idea as the key-set assertions, different
+  serialisation. Verified red on an injected `visible()` bypass.
+- **`DTSTAMP`/`LAST-MODIFIED` come from the row's `updated_at`, never from the
+  clock.** Using `new Date()` would change every byte of the feed on every
+  request, defeating the `ETag` and making every poll a full download.
+- **`UID` is `<event id>@<slug>.beacon2026` and must never change.** It is how
+  a subscriber's calendar recognises an event it already has; change the recipe
+  and every subscriber silently accumulates a duplicate of everything.
+- **Folding is by octet, not character** (RFC 5545 says 75 octets), and
+  `fold()` backs off a split that would land inside a multi-byte character. Cut
+  a UTF-8 sequence in half and the subscriber sees `U+FFFD` where a dash or an
+  accent should be. The test asserts both the byte limit and that unfolding
+  round-trips; the round-trip half was verified red with the backoff removed.
+- **The feed is bounded, not paginated** — 180 days back, no forward limit,
+  5000 events. `?limit=` would be meaningless to a calendar client. Both
+  numbers are in the OpenAPI description, so they are part of the contract.
+- **`DTEND` is omitted when it is not strictly after `DTSTART`.** Some clients
+  reject an entire calendar over one invalid event rather than skipping it.
+- **Times are `TZID=Europe/London` with a `VTIMEZONE` in the file.** Floating
+  times would read an hour out for a member abroad; UTC would lose the
+  summer-time transition.
+- **The SQL casts `event_date`, `start_time` and `end_time` to `text` and
+  formats `updated_at` with `to_char`.** No `pg` type parsers are configured,
+  so a `DATE` arrives as a JS `Date` at *local* midnight — fine for JSON, but a
+  timezone bug waiting to happen when it is reformatted into `YYYYMMDD`.
 
 ### Configuration
 

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -536,45 +536,58 @@ All items in this section have been completed (v0.8.6).
 ## Public read API (`/api/v1`) — deferred items
 
 Design, decisions and the phased plan are in
-[`docs/API-design.md`](docs/API-design.md). Phase 1 (anonymous read API) is
-built; the items below are deliberately out of it.
+[`docs/API-design.md`](docs/API-design.md). Phase 1 (anonymous read API) and
+phase 2 (the `events.ics` feed) are built; the items below are deliberately
+out of them.
 
-1. `[DEFERRED]` **`events.ics` iCalendar feed (phase 2)** — RFC 5545 feed at
-   `/api/v1/:slug/events.ics` with a `?group=` filter, so members can subscribe
-   to the u3a calendar in Google/Apple/Outlook. Needs stable `UID`s derived
-   from event id + tenant so a subscriber's calendar updates events in place
-   rather than duplicating them. Small, and the highest value-per-line item
-   remaining.
-2. `[DEFERRED]` **Shared SiteWorks display plugin (phase 2b)** — one WordPress
+1. `[OPEN]` **Nothing in beacon2026 tells a member the feed URL exists.** The
+   `events.ics` feed is built and works, but its value depends on members
+   finding it, and today they can only find it by reading the API
+   documentation. A "Subscribe to this calendar" link on the public Calendar
+   page — and a per-group one on the group's own entry — is the obvious next
+   step and is a frontend change, not an API one. Deliberately not done with
+   phase 2, which was scoped to the feed itself.
+2. `[OPEN]` **The feed has not been read by a real calendar client.** Its
+   structure is asserted line by line in `apiV1.test.js` and was checked by
+   hand against RFC 5545, but no third-party validator or actual
+   Google/Apple/Outlook subscription has seen it — no iCalendar parser is
+   available locally and adding a dependency to test-parse our own output was
+   not judged worth it. Fold at the 75-octet boundary, the `VTIMEZONE`
+   definition and all-day `DTEND` semantics are the parts most likely to be
+   subtly wrong. Subscribe from one real client when the demo tenant is
+   smoke-tested (item 8 below).
+3. `[DEFERRED]` **Shared SiteWorks display plugin (phase 2b)** — one WordPress
    plugin, used by every u3a, rendering groups and events from this API with
    sensible caching. Separate codebase. It is the deliverable most u3as will
    actually see, and the main defence against a per-u3a support load: the
    common case should need no support at all.
-3. `[CONDITIONAL]` **API keys (phase 3)** — tenant-scoped keys, hashed at rest,
+4. `[CONDITIONAL]` **API keys (phase 3)** — tenant-scoped keys, hashed at rest,
    with scopes, an admin page and revocation. Deliberately *not* scheduled: the
    settled decision is anonymous-first, and keys get built only if a consumer
    appears that already-public data cannot serve. Do not build speculatively.
-4. `[CONDITIONAL]` **Member endpoints (phase 4)** — `/members/stats` (aggregate
+5. `[CONDITIONAL]` **Member endpoints (phase 4)** — `/members/stats` (aggregate
    counts) before any individual records, key plus explicit `members:read`
    scope, never in a default role, never anonymous. A data-protection decision
    for each u3a, not a routine feature.
-5. `[OPEN]` **Deprecation notice needs channels that do not depend on
+6. `[OPEN]` **Deprecation notice needs channels that do not depend on
    identity.** Anonymous access is what lets this scale to every u3a, and the
    price is that we cannot email integrators. In-band `Deprecation`/`Sunset`
    headers are implemented; a Trust-owned changes page and an optional
    voluntary notification list are not. Needed before v1 is publicised widely.
-6. `[OPEN]` **Trust agreement to own the interface (phase 0b).** Not code. It
+7. `[OPEN]` **Trust agreement to own the interface (phase 0b).** Not code. It
    gates *publishing* rather than building, and should be secured before the
    API is advertised to other u3as.
-7. `[OPEN]` **`/api/v1` has never run against a real database.** The 35 tests in
+8. `[OPEN]` **`/api/v1` has never run against a real database.** The 46 tests in
    `apiV1.test.js` mock the DB layer, as every other route test here does, so
    the SQL itself is unexercised — column names, the `= ANY($1)` leader lookup,
-   and the `::date` casts in the event filters are all verified by inspection
-   only. Merged 2026-08-01 (#473) in that state deliberately: the feature is off
-   by default, so nothing is exposed until a u3a opts in. **Before enabling it
-   for any u3a**, enable `publicApi` on the demo tenant and hit
-   `/api/v1/demo2/{org,faculties,venues,groups,events}` — a few minutes' work
-   that closes the gap.
+   the `::date` casts in the event filters, and the `::text` casts and
+   `to_char(… AT TIME ZONE 'UTC', …)` in the `events.ics` query are all verified
+   by inspection only. Merged 2026-08-01 (#473, and the feed in phase 2) in that
+   state deliberately: the feature is off by default, so nothing is exposed
+   until a u3a opts in. **Before enabling it for any u3a**, enable `publicApi`
+   on the demo tenant and hit
+   `/api/v1/demo2/{org,faculties,venues,groups,events,events.ics}` — a few
+   minutes' work that closes the gap.
 
 ## Test flakiness
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-backend",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "beacon2026 API server",
   "type": "module",
   "main": "src/app.js",

--- a/backend/src/__tests__/apiV1.test.js
+++ b/backend/src/__tests__/apiV1.test.js
@@ -366,6 +366,176 @@ describe('GET /events', () => {
   });
 });
 
+// ── The iCalendar feed ──────────────────────────────────────────────────────
+// Same data and the same visibility rules as GET /events, in a second
+// serialisation. The leak guard is the same idea as the key-set assertions
+// above, applied to VEVENT property names.
+
+const ICS_ROW = {
+  id: 'e1',
+  event_date: '2026-09-01',
+  start_time: '14:30:00',
+  end_time: '16:00:00',
+  group_name: 'Walking',
+  event_type_name: null,
+  venue_name: 'Village Hall',
+  venue_postcode: 'PE27 1AA',
+  topic: 'Autumn walk',
+  contact: 'walk@demo.example',
+  details: 'Meet at the bridge',
+  stamp: '20260801T090000Z',
+};
+
+const ALL_CALENDAR_PUBLIC = [
+  {
+    group_info_config: {},
+    calendar_config: {
+      venue: { public: true },
+      topic: { public: true },
+      enquiries: { public: true },
+      detail: { public: true },
+    },
+  },
+];
+
+/** Fetch the feed with a given visibility config and event rows. */
+async function getIcs({ visibility = NOTHING_PUBLIC, rows = [ICS_ROW], query = '' } = {}) {
+  tenantQuery
+    .mockResolvedValueOnce(FEATURES_ON)
+    .mockResolvedValueOnce(visibility)
+    .mockResolvedValueOnce(rows);
+  return request(app).get(`${BASE}/events.ics${query}`);
+}
+
+/** The property names used inside the first VEVENT, e.g. 'DTSTART;TZID=…' → 'DTSTART'. */
+function veventProps(body) {
+  const lines = body.split('\r\n');
+  const start = lines.indexOf('BEGIN:VEVENT');
+  const end = lines.indexOf('END:VEVENT');
+  return lines
+    .slice(start + 1, end)
+    .filter((l) => !l.startsWith(' '))
+    .map((l) => l.split(/[;:]/)[0])
+    .sort();
+}
+
+describe('GET /events.ics', () => {
+  it('serves a cacheable calendar that defines its own timezone', async () => {
+    const res = await getIcs();
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/^text\/calendar; charset=utf-8/);
+    expect(res.headers['cache-control']).toBe('public, max-age=300');
+    expect(res.headers['content-disposition']).toBe('inline; filename="demo-events.ics"');
+    expect(res.headers.etag).toBeDefined();
+    expect(res.text.startsWith('BEGIN:VCALENDAR\r\n')).toBe(true);
+    expect(res.text.endsWith('END:VCALENDAR\r\n')).toBe(true);
+    expect(res.text).toContain('TZID:Europe/London');
+    expect(res.text).toContain('X-WR-CALNAME:Demo u3a');
+  });
+
+  it('publishes a timed event in local time with a stable uid', async () => {
+    const res = await getIcs();
+    expect(res.text).toContain('UID:e1@demo.beacon2026');
+    expect(res.text).toContain('DTSTART;TZID=Europe/London:20260901T143000');
+    expect(res.text).toContain('DTEND;TZID=Europe/London:20260901T160000');
+    // From the row's updated_at, not the clock, so the feed is byte-stable.
+    expect(res.text).toContain('DTSTAMP:20260801T090000Z');
+  });
+
+  it('publishes an event with no start time as an all-day event', async () => {
+    const res = await getIcs({ rows: [{ ...ICS_ROW, start_time: null, end_time: null }] });
+    expect(res.text).toContain('DTSTART;VALUE=DATE:20260901');
+    expect(res.text).toContain('DTEND;VALUE=DATE:20260902');
+  });
+
+  it('omits an end time that is not after the start, rather than emitting invalid ics', async () => {
+    const res = await getIcs({ rows: [{ ...ICS_ROW, end_time: '14:30:00' }] });
+    expect(res.text).toContain('DTSTART;TZID=Europe/London:20260901T143000');
+    expect(res.text).not.toContain('DTEND');
+  });
+
+  it('exposes only identity and timing properties when nothing is ticked public', async () => {
+    const res = await getIcs();
+    expect(veventProps(res.text)).toEqual([
+      'DTEND',
+      'DTSTAMP',
+      'DTSTART',
+      'LAST-MODIFIED',
+      'SUMMARY',
+      'UID',
+    ]);
+    for (const secret of ['Village Hall', 'PE27', 'Autumn walk', 'walk@demo.example', 'bridge']) {
+      expect(res.text).not.toContain(secret);
+    }
+    expect(res.text).toContain('SUMMARY:Walking');
+  });
+
+  it('includes venue, topic, details and enquiries once they are ticked public', async () => {
+    const res = await getIcs({ visibility: ALL_CALENDAR_PUBLIC });
+    expect(veventProps(res.text)).toContain('LOCATION');
+    expect(veventProps(res.text)).toContain('DESCRIPTION');
+    expect(res.text).toContain('SUMMARY:Walking: Autumn walk');
+    expect(res.text).toContain('LOCATION:Village Hall');
+    expect(res.text).toContain('Meet at the bridge');
+    expect(res.text).toContain('Enquiries: walk@demo.example');
+  });
+
+  it('falls back to the event type name for open meetings', async () => {
+    const res = await getIcs({
+      rows: [{ ...ICS_ROW, group_name: null, event_type_name: 'Open Meeting' }],
+    });
+    expect(res.text).toContain('SUMMARY:Open Meeting');
+  });
+
+  it('escapes separators and folds long lines to 75 octets', async () => {
+    // The dash is 3 bytes and the run of them is long enough that a naive
+    // 75-character fold is guaranteed to cut one in half.
+    const dashes = '—'.repeat(40);
+    const res = await getIcs({
+      visibility: ALL_CALENDAR_PUBLIC,
+      rows: [
+        {
+          ...ICS_ROW,
+          group_name: `Walking, Rambling; and Strolling ${dashes} the long way round`,
+          topic: 'Bring a coat\nand boots',
+        },
+      ],
+    });
+    expect(res.text).toContain('Walking\\, Rambling\\; and Strolling');
+    expect(res.text).toContain('Bring a coat\\nand boots');
+    for (const line of res.text.split('\r\n')) {
+      expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(75);
+    }
+    // Unfolding must give back exactly what went in — a split that landed
+    // inside a dash would surface as U+FFFD here.
+    const unfolded = res.text.replace(/\r\n /g, '');
+    expect(unfolded).not.toContain('�');
+    expect(unfolded).toContain(`Strolling ${dashes} the long way round`);
+  });
+
+  it('never includes private events, and reaches a bounded way back', async () => {
+    await getIcs();
+    const [, sql, params] = tenantQuery.mock.calls.at(-1);
+    expect(sql).toContain('ge.is_private IS NOT TRUE');
+    expect(sql).toContain('ge.event_date >= $1::date');
+    expect(params[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(params.at(-1)).toBe(5000); // the VEVENT ceiling, not a page size
+  });
+
+  it('filters to one group and names the calendar after it', async () => {
+    const res = await getIcs({ query: '?group=g1' });
+    expect(tenantQuery.mock.calls.at(-1)[2]).toContain('g1');
+    expect(res.text).toContain('X-WR-CALNAME:Demo u3a — Walking');
+  });
+
+  it('404s when the u3a has not enabled the API', async () => {
+    tenantQuery.mockResolvedValueOnce([{ feature_config: {} }]);
+    const res = await request(app).get(`${BASE}/events.ics`);
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('not_found');
+  });
+});
+
 // ── Venues, faculties and org ───────────────────────────────────────────────
 
 describe('venues, faculties and org', () => {
@@ -431,6 +601,7 @@ describe('specification matches the routes', () => {
       import('../routes/api/venues.js'),
       import('../routes/api/groups.js'),
       import('../routes/api/events.js'),
+      import('../routes/api/ics.js'),
     ]);
 
     // '/:slug/groups/:id' (Express) → '/{slug}/groups/{id}' (OpenAPI)
@@ -443,7 +614,7 @@ describe('specification matches the routes', () => {
     const documented = Object.keys(res.body.paths).sort();
 
     // Guard against a vacuous pass if router introspection ever returns nothing.
-    expect(actual.length).toBeGreaterThanOrEqual(8);
+    expect(actual.length).toBeGreaterThanOrEqual(9);
     expect(documented).toEqual(actual);
   });
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -82,7 +82,7 @@ const apiLimiter = rateLimit({
 app.use(
   '/api/v1',
   helmet({ crossOriginResourcePolicy: { policy: 'cross-origin' } }),
-  cors({ origin: '*' }),
+  cors({ origin: '*', exposedHeaders: ['Content-Disposition'] }),
   apiLimiter,
   apiV1Routes,
 );

--- a/backend/src/routes/api/helpers.js
+++ b/backend/src/routes/api/helpers.js
@@ -32,7 +32,8 @@ export function apiErrorHandler(err, req, res, _next) {
 
 // ─── Success envelope ─────────────────────────────────────────────────────
 
-const MAX_AGE_SECONDS = 300;
+/** Shared by every public response, JSON and iCalendar alike. */
+export const MAX_AGE_SECONDS = 300;
 
 /**
  * Send a cacheable public response. Express generates the ETag and answers

--- a/backend/src/routes/api/ics.js
+++ b/backend/src/routes/api/ics.js
@@ -1,0 +1,254 @@
+// beacon2026/backend/src/routes/api/ics.js
+// GET /api/v1/:slug/events.ics — the public calendar as a subscribable feed.
+//
+// Phase 2 of docs/API-design.md. Unlike every other route here this one has no
+// client to write and no integration to maintain: a member pastes the URL into
+// Google, Apple or Outlook Calendar and their u3a's programme stays current by
+// itself.
+//
+// Field visibility is exactly that of GET /events — the same `calendar_config`
+// toggles, all of which default to not-public. Anything not ticked simply does
+// not appear in the VEVENT, so a u3a cannot publish more through the feed than
+// through its own calendar page.
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { tenantQuery } from '../../utils/db.js';
+import { requireFeatures, visibility, visible, MAX_AGE_SECONDS } from './helpers.js';
+
+const router = Router();
+
+// ─── Feed shape ───────────────────────────────────────────────────────────
+// A subscription feed is fetched whole, repeatedly, forever, so it needs a
+// bound that /events does not: `?limit=` makes no sense when the client is a
+// calendar application. The window below is that bound, and it is part of the
+// published contract — see docs/API-design.md.
+
+/** How far back the feed reaches. Roughly two terms of history. */
+const PAST_WINDOW_DAYS = 180;
+
+/** Hard ceiling on VEVENTs, so one busy u3a cannot serve a huge file. */
+const MAX_EVENTS = 5000;
+
+/** Advisory poll interval for clients that honour it. */
+const REFRESH_INTERVAL = 'PT12H';
+
+/** u3as are UK organisations and event times are local wall-clock times. */
+const TZID = 'Europe/London';
+
+const filterSchema = z.object({
+  group: z.string().max(64).optional(),
+});
+
+// ─── RFC 5545 serialisation ───────────────────────────────────────────────
+
+/**
+ * Escape a TEXT value: backslash first (or it would double-escape the escapes
+ * added after it), then the separators, then newlines, then the control
+ * characters iCalendar has no representation for at all.
+ */
+function escapeText(value) {
+  return (
+    String(value)
+      .replace(/\\/g, '\\\\')
+      .replace(/;/g, '\\;')
+      .replace(/,/g, '\\,')
+      .replace(/\r\n|\r|\n/g, '\\n')
+      // Control characters have no iCalendar representation at all; real line
+      // breaks have already become the literal \n above.
+      .replace(/\p{Cc}/gu, '')
+  );
+}
+
+/**
+ * Fold a content line to 75 **octets**, continuing with CRLF + one space.
+ *
+ * The limit is in octets, not characters, so this works on the UTF-8 bytes and
+ * backs off a split that would land inside a multi-byte character — a group
+ * name with an accent or a dash would otherwise be cut in half and arrive as
+ * mojibake in the subscriber's calendar.
+ */
+function fold(line) {
+  const bytes = Buffer.from(line, 'utf8');
+  if (bytes.length <= 75) return line;
+
+  const parts = [];
+  let start = 0;
+  let limit = 75;
+  while (start < bytes.length) {
+    let end = Math.min(start + limit, bytes.length);
+    while (end > start + 1 && end < bytes.length && (bytes[end] & 0xc0) === 0x80) end--;
+    parts.push(bytes.subarray(start, end).toString('utf8'));
+    start = end;
+    limit = 74; // continuation lines spend one octet on the leading space
+  }
+  return parts.join('\r\n ');
+}
+
+/** '2026-09-01' → '20260901'. */
+function icsDate(value) {
+  return String(value).slice(0, 10).replace(/-/g, '');
+}
+
+/** '14:30:00' → '143000'. Tolerates '14:30' and fractional seconds. */
+function icsTime(value) {
+  const [h = '0', m = '0', s = '0'] = String(value).split(':');
+  return `${h.padStart(2, '0')}${m.padStart(2, '0')}${s.slice(0, 2).padStart(2, '0')}`;
+}
+
+/** '20260901' → '20260902', for the exclusive DTEND of an all-day event. */
+function nextDay(compact) {
+  const y = Number(compact.slice(0, 4));
+  const m = Number(compact.slice(4, 6));
+  const d = Number(compact.slice(6, 8));
+  return new Date(Date.UTC(y, m - 1, d + 1)).toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+/**
+ * Europe/London, spelled out so timed events land on the right hour whatever
+ * the subscriber's own timezone. Emitting floating times instead would look
+ * correct in Britain and be an hour out for a member reading their calendar
+ * from Spain; emitting UTC would lose the summer-time transition entirely.
+ */
+const VTIMEZONE = [
+  'BEGIN:VTIMEZONE',
+  `TZID:${TZID}`,
+  'BEGIN:DAYLIGHT',
+  'DTSTART:19700329T010000',
+  'TZOFFSETFROM:+0000',
+  'TZOFFSETTO:+0100',
+  'TZNAME:BST',
+  'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+  'END:DAYLIGHT',
+  'BEGIN:STANDARD',
+  'DTSTART:19701025T020000',
+  'TZOFFSETFROM:+0100',
+  'TZOFFSETTO:+0000',
+  'TZNAME:GMT',
+  'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+];
+
+/**
+ * One VEVENT.
+ *
+ * `UID` is derived from the event id and the u3a slug, and never changes, so a
+ * subscriber's calendar updates an event in place rather than accumulating a
+ * fresh copy on every poll. `DTSTAMP` comes from the row's `updated_at` rather
+ * than from the clock, which keeps the whole feed byte-identical between polls
+ * and lets the `ETag` do its job.
+ */
+function eventLines(ev, cfg, slug) {
+  const date = icsDate(ev.event_date);
+  const stamp = ev.stamp || `${date}T000000Z`;
+
+  const lines = ['BEGIN:VEVENT', `UID:${ev.id}@${slug}.beacon2026`, `DTSTAMP:${stamp}`];
+
+  if (ev.start_time) {
+    const from = icsTime(ev.start_time);
+    lines.push(`DTSTART;TZID=${TZID}:${date}T${from}`);
+    // A DTEND at or before DTSTART is invalid, and some clients reject the
+    // whole calendar rather than the one event. Omitting it is legal.
+    if (ev.end_time && icsTime(ev.end_time) > from) {
+      lines.push(`DTEND;TZID=${TZID}:${date}T${icsTime(ev.end_time)}`);
+    }
+  } else {
+    lines.push(`DTSTART;VALUE=DATE:${date}`);
+    lines.push(`DTEND;VALUE=DATE:${nextDay(date)}`);
+  }
+
+  const name = ev.group_name || ev.event_type_name || 'Open Meeting';
+  const topic = visible(cfg, 'topic') ? ev.topic : null;
+  lines.push(`SUMMARY:${escapeText(topic ? `${name}: ${topic}` : name)}`);
+
+  if (visible(cfg, 'venue')) {
+    const where = [ev.venue_name, ev.venue_postcode].filter(Boolean).join(', ');
+    if (where) lines.push(`LOCATION:${escapeText(where)}`);
+  }
+
+  const description = [];
+  if (visible(cfg, 'detail') && ev.details) description.push(ev.details);
+  if (visible(cfg, 'enquiries') && ev.contact) description.push(`Enquiries: ${ev.contact}`);
+  if (description.length) lines.push(`DESCRIPTION:${escapeText(description.join('\n\n'))}`);
+
+  lines.push(`LAST-MODIFIED:${stamp}`);
+  lines.push('END:VEVENT');
+  return lines;
+}
+
+/** Wrap the events in a VCALENDAR and serialise, folded, CRLF-terminated. */
+function buildCalendar(rows, cfg, { slug, calendarName }) {
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//beacon2026//Public read API v1//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    `NAME:${escapeText(calendarName)}`,
+    `X-WR-CALNAME:${escapeText(calendarName)}`,
+    `X-WR-TIMEZONE:${TZID}`,
+    `REFRESH-INTERVAL;VALUE=DURATION:${REFRESH_INTERVAL}`,
+    `X-PUBLISHED-TTL:${REFRESH_INTERVAL}`,
+    ...VTIMEZONE,
+    ...rows.flatMap((ev) => eventLines(ev, cfg, slug)),
+    'END:VCALENDAR',
+  ];
+  return `${lines.map(fold).join('\r\n')}\r\n`;
+}
+
+// ─── GET /:slug/events.ics ────────────────────────────────────────────────
+
+const SELECT_EVENT = `
+  SELECT ge.id,
+         ge.event_date::text AS event_date,
+         ge.start_time::text AS start_time,
+         ge.end_time::text   AS end_time,
+         g.name  AS group_name,
+         et.name AS event_type_name,
+         v.name AS venue_name, v.postcode AS venue_postcode,
+         ge.topic, ge.contact, ge.details,
+         to_char(ge.updated_at AT TIME ZONE 'UTC', 'YYYYMMDD"T"HH24MISS"Z"') AS stamp
+  FROM group_events ge
+  LEFT JOIN groups g       ON g.id  = ge.group_id
+  LEFT JOIN venues v       ON v.id  = ge.venue_id
+  LEFT JOIN event_types et ON et.id = ge.event_type_id`;
+
+router.get('/:slug/events.ics', async (req, res, next) => {
+  try {
+    if (!(await requireFeatures(req, res, ['events']))) return;
+    const { group } = filterSchema.parse(req.query);
+    const cfg = (await visibility(req)).calendar;
+
+    const since = new Date(Date.now() - PAST_WINDOW_DAYS * 86400000).toISOString().slice(0, 10);
+    const params = [since];
+    let whereSQL = `WHERE ge.is_private IS NOT TRUE AND ge.event_date >= $1::date`;
+    if (group) {
+      params.push(group);
+      whereSQL += ` AND ge.group_id = $${params.length}`;
+    }
+
+    const rows = await tenantQuery(
+      req.tenantSlug,
+      `${SELECT_EVENT} ${whereSQL}
+       ORDER BY ge.event_date, ge.start_time, g.name
+       LIMIT $${params.length + 1}`,
+      [...params, MAX_EVENTS],
+    );
+
+    // A member subscribing to two group feeds needs to tell them apart in the
+    // calendar sidebar, so a filtered feed carries the group's name.
+    const u3a = req.tenant.name || req.tenantSlug;
+    const groupName = group ? rows.find((r) => r.group_name)?.group_name : null;
+    const calendarName = groupName ? `${u3a} — ${groupName}` : u3a;
+
+    res.set('Content-Type', 'text/calendar; charset=utf-8');
+    res.set('Cache-Control', `public, max-age=${MAX_AGE_SECONDS}`);
+    res.set('Content-Disposition', `inline; filename="${req.tenantSlug}-events.ics"`);
+    return res.send(buildCalendar(rows, cfg, { slug: req.tenantSlug, calendarName }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/api/index.js
+++ b/backend/src/routes/api/index.js
@@ -24,6 +24,7 @@ import facultyRoutes from './faculties.js';
 import venueRoutes from './venues.js';
 import groupRoutes from './groups.js';
 import eventRoutes from './events.js';
+import icsRoutes from './ics.js';
 
 const require = createRequire(import.meta.url);
 const openapi = require('./openapi.json');
@@ -71,6 +72,7 @@ router.use('/', facultyRoutes);
 router.use('/', venueRoutes);
 router.use('/', groupRoutes);
 router.use('/', eventRoutes);
+router.use('/', icsRoutes);
 
 // ─── Fallbacks ────────────────────────────────────────────────────────────
 

--- a/backend/src/routes/api/openapi.json
+++ b/backend/src/routes/api/openapi.json
@@ -259,6 +259,32 @@
         }
       }
     },
+    "/{slug}/events.ics": {
+      "get": {
+        "tags": ["Events"],
+        "summary": "The public calendar as a subscribable iCalendar feed",
+        "description": "The same events as `/{slug}/events`, serialised as iCalendar (RFC 5545) so it can be subscribed to directly in Google Calendar, Apple Calendar or Outlook. No key and no client code are needed — the URL is the integration.\n\nUnlike the JSON collection this feed is not paginated, because a calendar application fetches it whole. Instead it is bounded: it contains events from 180 days ago onwards, with no end date, up to a maximum of 5000 events.\n\nEach event carries a stable `UID` derived from its id and the u3a, so a subscriber's calendar updates events in place rather than duplicating them. Timed events are published in the `Europe/London` timezone, which the feed defines; events with no start time are published as all-day events. Which of `LOCATION` and `DESCRIPTION` appear depends on what the u3a has chosen to publish, exactly as for the JSON representation.",
+        "parameters": [
+          { "$ref": "#/components/parameters/slug" },
+          {
+            "name": "group",
+            "in": "query",
+            "description": "Filter to one group, by its id, so a member can subscribe to just their own group.",
+            "schema": { "type": "string", "maxLength": 64 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An iCalendar document",
+            "content": {
+              "text/calendar": { "schema": { "type": "string" } }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
     "/{slug}/events/{id}": {
       "get": {
         "tags": ["Events"],

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -1,7 +1,7 @@
 # beacon2026 — Project Definition (last reviewed 2026-06-14)
 
 > **Note:** This document describes the *current* state of the project as of
-> 2026-06-14 (version 0.12.0). It is the canonical inventory of modules, routes,
+> 2026-06-14 (version 0.12.1). It is the canonical inventory of modules, routes,
 > and pages; for a contributor-oriented repo map and quickstart see
 > [`README.md`](README.md). Read it alongside `CLAUDE.md`, `CLAUDE-STANDARDS.md`,
 > and `CLAUDE-REFERENCE.md` in the repository root, which contain coding
@@ -26,7 +26,7 @@ beacon2026 is a ground-up rebuild with these goals:
 
 ---
 
-## What has been built (as of version 0.12.0)
+## What has been built (as of version 0.12.1)
 
 ### Infrastructure and platform
 - Full multi-tenant architecture (PostgreSQL schema-per-tenant)
@@ -261,6 +261,11 @@ beacon2026 is a ground-up rebuild with these goals:
 - Resources: `org`, `faculties`, `venues` (+ `/:id`), `groups` (+ `/:id`,
   `?faculty=`), `events` (+ `/:id`, `?from=&to=&group=`). Collections are
   paginated and return `{ data, meta }`; errors are `{ error: { code, message } }`
+- **`events.ics` — the public calendar as a subscribable iCalendar feed**
+  (RFC 5545, `?group=` filter), so a member can subscribe in Google, Apple or
+  Outlook Calendar. Same rows and same visibility rules as `events`; bounded
+  (180 days back, no forward limit, 5,000 events) rather than paginated, with
+  stable `UID`s and `Europe/London` times
 - **Opt-in per u3a** behind the `publicApi` feature toggle (defaults **off** —
   the only feature besides `giftAid`, `groupLedger` and `siteworks` to do so)
 - **Field visibility reuses `group_info_config` / `calendar_config`**, so the

--- a/docs/API-design.md
+++ b/docs/API-design.md
@@ -174,6 +174,37 @@ It is also the one item here that delivers value directly to ordinary
 members rather than to webmasters, which makes it the easiest to
 justify and the easiest to demonstrate.
 
+**Four decisions settled while building it (phase 2, 2026-08-01).** Each
+is part of the published contract, so each is recorded here rather than
+only in the code.
+
+- **Bounded, not paginated.** A calendar client fetches the whole file
+  every time, so `?limit=` and `?offset=` are meaningless here. Instead
+  the feed carries events from **180 days ago onwards, with no end date,
+  up to 5000 events**. Both numbers are in the OpenAPI description. The
+  window is the one thing a subscriber could notice changing, so
+  widening it later is safe and narrowing it is not.
+- **`Europe/London` with a `VTIMEZONE`, not floating time and not UTC.**
+  Floating times read correctly in Britain and an hour out for a member
+  looking at their calendar from abroad; UTC loses the summer-time
+  transition. Spelling the timezone out costs seventeen lines once.
+- **`DTSTAMP` from the row's `updated_at`, never from the clock.** A
+  feed built from `now()` differs on every request, which defeats the
+  `ETag` and turns every poll into a full download — exactly the load
+  the caching design exists to avoid.
+- **`UID` is `<event id>@<slug>.beacon2026` and is frozen.** It is how a
+  subscriber's calendar recognises an event it already holds. Changing
+  the recipe would not break anything visibly; it would silently give
+  every existing subscriber a duplicate of every event, with no way for
+  us to know and no way for them to fix it except unsubscribing. This is
+  the single most irreversible commitment in v1.
+
+The feed is only half the value while nothing in beacon2026 tells a
+member the URL exists. A "subscribe to this calendar" link on the public
+Calendar page is the obvious companion, and is a frontend change rather
+than an API one — carried in `KNOWN-ISSUES.md` rather than done here, so
+that phase 2 stayed the size it was estimated at.
+
 ---
 
 ## Cross-cutting design
@@ -414,6 +445,11 @@ decisions, review and real-browser testing.
 
 Both columns are rough — honest enough for go / no-go, not accurate
 enough to commit a date to.
+
+**Status: phases 0, 1 and 2 are built** (2026-08-01). Phase 2b has not
+started. What remains open within the built phases — the Trust
+agreement, the deprecation-notice channels, and a first run against a
+real database — is tracked in `KNOWN-ISSUES.md`, not here.
 
 | Phase | Contents | By hand | With Claude Code |
 |---|---|---|---|

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-frontend",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.27.3",
         "@tiptap/extension-text-style": "^3.27.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Implements phase 2 of docs/API-design.md: GET /api/v1/:slug/events.ics,
with the ?group= filter, so a member can paste one URL into Google, Apple
or Outlook Calendar and have their u3a's programme keep itself current.
No key, no registration, no client to write.

It is a second serialisation of GET /events, not a second data source: the
same rows, run through the same calendar_config toggles, all of which
default to not-public. Private events are excluded. The leak guard is the
same idea as phase 1's exact-key-set assertions, applied to VEVENT
property names - veventProps() asserts the exact property set plus a list
of values that must not appear anywhere in the body. Verified red against
an injected visible() bypass.

Four contract decisions, all recorded in docs/API-design.md rather than
only in code:

- Bounded, not paginated - 180 days back, no forward limit, 5000 events.
  A calendar client fetches the whole file every time, so ?limit= is
  meaningless; both numbers are in the OpenAPI description.
- TZID=Europe/London with a VTIMEZONE in the file. Floating times read an
  hour out for a member abroad; UTC loses the summer-time transition.
- DTSTAMP/LAST-MODIFIED from the row's updated_at, never from the clock,
  so the feed is byte-stable between polls and the ETag does its job.
- UID is <event id>@<slug>.beacon2026 and is frozen. Changing the recipe
  would silently give every subscriber a duplicate of every event.

Folding is by octet (RFC 5545 says 75 octets, not characters) and backs
off a split that would land inside a multi-byte character; the test
asserts the byte limit and that unfolding round-trips, and the round-trip
half was verified red with the backoff removed. DTEND is omitted when it
is not strictly after DTSTART, because some clients reject a whole
calendar over one invalid event.

The SQL casts event_date/start_time/end_time to text and formats
updated_at with to_char: no pg type parsers are configured, so a DATE
arrives as a JS Date at local midnight - harmless in JSON, a timezone bug
waiting to happen when reformatted to YYYYMMDD.

Also adds exposedHeaders: ['Content-Disposition'] to the /api/v1 CORS
config, per the downloads rule in CLAUDE-STANDARDS.

Docs: CHANGELOG, API-design (the four decisions + phase status),
CLAUDE-REFERENCE section 27, Project Definition, KNOWN-ISSUES (two new
open items - no frontend link to the feed yet, and it has not been read
by a real calendar client or validator).

Backend 654 tests pass, frontend 198, lint clean both sides.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)