### PR TITLE
Fix stale E2E selectors after Calendar/Events and Ledger/Cash rename

### DIFF
--- a/e2e/tests/04-groups.spec.js
+++ b/e2e/tests/04-groups.spec.js
@@ -82,13 +82,13 @@ test.describe('Group tabs', () => {
     await page.waitForURL(/\/groups\/[^/]+$/);
   }
 
-  test('Schedule tab is visible and clickable', async ({ adminPage: page }) => {
+  test('Events tab is visible and clickable', async ({ adminPage: page }) => {
     await openGroup(page);
-    const scheduleTab = page.getByRole('tab', { name: /schedule/i }).first();
-    await expect(scheduleTab).toBeVisible();
-    await scheduleTab.click();
-    // Schedule panel should contain an "Add Events" section or similar
-    await expect(page.getByText(/schedule/i).first()).toBeVisible();
+    const eventsTab = page.getByRole('tab', { name: /events/i }).first();
+    await expect(eventsTab).toBeVisible();
+    await eventsTab.click();
+    // Events panel should contain an "Add Events" section
+    await expect(page.getByText(/add events/i).first()).toBeVisible();
   });
 
   test('Members tab is visible and clickable', async ({ adminPage: page }) => {
@@ -98,18 +98,18 @@ test.describe('Group tabs', () => {
     await membersTab.click();
   });
 
-  test('Ledger tab is visible and clickable', async ({ adminPage: page }) => {
+  test('Group Cash tab is visible and clickable', async ({ adminPage: page }) => {
     await openGroup(page);
-    const ledgerTab = page.getByRole('tab', { name: /ledger/i }).first();
-    await expect(ledgerTab).toBeVisible();
-    await ledgerTab.click();
+    const cashTab = page.getByRole('tab', { name: /group cash/i }).first();
+    await expect(cashTab).toBeVisible();
+    await cashTab.click();
     // Ledger panel loads
     await expect(page.getByText(/brought forward/i).first()).toBeVisible({ timeout: 6_000 });
   });
 
-  test('add a schedule event', async ({ adminPage: page }) => {
+  test('add an event', async ({ adminPage: page }) => {
     await openGroup(page);
-    await page.getByRole('tab', { name: /schedule/i }).first().click();
+    await page.getByRole('tab', { name: /events/i }).first().click();
 
     // Fill add-event form — native date input uses YYYY-MM-DD format
     const dateInput = page.locator('input[name="eventDate"]').first();

--- a/e2e/tests/04b-teams.spec.js
+++ b/e2e/tests/04b-teams.spec.js
@@ -51,25 +51,25 @@ test.describe('Team tabs', () => {
     await expect(page.getByRole('heading', { name: TEAM_NAME })).toBeVisible({ timeout: 10_000 });
   }
 
-  test('Schedule tab is visible and clickable', async ({ adminPage: page }) => {
+  test('Events tab is visible and clickable', async ({ adminPage: page }) => {
     await openTeam(page);
-    const scheduleTab = page.getByRole('tab', { name: /schedule/i }).first();
-    await expect(scheduleTab).toBeVisible();
-    await scheduleTab.click();
-    await expect(page.getByText(/schedule/i).first()).toBeVisible();
+    const eventsTab = page.getByRole('tab', { name: /events/i }).first();
+    await expect(eventsTab).toBeVisible();
+    await eventsTab.click();
+    await expect(page.getByText(/add events/i).first()).toBeVisible();
   });
 
-  test('Ledger tab is visible and clickable', async ({ adminPage: page }) => {
+  test('Team Cash tab is visible and clickable', async ({ adminPage: page }) => {
     await openTeam(page);
-    const ledgerTab = page.getByRole('tab', { name: /ledger/i }).first();
-    await expect(ledgerTab).toBeVisible();
-    await ledgerTab.click();
+    const cashTab = page.getByRole('tab', { name: /team cash/i }).first();
+    await expect(cashTab).toBeVisible();
+    await cashTab.click();
     await expect(page.getByText(/brought forward/i).first()).toBeVisible({ timeout: 6_000 });
   });
 
-  test('add a schedule event to a team', async ({ adminPage: page }) => {
+  test('add an event to a team', async ({ adminPage: page }) => {
     await openTeam(page);
-    await page.getByRole('tab', { name: /schedule/i }).first().click();
+    await page.getByRole('tab', { name: /events/i }).first().click();
 
     const dateInput = page.locator('input[name="eventDate"]').first();
     await expect(dateInput).toBeVisible({ timeout: 5_000 });

--- a/e2e/tests/12-calendar.spec.js
+++ b/e2e/tests/12-calendar.spec.js
@@ -14,6 +14,9 @@ import { test, expect } from '../fixtures/admin.js';
 
 // ── Helper: SPA-navigate to a Home link ──────────────────────────────────
 
+// The Calendar page (route /calendar) renders under an "Events" heading
+// (renamed from "Calendar" in commit 8342f14, 2026-04-20) — the route/nav
+// link is still /calendar, only the on-page <h1> text changed.
 async function gotoHomeLink(page, href, headingText) {
   await page.evaluate(() => {
     const h = document.querySelector('a[href="/"]');
@@ -33,7 +36,7 @@ async function gotoHomeLink(page, href, headingText) {
 
 test.describe('Calendar', () => {
   test('page loads with heading and filter controls', async ({ adminPage: page }) => {
-    await gotoHomeLink(page, '/calendar', 'Calendar');
+    await gotoHomeLink(page, '/calendar', 'Events');
 
     // Filter radio buttons
     await expect(page.getByText('All').first()).toBeVisible();
@@ -44,7 +47,7 @@ test.describe('Calendar', () => {
   });
 
   test('Download PDF button appears when events exist', async ({ adminPage: page }) => {
-    await gotoHomeLink(page, '/calendar', 'Calendar');
+    await gotoHomeLink(page, '/calendar', 'Events');
 
     // Button only renders when events are loaded and non-empty.
     // In a fresh tenant there may be no events, so verify either
@@ -55,7 +58,7 @@ test.describe('Calendar', () => {
   });
 
   test('Show Detail checkbox is present exactly once', async ({ adminPage: page }) => {
-    await gotoHomeLink(page, '/calendar', 'Calendar');
+    await gotoHomeLink(page, '/calendar', 'Events');
 
     // Wait for the filter controls to render
     await expect(page.locator('input[type="date"][name="from"]')).toBeVisible();
@@ -66,7 +69,7 @@ test.describe('Calendar', () => {
   });
 
   test('"Other" filter mode shows event type dropdown', async ({ adminPage: page }) => {
-    await gotoHomeLink(page, '/calendar', 'Calendar');
+    await gotoHomeLink(page, '/calendar', 'Events');
 
     // Click the "other" radio button
     const otherRadio = page.locator('input[name="filter"][value="other"]');
@@ -87,7 +90,7 @@ test.describe('Calendar', () => {
   });
 
   test('Group/Team filter dropdown is present', async ({ adminPage: page }) => {
-    await gotoHomeLink(page, '/calendar', 'Calendar');
+    await gotoHomeLink(page, '/calendar', 'Events');
 
     // Wait for filter controls to render, then click the "group" radio
     const groupRadio = page.locator('input[name="filter"][value="group"]');


### PR DESCRIPTION
## Summary
- The E2E suite failed 11/164 tests on staging because two UI-text renames from 2026-04-20 (commits 8342f14, fa1a5d0) were never reflected in the specs: Calendar heading "Calendar"→"Events", and Group/Team tabs "Schedule"→"Events", "Ledger"→"Group Cash"/"Team Cash".
- Updated `e2e/tests/12-calendar.spec.js`, `04-groups.spec.js`, `04b-teams.spec.js` selectors/titles to match current UI text. No app code changed.

## Test plan
- [x] Reviewed current component source (`Calendar.jsx`, `GroupRecord.jsx`, `TeamRecord.jsx`, `Schedule.jsx`, `GroupLedger.jsx`, `TeamLedger.jsx`) to confirm exact rendered text used in the new selectors
- [ ] CI green
- [ ] Re-run E2E workflow against staging and confirm previously-failing tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)