### PR TITLE
Fix stale 'View' link selector in group Events tab E2E test

### DIFF
--- a/e2e/tests/19-event-members.spec.js
+++ b/e2e/tests/19-event-members.spec.js
@@ -22,7 +22,7 @@
 //    ✓ Add-transaction link is present
 //    ✓ Create transaction linked to event
 //  Schedule View link:
-//    ✓ View link in group schedule opens EventRecord
+//    ✓ Date link in group Events tab opens EventRecord
 //  Cleanup:
 //    ✓ Delete the test member
 //    ✓ Delete the test group
@@ -385,19 +385,21 @@ test.describe('Event Financials', () => {
 
 // ── Schedule View Link ──────────────────────────────────────────────────
 
-test.describe('Events tab View link', () => {
-  test('View link in group Events tab opens EventRecord', async ({ adminPage: page }) => {
+test.describe('Events tab date link', () => {
+  test('date link in group Events tab opens EventRecord', async ({ adminPage: page }) => {
     await openGroup(page);
     await page.getByRole('tab', { name: /events/i }).first().click();
 
     // Wait for the events list to load with our event
     await expect(page.getByText(EVENT_TOPIC)).toBeVisible({ timeout: 6_000 });
 
-    // Click the "View" link for the event
+    // The event's date/time cell is itself the link to EventRecord — there
+    // is no separate "View" link/button (Schedule.jsx wraps the date text
+    // in a <Link to={`/calendar/events/${ev.id}`}>).
     const eventRow = page.getByRole('row').filter({ hasText: EVENT_TOPIC });
-    const viewLink = eventRow.getByRole('link', { name: 'View' });
-    await expect(viewLink).toBeVisible();
-    await viewLink.click();
+    const dateLink = eventRow.locator('a[href^="/calendar/events/"]');
+    await expect(dateLink.first()).toBeVisible();
+    await dateLink.first().click();
 
     // Should navigate to EventRecord
     await expect(page).toHaveURL(/\/calendar\/events\/[^/]+$/);


### PR DESCRIPTION
## Summary
- `Schedule.jsx` no longer renders a separate "View" link/button per event row — the date/time cell itself is the `<Link to={'/calendar/events/'+ev.id}>`. The E2E test's `getByRole('link', { name: 'View' })` selector was stale, so "View link in group Events tab opens EventRecord" timed out looking for an element that no longer exists (this is the last of the 12 original failures from the label-rename drift fixed in #487-#489).
- Updated the test to click the date-cell link via its `href` prefix (`a[href^="/calendar/events/"]`), matching the pattern already used by `gotoEventViaCalendar()` elsewhere in the same file. Renamed the test/describe titles to match.
- Swept the rest of the E2E suite for any other `'View'`-link assumptions — none found.

## Test plan
- [x] Confirmed current `Schedule.jsx` markup — no "View" link exists, date cell is the link
- [ ] CI green
- [ ] Re-run E2E workflow against staging and confirm full suite is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)