### PR TITLE
Fix hardcoded past event date in event-members E2E test

### DIFF
--- a/e2e/tests/19-event-members.spec.js
+++ b/e2e/tests/19-event-members.spec.js
@@ -37,8 +37,20 @@ const GROUP_NAME  = 'E2EEvtGroup';
 const MEMBER_SUR  = 'E2EEvtMbr';
 const MEMBER_FORE = 'Eve';
 const EVENT_TOPIC = 'E2E Event Test';
-const EVENT_DATE  = '2026-06-15';
 const TXN_PAYEE   = 'E2EEvtPayee';
+
+// The Calendar page only shows events within its default filter window
+// (today .. today+3 months — see frontend/src/pages/calendar/calendarUtils.js).
+// A hardcoded past date would silently drop out of that window as time
+// passes, so compute a date 14 days out instead.
+const eventDateObj = new Date();
+eventDateObj.setDate(eventDateObj.getDate() + 14);
+const EVENT_DATE      = eventDateObj.toISOString().slice(0, 10); // YYYY-MM-DD, for date inputs
+const EVENT_DATE_DISP = [
+  String(eventDateObj.getDate()).padStart(2, '0'),
+  String(eventDateObj.getMonth() + 1).padStart(2, '0'),
+  eventDateObj.getFullYear(),
+].join('/'); // DD/MM/YYYY, for display assertions
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -194,7 +206,7 @@ test.describe('EventRecord navigation and details', () => {
     await gotoEventViaCalendar(page);
 
     // Date in DD/MM/YYYY format
-    await expect(page.getByText('15/06/2026', { exact: true })).toBeVisible();
+    await expect(page.getByText(EVENT_DATE_DISP, { exact: true })).toBeVisible();
     // Time
     await expect(page.getByText('10:00', { exact: true })).toBeVisible();
     // Group name as a link


### PR DESCRIPTION
## Summary
- `19-event-members.spec.js` hardcoded `EVENT_DATE = '2026-06-15'`. The Calendar page only lists events within its default filter window (today .. today+3 months, `frontend/src/pages/calendar/calendarUtils.js`), so once today's date passed 2026-06-15 the test event silently dropped out of that window — every test that finds the event via the Calendar page (`gotoEventViaCalendar`) started failing to locate it, cascading into 11 failures on the last E2E run.
- `EVENT_DATE` is now computed 14 days from today at test-run time (plus its DD/MM/YYYY display form for the "Details tab shows event info" assertion), so it stays inside the Calendar's forward window indefinitely.
- Confirmed the Group/Team "Events" tab (`Schedule.jsx`) has no date filtering, so the existing hardcoded dates in `04-groups.spec.js`/`04b-teams.spec.js` aren't affected by this class of bug.

## Test plan
- [x] Confirmed `Schedule.jsx` has no date-range filter (only Calendar.jsx does)
- [x] Confirmed `fmtDate()` produces zero-padded `DD/MM/YYYY`, matching the new `EVENT_DATE_DISP` format
- [ ] CI green
- [ ] Re-run E2E workflow against staging and confirm previously-failing tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)