### PR TITLE
Add persistent Add Event button to Events page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format: `## [version] — YYYY-MM-DD` with bullet points per change.
 heading for the next release sit under dated `## [Unreleased]` headings; released
 versions follow as `## [x.y.z] — date`. Entries for **0.9.7 and earlier** live in
 [`docs/history/CHANGELOG-archive.md`](docs/history/CHANGELOG-archive.md). The most
-recent released version is **[0.12.2](#0122--2026-08-02)** — check
+recent released version is **[0.12.3](#0123--2026-08-02)** — check
 `backend/package.json` / `frontend/package.json` for the authoritative current
 version, since not every `## [Unreleased]` heading below has been retitled with
 its release version yet (several date from 2026-04-28 through 2026-07-31, covering
@@ -16,7 +16,15 @@ that still says "Unreleased".
 
 ---
 
-## [Unreleased] — 2026-08-02
+## [0.12.3] — 2026-08-02
+
+### Added
+- **"+ Add Event" button on the Events page.** Adding a non-group event
+  (an open meeting or other general event) previously required knowing to
+  select the "open meetings and other" filter radio first — nothing on the
+  page hinted that was also how you add one. A persistent button in the
+  page header now switches to that mode and scrolls straight to the
+  existing "Add Events" form. `frontend/src/pages/calendar/Calendar.jsx`.
 
 ### Fixed
 - **Forced password change was still logging the user out, even after

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-backend",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "beacon2026 API server",
   "type": "module",
   "main": "src/app.js",

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -1,7 +1,7 @@
 # beacon2026 — Project Definition (last reviewed 2026-06-14)
 
 > **Note:** This document describes the *current* state of the project as of
-> 2026-06-14 (version 0.12.2). It is the canonical inventory of modules, routes,
+> 2026-06-14 (version 0.12.3). It is the canonical inventory of modules, routes,
 > and pages; for a contributor-oriented repo map and quickstart see
 > [`README.md`](README.md). Read it alongside `CLAUDE.md`, `CLAUDE-STANDARDS.md`,
 > and `CLAUDE-REFERENCE.md` in the repository root, which contain coding
@@ -26,7 +26,7 @@ beacon2026 is a ground-up rebuild with these goals:
 
 ---
 
-## What has been built (as of version 0.12.2)
+## What has been built (as of version 0.12.3)
 
 ### Infrastructure and platform
 - Full multi-tenant architecture (PostgreSQL schema-per-tenant)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-frontend",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.27.3",
         "@tiptap/extension-text-style": "^3.27.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/calendar/Calendar.jsx
+++ b/frontend/src/pages/calendar/Calendar.jsx
@@ -1,7 +1,7 @@
 // beacon2026/frontend/src/pages/calendar/Calendar.jsx
 // Calendar — chronological list of all group/team events + non-group events.
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import {
   calendar as calendarApi,
@@ -70,6 +70,8 @@ export default function Calendar() {
   const [addForm, setAddForm] = useState(EMPTY_EV);
   const [addError, setAddError] = useState(null);
   const [addSaving, setAddSaving] = useState(false);
+  const [scrollToAddForm, setScrollToAddForm] = useState(false);
+  const addFormRef = useRef(null);
 
   const canManage = can('meetings', 'create') || can('meetings', 'change');
   const canViewMeetings = can('meetings', 'view');
@@ -164,6 +166,22 @@ export default function Calendar() {
       setEventTypeId(eventTypeList[0].id);
     }
   }, [filterMode, eventTypeList]);
+
+  // Scroll the "Add Events" form into view after the "Add Event" header button is used
+  useEffect(() => {
+    if (scrollToAddForm && filterMode === 'other' && eventTypeId && addFormRef.current) {
+      addFormRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setScrollToAddForm(false);
+    }
+  }, [scrollToAddForm, filterMode, eventTypeId]);
+
+  function handleAddEventClick() {
+    setFilterMode('other');
+    clearMember();
+    setVenueId('');
+    setGroupId('');
+    setScrollToAddForm(true);
+  }
 
   function setAdd(field, value) {
     setAddForm((prev) => ({ ...prev, [field]: value }));
@@ -297,7 +315,18 @@ export default function Calendar() {
       <NavBar links={navLinks} />
 
       <div className="max-w-6xl mx-auto px-4 mt-4 space-y-4">
-        <h1 className="text-xl font-bold text-center">Events</h1>
+        <div className="relative">
+          <h1 className="text-xl font-bold text-center">Events</h1>
+          {canManage && canViewMeetings && (
+            <button
+              type="button"
+              onClick={handleAddEventClick}
+              className="absolute right-0 top-0 bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-1.5 text-sm font-medium transition-colors"
+            >
+              + Add Event
+            </button>
+          )}
+        </div>
 
         {/* Filter controls */}
         <div className="bg-white/90 rounded-lg shadow-sm p-4 space-y-3">
@@ -711,7 +740,7 @@ export default function Calendar() {
 
   function renderAddForm() {
     return (
-      <div className="bg-white/90 rounded-lg shadow-sm p-4">
+      <div ref={addFormRef} className="bg-white/90 rounded-lg shadow-sm p-4">
         <h3 className="text-sm font-semibold text-slate-700 mb-3">Add Events</h3>
         {addError && <p className="text-red-600 text-sm mb-2">{addError}</p>}
         <form onSubmit={handleAdd} noValidate className="space-y-3">


### PR DESCRIPTION
## Summary
- Adds a persistent "+ Add Event" button to the Events page header (visible to users with meeting create/change privilege) that switches into "open meetings and other" mode and scrolls to the add form — previously the only way to add a non-group event was to know to select that filter radio first.
- Bumps version to 0.12.3.

## Test plan
- [x] `npm run lint` (frontend) — clean, no new errors
- [x] `npm test` (backend) — 655 passed
- [x] `npm test` (frontend) — 196 passed; 2 unrelated tests (JoinForm, TransferMoney) pass individually but time out under full-suite parallelism, confirmed pre-existing/unaffected by this change
- [ ] Manual eyeball in browser (deferred — no local Postgres/env configured in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)