### PR TITLE
Point the phase 2b plugin references at its GitHub repo

### DIFF
--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -2161,8 +2161,10 @@ public in JSON but missing from the feed is a bug, not a safety margin.
 ### The consumer side lives outside this repo
 
 The phase 2b WordPress plugin ("beacon2026 Display", proof of concept) is a
-**separate local repo**: `C:\Claude\beacon2026-siteworks-plugin`, not pushed
-anywhere. It is the only thing that consumes `/api/v1` today, so it is where a
+**separate repo**:
+[`PeterC66/beacon2026-siteworks-plugin`](https://github.com/PeterC66/beacon2026-siteworks-plugin)
+(private), cloned at `C:\Claude\beacon2026-siteworks-plugin`. It is the only
+thing that consumes `/api/v1` today, so it is where a
 contract change gets noticed first — if you add, rename or remove a v1 field,
 check its `includes/class-b2026-render.php` before assuming nothing depends on
 it. Its own README carries the setup, the test commands and the limitations;

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -557,8 +557,9 @@ out of them.
    subtly wrong. Subscribe from one real client when the demo tenant is
    smoke-tested (item 10 below).
 3. `[OPEN]` **Shared SiteWorks display plugin (phase 2b) — proof of concept
-   built, not released.** Separate codebase, local only:
-   `C:\Claude\beacon2026-siteworks-plugin` (git repo, not pushed). "beacon2026
+   built, not released.** Separate codebase:
+   [`PeterC66/beacon2026-siteworks-plugin`](https://github.com/PeterC66/beacon2026-siteworks-plugin)
+   (**private**), cloned at `C:\Claude\beacon2026-siteworks-plugin`. "beacon2026
    Display" 0.1.0 — three server-rendered shortcodes (`[beacon2026_groups]`,
    `[beacon2026_events]`, `[beacon2026_calendar_link]`), a settings page with a
    live connection check, `If-None-Match` revalidation, stale-on-error, and the


### PR DESCRIPTION
The proof-of-concept plugin now lives at PeterC66/beacon2026-siteworks-plugin
(private) rather than only on one disk, so KNOWN-ISSUES item 3 and
CLAUDE-REFERENCE section 27 no longer describe it as unpushed and give the
URL instead of just the local path.

Docs-only. No code, no CHANGELOG entry, no version bump.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)