### PR TITLE
Fix sign-in background not showing (body painted over html's image)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,11 +11,14 @@ html, body {
   background-size: cover;
   background-color: #9dc8df;
 }
-html[data-daytime='day'] {
+/* Targeted via the html ancestor (not html, body together): body paints its
+   own opaque box over html's, so body needs the image directly or it hides
+   whatever html has underneath. */
+html[data-daytime='day'], html[data-daytime='day'] body {
   background: url('/light-day.png') no-repeat center center fixed;
   background-size: cover;
 }
-html[data-daytime='night'] {
+html[data-daytime='night'], html[data-daytime='night'] body {
   background: url('/light-night.png') no-repeat center center fixed;
   background-size: cover;
 }


### PR DESCRIPTION
## Summary
- Follow-up to #480. The day/night lighthouse background wasn't visible in real browsers even though it was merged — `getComputedStyle(document.documentElement)` showed the correct `background-image`, but that only reflects `<html>`'s own computed style, not what actually paints on screen.
- Root cause: `html, body { background-color: #9dc8df }` gives `<body>` its own opaque background. Since `<body>` fully covers the viewport, it paints **over** `<html>`'s background image underneath. The image rules only targeted `html`, so `body`'s solid colour hid it.
- Fix: also apply the image to `body` via an `html[data-daytime='day'] body` / `...night' body` ancestor selector, matching how the original single-image CSS applied the same background to both elements.

## Test plan
- [x] `npm test` — 198/198 passing
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] Verified in dev preview: `getComputedStyle(document.body).backgroundImage` now correctly resolves to the day/night image (previously only `html`'s did)

🤖 Generated with [Claude Code](https://claude.com/claude-code)