### PR TITLE
Fix forced password-change re-login and greyed-out home menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,22 @@ under the Unreleased headings below).
 
 ---
 
-## [Unreleased] — 2026-08-01
+## [Unreleased] — 2026-08-02
+
+### Fixed
+- **Forced password change (restore / new user set-up) no longer logs the
+  user out.** `/auth/change-password` and `/auth/force-change-password` both
+  revoke the caller's other sessions, but only the regular change flow kept
+  the current session alive — the forced-change screen navigated straight to
+  Home with the now-stale in-memory access token, surfacing as an unwanted
+  re-login. Both endpoints now also return a freshly-signed access token in
+  the response, which the frontend stores immediately
+  (`frontend/src/lib/api/core.js` → `setAccessToken`), so neither flow forces
+  a re-login.
+- **Home menu now hides options the user has no privilege for**, instead of
+  showing them greyed out. `frontend/src/pages/Home.jsx`'s `visibleSections`
+  filter now drops any item without an accessible route, matching how
+  feature-toggled items were already hidden.
 
 ### Changed
 - **Sign-in page background swapped for a day/night pair.** The lighthouse

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -133,6 +133,23 @@ force-logs the user out on their very next action. This was a real bug, fixed
 "sign + store + return a refresh token outside the normal login/refresh
 flow" — reuse it rather than duplicating the sign/hash/insert sequence again.
 
+Reissuing the refresh cookie isn't quite enough on its own: `invalidateUserSessions`
+also marks the **access token already in the client's memory** as stale (checked
+by `requireAuth` via `isSessionInvalidated`), so the very next authenticated
+request 401s and only recovers once `core.js`'s transparent-refresh-on-401 path
+completes. That's normally invisible, but a route that navigates straight to a
+page that fires its own authenticated request on mount (e.g. `ChangePassword.jsx`
+→ Home → `getHomeInfo()`) can expose it as a visible flash/failure, and it's one
+more round trip than necessary either way. Both password-change routes now also
+call `issueAccessToken(tenantSlug, userId)` (`authService.js` — recomputes
+privileges and signs a fresh access token, same shape as login/refresh) and
+return it as `accessToken` in the JSON body; the frontend calls
+`setAccessToken()` (`frontend/src/lib/api/core.js`) immediately on success in
+both `ChangePassword.jsx` (forced change) and `PersonalPreferences.jsx` (regular
+change) so the in-memory token is replaced before anything else fires. Fixed
+2026-08-02 — previously only the forced-change flow visibly hit this, since the
+regular change-password screen doesn't navigate anywhere afterward.
+
 ### Audit events for login/logout/timeout
 
 `loginUser()` success path, `POST /auth/logout`, and a dedicated
@@ -1970,6 +1987,11 @@ are treated as off. If you add a new sub-feature, add it to **both** maps.
 - `PF` shorthand = `ProtectedRoute` + `FeatureRoute`
 - Home.jsx items have optional `f` property for feature key filtering
 - Home.jsx sections have optional `feature` property for master toggle filtering
+- Home.jsx items are also filtered on privilege (`item.to` is `null` when `can()`
+  is false) — `visibleSections` drops any item without a route entirely, so
+  menu options the user has no privilege for are omitted, not shown greyed
+  out. Fixed 2026-08-02 (see CHANGELOG); previously the item still rendered
+  as a disabled `<span>`.
 - Group/Team record tabs use `hasFeature()` for Schedule (`events`) and Ledger (`groupLedger`)
 
 ### Backend patterns

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -31,6 +31,7 @@ vi.mock('../services/authService.js', () => ({
   refreshTokens: vi.fn(),
   loginSysAdmin: vi.fn(),
   issueRefreshToken: vi.fn().mockResolvedValue('new.refresh.token'),
+  issueAccessToken: vi.fn().mockResolvedValue('new.access.token'),
 }));
 
 const { default: app } = await import('../app.js');
