### PR TITLE
Record the phase 2b proof of concept and correct the SiteWorks assumption

### DIFF
--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -555,29 +555,58 @@ out of them.
    not judged worth it. Fold at the 75-octet boundary, the `VTIMEZONE`
    definition and all-day `DTEND` semantics are the parts most likely to be
    subtly wrong. Subscribe from one real client when the demo tenant is
-   smoke-tested (item 8 below).
-3. `[DEFERRED]` **Shared SiteWorks display plugin (phase 2b)** — one WordPress
-   plugin, used by every u3a, rendering groups and events from this API with
-   sensible caching. Separate codebase. It is the deliverable most u3as will
-   actually see, and the main defence against a per-u3a support load: the
-   common case should need no support at all.
-4. `[CONDITIONAL]` **API keys (phase 3)** — tenant-scoped keys, hashed at rest,
+   smoke-tested (item 10 below).
+3. `[OPEN]` **Shared SiteWorks display plugin (phase 2b) — proof of concept
+   built, not released.** Separate codebase, local only:
+   `C:\Claude\beacon2026-siteworks-plugin` (git repo, not pushed). "beacon2026
+   Display" 0.1.0 — three server-rendered shortcodes (`[beacon2026_groups]`,
+   `[beacon2026_events]`, `[beacon2026_calendar_link]`), a settings page with a
+   live connection check, `If-None-Match` revalidation, stale-on-error, and the
+   `Deprecation`/`Sunset` headers surfaced as a WP admin notice. 83 assertions
+   plus an over-HTTP integration check against a bundled stand-in API; its own
+   README carries the full limitations list. **Not verified against a real
+   beacon2026** (none is live) and **never activated inside WordPress** — it is
+   linked into the Local site `dev-based-on-20260519` awaiting that. Blocks
+   rather than shortcodes, and matching the SiteWorks theme, are the obvious
+   next steps.
+4. `[OPEN]` **The overlap with `u3a-siteworks-core` is unresolved, and is the
+   real phase 2b question.** `docs/API-design.md` was written without this
+   detail: `u3a-siteworks-core` (v2.1.2, on every SiteWorks site) already
+   registers `u3a_group`, `u3a_event`, `u3a_venue` and `u3a_contact` post
+   types, ships the `u3a/grouplist`, `u3a/groupdata`, `u3a/venuelist` and
+   `u3a/venuedata` blocks, and `u3a-importexport` defines a CSV format that is
+   today's manual Beacon → SiteWorks path. A display plugin therefore stands
+   *beside* a mature, theme-styled Groups system rather than filling a gap, and
+   a u3a running both has two of everything. The alternative — a plugin the
+   u3a installs that **pulls** from `/api/v1` and populates those existing post
+   types — gets what "push" was wanted for (real WP posts, search-engine
+   indexing, the theme's own styling, every existing block working untouched)
+   without anyone holding a WordPress application password per u3a, which is
+   what made push unattractive in the design. Decide this before anything past
+   the proof of concept; it changes what the plugin is.
+5. `[DEFERRED]` **Shared SiteWorks display plugin — release.** Whichever shape
+   wins above, it is the deliverable most u3as will actually see, and the main
+   defence against a per-u3a support load: the common case should need no
+   support at all. Distribution (zip passed around vs central submission),
+   a `.pot` file, and a SiteWorks instance to develop against are all still
+   open.
+6. `[CONDITIONAL]` **API keys (phase 3)** — tenant-scoped keys, hashed at rest,
    with scopes, an admin page and revocation. Deliberately *not* scheduled: the
    settled decision is anonymous-first, and keys get built only if a consumer
    appears that already-public data cannot serve. Do not build speculatively.
-5. `[CONDITIONAL]` **Member endpoints (phase 4)** — `/members/stats` (aggregate
+7. `[CONDITIONAL]` **Member endpoints (phase 4)** — `/members/stats` (aggregate
    counts) before any individual records, key plus explicit `members:read`
    scope, never in a default role, never anonymous. A data-protection decision
    for each u3a, not a routine feature.
-6. `[OPEN]` **Deprecation notice needs channels that do not depend on
+8. `[OPEN]` **Deprecation notice needs channels that do not depend on
    identity.** Anonymous access is what lets this scale to every u3a, and the
    price is that we cannot email integrators. In-band `Deprecation`/`Sunset`
    headers are implemented; a Trust-owned changes page and an optional
    voluntary notification list are not. Needed before v1 is publicised widely.
-7. `[OPEN]` **Trust agreement to own the interface (phase 0b).** Not code. It
+9. `[OPEN]` **Trust agreement to own the interface (phase 0b).** Not code. It
    gates *publishing* rather than building, and should be secured before the
    API is advertised to other u3as.
-8. `[OPEN]` **`/api/v1` has never run against a real database.** The 46 tests in
+10. `[OPEN]` **`/api/v1` has never run against a real database.** The 46 tests in
    `apiV1.test.js` mock the DB layer, as every other route test here does, so
    the SQL itself is unexercised — column names, the `= ANY($1)` leader lookup,
    the `::date` casts in the event filters, and the `::text` casts and

--- a/docs/API-design.md
+++ b/docs/API-design.md
@@ -446,10 +446,44 @@ decisions, review and real-browser testing.
 Both columns are rough — honest enough for go / no-go, not accurate
 enough to commit a date to.
 
-**Status: phases 0, 1 and 2 are built** (2026-08-01). Phase 2b has not
-started. What remains open within the built phases — the Trust
-agreement, the deprecation-notice channels, and a first run against a
-real database — is tracked in `KNOWN-ISSUES.md`, not here.
+**Status: phases 0, 1 and 2 are built** (2026-08-01), and phase 2b has a
+proof of concept — see the correction below, which the proof of concept
+turned up and which this note did not anticipate. What remains open
+within the built phases — the Trust agreement, the deprecation-notice
+channels, and a first run against a real database — is tracked in
+`KNOWN-ISSUES.md`, not here.
+
+### Correction: what a SiteWorks site already has (2026-08-01)
+
+This note assumed phase 2b filled a gap. It does not, and the estimate
+and the argument above should be read with that in mind.
+
+Every SiteWorks site already runs **`u3a-siteworks-core`** (v2.1.2),
+which registers `u3a_group`, `u3a_event`, `u3a_venue` and `u3a_contact`
+post types, ships the `u3a/grouplist`, `u3a/groupdata`, `u3a/venuelist`
+and `u3a/venuedata` blocks, and is styled by `u3a-siteworks-theme`.
+Beside it, **`u3a-importexport`** defines a Groups / Events / Venues /
+Contacts CSV format — the manual export-and-import that is today's
+Beacon-to-website path.
+
+So a display plugin does not add groups to a site that had none. It
+stands next to a mature, themed Groups system, and a u3a running both
+has two of everything.
+
+That reopens the push/pull table above with a row it does not contain.
+Push was rejected because *we* would have to hold a WordPress
+application password for every u3a. But a plugin **the u3a installs**
+can pull from `/api/v1` and materialise the results into those existing
+post types — real WordPress posts, indexed by search engines, styled by
+the theme, with every existing block and page working untouched, and no
+credential held by anyone but the u3a. It would replace the CSV round
+trip, which is the part that actually hurts.
+
+The proof of concept built in August 2026 is nonetheless the **display**
+plugin as specified here, deliberately: it is the smaller of the two,
+it exercises the API end to end, and it is the cheaper thing to throw
+away. The choice between the two shapes is recorded as an open decision
+in `KNOWN-ISSUES.md` and should be made before anything is released.
 
 | Phase | Contents | By hand | With Claude Code |
 |---|---|---|---|


### PR DESCRIPTION
Docs-only. Two things learned building the phase 2b plugin, neither of
which was in docs/API-design.md.

The correction matters more than the plugin. The note assumed phase 2b
filled a gap on a u3a's website. It does not: every SiteWorks site
already runs u3a-siteworks-core v2.1.2, which registers u3a_group,
u3a_event, u3a_venue and u3a_contact post types, ships the
u3a/grouplist, u3a/groupdata, u3a/venuelist and u3a/venuedata blocks and
is styled by u3a-siteworks-theme - and u3a-importexport defines the CSV
format that is today's manual Beacon-to-website path. A display plugin
therefore stands beside a mature themed Groups system rather than
filling a gap, and a u3a running both has two of everything.

That reopens the push/pull table with a row it does not contain. Push
was rejected because we would have to hold a WordPress application
password per u3a; a plugin the u3a installs can pull from /api/v1 and
populate those existing post types, getting what push was wanted for
(real WP posts, SEO, theme styling, existing blocks untouched) with no
credential held by anyone but the u3a. Recorded as an open decision to
take before release, not silently acted on.

The proof of concept built is still the display plugin as specified,
deliberately - the smaller of the two shapes, and the cheaper one to
throw away.

KNOWN-ISSUES gains the POC's location and state (local git repo at
C:\Claude\beacon2026-siteworks-plugin, not pushed; never run against a
real beacon2026 and never activated inside WordPress), the unresolved
overlap as its own item, and release questions split out from both.
List renumbered.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)