### PR TITLE
Fix remaining stale E2E selectors and bump CI global timeout

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -59,8 +59,11 @@ export default defineConfig({
 
   // Global setup creates (or resets) the test tenant before any tests run.
   // globalTimeout covers the ENTIRE test run (setup + all tests + teardown).
-  // 15 minutes for CI (130 tests × ~5 s avg including login overhead).
-  globalTimeout: process.env.CI ? 900_000 : 300_000,
+  // 25 minutes for CI (suite has grown to ~170 tests × ~5s avg including
+  // login/cold-start overhead; leaves headroom under the 30-min job cap in
+  // .github/workflows/e2e.yml so teardown always gets to run and delete the
+  // test tenant, even if a slow run trips this budget).
+  globalTimeout: process.env.CI ? 1_500_000 : 300_000,
   globalSetup: './global-setup.js',
   globalTeardown: './global-teardown.js',
 

--- a/e2e/tests/19-event-members.spec.js
+++ b/e2e/tests/19-event-members.spec.js
@@ -42,6 +42,9 @@ const TXN_PAYEE   = 'E2EEvtPayee';
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
+// Note: the Calendar page (route /calendar) renders under an "Events"
+// heading, and the Group "Schedule" tab is now labelled "Events" — see
+// e2e/tests/12-calendar.spec.js and 04-groups.spec.js for the same rename.
 async function gotoHomeLink(page, href, headingText) {
   await page.evaluate(() => {
     const h = document.querySelector('a[href="/"]');
@@ -59,7 +62,7 @@ async function gotoHomeLink(page, href, headingText) {
 
 /** Navigate to Calendar, find the test event, click into EventRecord. */
 async function gotoEventViaCalendar(page) {
-  await gotoHomeLink(page, '/calendar', 'Calendar');
+  await gotoHomeLink(page, '/calendar', 'Events');
   // Wait for events to load — find the row containing our topic
   const eventRow = page.getByRole('row').filter({ hasText: EVENT_TOPIC });
   await expect(eventRow.first()).toBeVisible({ timeout: 15_000 });
@@ -107,9 +110,9 @@ test.describe('Event members setup', () => {
     await expect(page.getByRole('heading', { name: GROUP_NAME })).toBeVisible({ timeout: 10_000 });
   });
 
-  test('add a schedule event to the group', async ({ adminPage: page }) => {
+  test('add an event to the group', async ({ adminPage: page }) => {
     await openGroup(page);
-    await page.getByRole('tab', { name: /schedule/i }).first().click();
+    await page.getByRole('tab', { name: /events/i }).first().click();
 
     const dateInput = page.locator('input[name="eventDate"]').first();
     await expect(dateInput).toBeVisible({ timeout: 5_000 });
@@ -370,12 +373,12 @@ test.describe('Event Financials', () => {
 
 // ── Schedule View Link ──────────────────────────────────────────────────
 
-test.describe('Schedule View link', () => {
-  test('View link in group schedule opens EventRecord', async ({ adminPage: page }) => {
+test.describe('Events tab View link', () => {
+  test('View link in group Events tab opens EventRecord', async ({ adminPage: page }) => {
     await openGroup(page);
-    await page.getByRole('tab', { name: /schedule/i }).first().click();
+    await page.getByRole('tab', { name: /events/i }).first().click();
 
-    // Wait for the schedule to load with our event
+    // Wait for the events list to load with our event
     await expect(page.getByText(EVENT_TOPIC)).toBeVisible({ timeout: 6_000 });
 
     // Click the "View" link for the event


### PR DESCRIPTION
## Summary
- `19-event-members.spec.js` still used the pre-rename "Schedule" tab / "Calendar" heading selectors (same drift already fixed for the other spec files in #487) — updated 3 selectors + 2 test titles to match current UI text ("Events" tab/heading).
- Swept all `e2e/tests/*.spec.js` for any other stale `/schedule/i`, `/ledger/i`, `'Calendar'` references — none left (the remaining `/ledger/i` hits in `06-finance.spec.js` are the unrelated Finance Ledger page, which was never renamed).
- Bumped `playwright.config.js` CI `globalTimeout` from 15 to 25 minutes — the previous run hit "Timed out waiting 900s for the test suite to run" after 149/169 tests, and global-teardown never ran (leaving the E2E test tenant undeleted on staging). The suite has grown from ~130 to ~170 tests since the 15-minute budget was set; 25 minutes leaves headroom under the 30-minute job cap in `.github/workflows/e2e.yml`.

## Test plan
- [x] Read current `Schedule.jsx`/`GroupRecord.jsx`/`TeamRecord.jsx` to confirm tab text
- [x] Grepped all e2e spec files for remaining stale label references
- [ ] CI green
- [ ] Re-run E2E workflow against staging and confirm previously-failing/timed-out tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)