### PR TITLE
Bump version to 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ under the Unreleased headings below).
 
 ---
 
-## [Unreleased] — 2026-08-02
+## [0.12.2] — 2026-08-02
 
 ### Fixed
 - **Forced password change (restore / new user set-up) no longer logs the

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-backend",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "beacon2026 API server",
   "type": "module",
   "main": "src/app.js",

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -1,7 +1,7 @@
 # beacon2026 — Project Definition (last reviewed 2026-06-14)
 
 > **Note:** This document describes the *current* state of the project as of
-> 2026-06-14 (version 0.12.1). It is the canonical inventory of modules, routes,
+> 2026-06-14 (version 0.12.2). It is the canonical inventory of modules, routes,
 > and pages; for a contributor-oriented repo map and quickstart see
 > [`README.md`](README.md). Read it alongside `CLAUDE.md`, `CLAUDE-STANDARDS.md`,
 > and `CLAUDE-REFERENCE.md` in the repository root, which contain coding
@@ -26,7 +26,7 @@ beacon2026 is a ground-up rebuild with these goals:
 
 ---
 
-## What has been built (as of version 0.12.1)
+## What has been built (as of version 0.12.2)
 
 ### Infrastructure and platform
 - Full multi-tenant architecture (PostgreSQL schema-per-tenant)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-frontend",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.27.3",
         "@tiptap/extension-text-style": "^3.27.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bumps both `package.json` files and the Project Definition doc to 0.12.2 (via `npm run bump-version -- 0.12.2`) for the password-change / home-menu fix from #482.
- Converts the `[Unreleased] — 2026-08-02` CHANGELOG heading to `[0.12.2] — 2026-08-02`.

## Test plan
- [x] Version-only + doc/lockfile change; no code touched — relying on #482's test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)