@@ -217,6 +218,7 @@ describe('POST /auth/change-password', () => {
       .send(validBody);
 
     expect(res.status).toBe(200);
+    expect(res.body.accessToken).toBe('new.access.token');
 
     const sqlCalls = tenantQuery.mock.calls.map((c) => c[1]);
     expect(sqlCalls.some((s) => /UPDATE refresh_tokens SET revoked = true/.test(s))).toBe(true);
@@ -289,6 +291,7 @@ describe('POST /auth/force-change-password', () => {
       .send(validBody);
 
     expect(res.status).toBe(200);
+    expect(res.body.accessToken).toBe('new.access.token');
     const sqlCalls = tenantQuery.mock.calls.map((c) => c[1]);
     expect(
       sqlCalls.some((s) =>

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -10,6 +10,7 @@ import {
   refreshTokens,
   loginSysAdmin,
   issueRefreshToken,
+  issueAccessToken,
 } from '../services/authService.js';
 import { requireAuth } from '../middleware/auth.js';
 import { tenantQuery, prisma } from '../utils/db.js';
@@ -226,6 +227,11 @@ router.post('/change-password', requireAuth, async (req, res, next) => {
     const newRefreshToken = await issueRefreshToken(slug, user.id);
     res.cookie(COOKIE_NAME, newRefreshToken, cookieOptions);
 
+    // Also hand back a fresh access token so the caller can replace its
+    // in-memory token immediately, rather than relying on the next 401 to
+    // trigger a refresh (which the invalidation above would otherwise force).
+    const newAccessToken = await issueAccessToken(slug, user.id);
+
     logAudit(slug, {
       userId: req.user.userId,
       userName: req.user.name,
@@ -234,7 +240,7 @@ router.post('/change-password', requireAuth, async (req, res, next) => {
       entityId: user.id,
       entityName: req.user.name,
     });
-    res.json({ message: 'Password changed.' });
+    res.json({ message: 'Password changed.', accessToken: newAccessToken });
   } catch (err) {
     next(err);
   }
@@ -443,6 +449,11 @@ router.post('/force-change-password', requireAuth, async (req, res, next) => {
     const newRefreshToken = await issueRefreshToken(slug, req.user.userId);
     res.cookie(COOKIE_NAME, newRefreshToken, cookieOptions);
 
+    // Also hand back a fresh access token so the caller can replace its
+    // in-memory token immediately — matches /auth/change-password behaviour
+    // so a forced change (restore / new user) doesn't force a re-login either.
+    const newAccessToken = await issueAccessToken(slug, req.user.userId);
+
     logAudit(slug, {
       userId: req.user.userId,
       userName: req.user.name,
@@ -451,7 +462,7 @@ router.post('/force-change-password', requireAuth, async (req, res, next) => {
       entityId: req.user.userId,
       entityName: req.user.name,
     });
-    res.json({ message: 'Password changed successfully.' });
+    res.json({ message: 'Password changed successfully.', accessToken: newAccessToken });
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -248,6 +248,37 @@ export async function issueRefreshToken(tenantSlug, userId) {
   return refreshToken;
 }
 
+/**
+ * Sign a fresh access token reflecting the user's current privileges,
+ * outside of the normal login/refresh flow (e.g. after a password change
+ * so the caller's in-memory token is replaced instead of only their
+ * refresh cookie, avoiding a round-trip through the 401-refresh cycle).
+ *
+ * @param {string} tenantSlug
+ * @param {string} userId
+ * @returns {Promise<string>} a signed access token
+ */
+export async function issueAccessToken(tenantSlug, userId) {
+  const [user] = await tenantQuery(
+    tenantSlug,
+    `SELECT id, name, is_site_admin FROM users WHERE id = $1`,
+    [userId],
+  );
+  if (!user) throw AppError('User not found.', 404);
+
+  const privileges = user.is_site_admin
+    ? await computeAllPrivileges(tenantSlug)
+    : await computePrivileges(tenantSlug, user.id);
+
+  return signAccessToken({
+    userId: user.id,
+    tenantSlug,
+    name: user.name,
+    privileges,
+    isSiteAdmin: user.is_site_admin || false,
+  });
+}
+
 // ─── Logout ───────────────────────────────────────────────────────────────
 
 export async function logoutUser(tenantSlug, refreshToken) {

--- a/docs/BeaconUG-Comparison.md
+++ b/docs/BeaconUG-Comparison.md
@@ -43,7 +43,7 @@
 | Documents link | Built | Links to prospective Beacon users documentation |
 | System-wide message | Built | Editable by system admin from System Dashboard; displayed on all tenants' Home pages |
 | Home page notice (tenant message) | Built | Uses `home_page_notice` system message with `#U3ANAME` substitution |
-| **beacon2026 extra:** Privilege-gated cards | beacon2026 extra | Home page cards are greyed out if user lacks privileges (rather than hidden) |
+| **beacon2026 extra:** Privilege-gated cards | beacon2026 extra | Home page cards a user lacks privileges for are omitted entirely (changed 2026-08-02 — previously shown greyed out) |
 
 ---
 
@@ -55,6 +55,7 @@
 | Password requirements | Built | Min 10 chars, no spaces, upper+lower+number |
 | Security Q&A setup | Built | Required during forced password change |
 | Blocks navigation until completed | Built | — |
+| Doesn't force a re-login afterward | Built | Matches the regular change-password flow (fixed 2026-08-02) |
 
 ---
 

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -10,6 +10,7 @@ import { request, requestBlob, requestMultipart, fetchAuthBlob } from './api/cor
 export {
   setAuth,
   clearAuth,
+  setAccessToken,
   getAccessToken,
   restoreSession,
   ApiError,

--- a/frontend/src/lib/api/core.js
+++ b/frontend/src/lib/api/core.js
@@ -16,6 +16,12 @@ export function clearAuth() {
   tenantSlug = null;
 }
 
+// Replace just the access token (e.g. after a password change), keeping
+// the current tenant slug — unlike setAuth() this doesn't imply a fresh login.
+export function setAccessToken(token) {
+  accessToken = token;
+}
+
 export function getAccessToken() {
   return accessToken;
 }

--- a/frontend/src/pages/ChangePassword.jsx
+++ b/frontend/src/pages/ChangePassword.jsx
@@ -5,7 +5,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext.jsx';
-import { auth as authApi } from '../lib/api.js';
+import { auth as authApi, setAccessToken } from '../lib/api.js';
 import BeaconLogo from '../components/BeaconLogo.jsx';
 import FormError from '../components/FormError.jsx';
 
@@ -64,7 +64,12 @@ export default function ChangePassword() {
     setApiError(null);
     setErrors({});
     try {
-      await authApi.forceChangePassword(form.newPassword, form.question.trim(), form.answer.trim());
+      const result = await authApi.forceChangePassword(
+        form.newPassword,
+        form.question.trim(),
+        form.answer.trim(),
+      );
+      if (result?.accessToken) setAccessToken(result.accessToken);
       clearMustChangePassword();
       navigate('/');
     } catch (err) {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -368,12 +368,14 @@ export default function Home() {
     },
   ];
 
-  // Filter items by feature toggles, then filter out empty sections
+  // Filter items by feature toggle and privilege, then filter out empty sections.
+  // Items the user lacks the privilege for (item.to === null) are omitted
+  // entirely rather than shown disabled/greyed out.
   const visibleSections = sections
     .filter((s) => !s.feature || hasFeature(s.feature))
     .map((s) => ({
       ...s,
-      items: s.items.filter((item) => !item.f || hasFeature(item.f)),
+      items: s.items.filter((item) => (!item.f || hasFeature(item.f)) && item.to),
     }))
     .filter((s) => s.items.length > 0);
 
@@ -473,15 +475,9 @@ export default function Home() {
               <ul className="divide-y divide-slate-100">
                 {section.items.map((item) => (
                   <li key={item.label} className="px-4 py-2.5 text-sm">
-                    {item.to ? (
-                      <Link to={item.to} title={item.tip} className="text-blue-700 hover:underline">
-                        {item.label}
-                      </Link>
-                    ) : (
-                      <span title={item.tip} className="text-slate-400">
-                        {item.label}
-                      </span>
-                    )}
+                    <Link to={item.to} title={item.tip} className="text-blue-700 hover:underline">
+                      {item.label}
+                    </Link>
                     {item.isNew && <NewBadge />}
                   </li>
                 ))}
@@ -514,15 +510,9 @@ export default function Home() {
                     key={item.label}
                     className="px-4 py-1 text-sm border-b border-slate-200 last:border-b-0 whitespace-nowrap"
                   >
-                    {item.to ? (
-                      <Link to={item.to} title={item.tip} className="text-blue-700 hover:underline">
-                        {item.label}
-                      </Link>
-                    ) : (
-                      <span title={item.tip} className="text-slate-400">
-                        {item.label}
-                      </span>
-                    )}
+                    <Link to={item.to} title={item.tip} className="text-blue-700 hover:underline">
+                      {item.label}
+                    </Link>
                     {item.isNew && <NewBadge />}
                   </li>
                 ))}

--- a/frontend/src/pages/settings/PersonalPreferences.jsx
+++ b/frontend/src/pages/settings/PersonalPreferences.jsx
@@ -2,7 +2,7 @@
 // Personal preferences — doc 9.1
 
 import { useState, useEffect } from 'react';
-import { auth as authApi } from '../../lib/api.js';
+import { auth as authApi, setAccessToken } from '../../lib/api.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
@@ -112,7 +112,8 @@ export default function PersonalPreferences() {
     setPwMsg(null);
     setPwErr({});
     try {
-      await authApi.changePassword(pwForm.current, pwForm.newPw);
+      const result = await authApi.changePassword(pwForm.current, pwForm.newPw);
+      if (result?.accessToken) setAccessToken(result.accessToken);
       markClean();
       setPwMsg({ type: 'success', text: 'Password changed successfully.' });
       setPwForm({ current: '', newPw: '', confirm: '' });


### PR DESCRIPTION
## Summary
- `/auth/change-password` and `/auth/force-change-password` now both return a freshly-signed access token, which the frontend stores immediately (`setAccessToken`) — so the forced password-change flow (restore / new user set-up) no longer forces a re-login, matching the regular change-password flow.
- Home menu now omits options the user lacks privilege for, instead of showing them as a greyed-out disabled label.

## Test plan
- [x] `cd backend && npm test` — 654 passed
- [x] `cd frontend && npm test` — 198 passed
- [x] `npm run lint` — backend clean, frontend 0 errors (pre-existing warnings only)
- [x] `format:check`-equivalent diff on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)