### PR TITLE
Fix same-second session-invalidation race; narrow sign-in dark period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@ that still says "Unreleased".
 
 ---
 
+## [Unreleased] — 2026-08-02
+
+### Fixed
+- **Forced password change was still logging the user out, even after
+  0.12.2.** That fix reissued a fresh access token immediately after
+  revoking the caller's sessions, but the two calls landed in the same
+  request and often the same millisecond — and `isSessionInvalidated()`
+  (`backend/src/utils/redis.js`) compared the token's second-precision
+  `iat` against a millisecond-precision invalidation marker, so the brand
+  new token could still land in the same second as the marker and get
+  flagged as predating it. Fixed by flooring the marker to whole seconds
+  before comparing; see `CLAUDE-REFERENCE.md` → "Password-change routes
+  must reissue the refresh cookie" for the full race-condition writeup.
+
+### Changed
+- **Sign-in background dark period narrowed to 01:00–05:00 local time**
+  (previously night ran 18:00–06:00). `frontend/src/utils/backgroundTime.js`.
+
 ## [0.12.2] — 2026-08-02
 
 ### Fixed

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -150,6 +150,26 @@ change) so the in-memory token is replaced before anything else fires. Fixed
 2026-08-02 — previously only the forced-change flow visibly hit this, since the
 regular change-password screen doesn't navigate anywhere afterward.
 
+That still wasn't the whole story: `issueAccessToken()` is called *immediately*
+after `invalidateUserSessions()`, often within the same millisecond. JWT `iat`
+is second-precision (`jsonwebtoken` floors `Date.now()/1000`), but the
+Redis/Postgres invalidation marker is stored with millisecond precision
+(`Date.now()`). `isSessionInvalidated()` (`utils/redis.js`) originally compared
+`tokenIssuedAt * 1000 < invalidatedAtMs` — so a brand-new token minted a few ms
+after the marker could still land in the *same second* as the marker and get
+flagged as predating it, 401ing on its very first use and forcing a real
+logout (the retry-once transparent-refresh in `core.js` doesn't save you: the
+refreshed token faces the identical same-second race). Fixed 2026-08-02 by
+flooring the marker to whole seconds before comparing
+(`invalidatedSeconds()` in `utils/redis.js`) — a token issued in the same
+second as the marker is no longer treated as predating it. This is the kind
+of bug that's easy to miss because it's timing-dependent: it reproduces
+reliably in production (same-request calls land in the same second constantly)
+but any test asserting it with a realistic multi-second gap between marker and
+token (as the original `redis.test.js` cases did) won't catch it — the
+regression test added alongside the fix uses a token issued in the *same*
+second as the marker specifically to exercise the race.
+
 ### Audit events for login/logout/timeout
 
 `loginUser()` success path, `POST /auth/logout`, and a dedicated

--- a/backend/src/__tests__/redis.test.js
+++ b/backend/src/__tests__/redis.test.js
@@ -59,6 +59,21 @@ describe('redis.js Postgres fallback (Redis disabled)', () => {
     expect(result).toBe(false);
   });
 
+  it('isSessionInvalidated returns false for a token issued in the same second as the marker', async () => {
+    // Regression test: a self-service route (e.g. change-password) calls
+    // invalidateUserSessions() and then immediately mints a fresh token for
+    // the caller's own session. JWT `iat` is second-precision, so that fresh
+    // token can land in the exact same second as the (millisecond-precision)
+    // invalidation marker. It must not be treated as predating the marker,
+    // or the caller is logged out by their own password change.
+    const invalidatedAt = new Date(2_000_500); // second 2000, 500ms in
+    const tokenIssuedAt = 2_000; // seconds — same second, issued after the marker
+    tenantQuery.mockResolvedValueOnce([{ invalidated_at: invalidatedAt }]);
+
+    const result = await isSessionInvalidated(SLUG, SUBJECT, tokenIssuedAt);
+    expect(result).toBe(false);
+  });
+
   it('purgeTenantInvalidations clears the tenant fallback rows', async () => {
     tenantQuery.mockResolvedValueOnce([]);
     await purgeTenantInvalidations(SLUG);

--- a/backend/src/utils/redis.js
+++ b/backend/src/utils/redis.js
@@ -75,7 +75,7 @@ export async function isSessionInvalidated(tenantSlug, userId, tokenIssuedAt) {
     const value = await client.get(key);
     if (!value) return false;
     const invalidatedAt = parseInt(value, 10);
-    return tokenIssuedAt * 1000 < invalidatedAt;
+    return tokenIssuedAt < invalidatedSeconds(invalidatedAt);
   }
   if (USE_REDIS) return false;
   const [row] = await tenantQuery(
@@ -84,7 +84,24 @@ export async function isSessionInvalidated(tenantSlug, userId, tokenIssuedAt) {
     [userId],
   );
   if (!row) return false;
-  return tokenIssuedAt * 1000 < new Date(row.invalidated_at).getTime();
+  return tokenIssuedAt < invalidatedSeconds(new Date(row.invalidated_at).getTime());
+}
+
+// JWT `iat` is second-precision (jsonwebtoken floors it), but the
+// invalidation marker is stored with millisecond precision. Comparing them
+// directly (`tokenIssuedAt * 1000 < invalidatedAtMs`) means a token minted
+// milliseconds *after* invalidation — e.g. the fresh access token a
+// password-change route reissues for the caller's own session, moments
+// after calling invalidateUserSessions() — can land in the very same
+// second as the marker (its floored `iat` equals the marker's floored
+// second) and still get wrongly flagged as stale. Flooring the marker to
+// whole seconds before comparing removes that race: a token issued in the
+// same second as the marker is no longer treated as predating it. This
+// only widens the "still valid" window by under a second at the boundary —
+// an unavoidable consequence of `iat` losing sub-second precision, not a
+// meaningful weakening of the invalidation guarantee.
+function invalidatedSeconds(invalidatedAtMs) {
+  return Math.floor(invalidatedAtMs / 1000);
 }
 
 // Remove every session-invalidation mark for a tenant. Used after a restore,

--- a/frontend/src/utils/backgroundTime.js
+++ b/frontend/src/utils/backgroundTime.js
@@ -1,12 +1,12 @@
 // beacon2026/frontend/src/utils/backgroundTime.js
-// Sets html[data-daytime] to "day" (06:00-18:00 local time) or "night",
+// Sets html[data-daytime] to "day" or "night" (01:00-05:00 local time),
 // driving the light-day.png / light-night.png page background in index.css.
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1000;
 
 function currentDaytime() {
   const hour = new Date().getHours();
-  return hour >= 6 && hour < 18 ? 'day' : 'night';
+  return hour >= 1 && hour < 5 ? 'night' : 'day';
 }
 
 export function startBackgroundTimeUpdater() {


### PR DESCRIPTION
## Summary
- Forced password change (0.12.2) was still logging the user out: the fix reissued a fresh access token immediately after `invalidateUserSessions()`, but `isSessionInvalidated()` compared that token's second-precision JWT `iat` against a millisecond-precision invalidation marker — so the new token could land in the same second as the marker and be wrongly treated as predating it. Fixed by flooring the marker to whole seconds before comparing (`backend/src/utils/redis.js`).
- Sign-in page dark background now shows only 01:00–05:00 local time (was 18:00–06:00).

## Test plan
- [x] `cd backend && npm test` — 655 passed, including a new regression test for a token issued in the same second as the invalidation marker
- [x] `cd frontend && npm test` — 198 passed
- [x] `npm run lint` — clean
- [x] format check on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)