### PR TITLE
Give the Event Financials tab load more time in E2E tests

### DIFF
--- a/e2e/tests/19-event-members.spec.js
+++ b/e2e/tests/19-event-members.spec.js
@@ -98,7 +98,10 @@ async function gotoEventMembersTab(page) {
 async function gotoEventFinancialsTab(page) {
   await gotoEventViaCalendar(page);
   await page.getByRole('tab', { name: /financials/i }).first().click();
-  await page.getByText(/income/i).first().waitFor({ timeout: 10_000 });
+  // 20s: the financials fetch runs after a fresh calendar->event navigation
+  // (itself two round-trips), and has been observed to occasionally exceed
+  // 10s under CI load without indicating an actual app problem.
+  await page.getByText(/income/i).first().waitFor({ timeout: 20_000 });
 }
 
 /** Open the test group record from the group list. */


### PR DESCRIPTION
## Summary
- `gotoEventFinancialsTab()` waited only 10s for the "Income" summary text after a Calendar→EventRecord→Financials-tab navigation (two XHR round-trips) plus a tab click. This was tight enough to time out under CI load: "create transaction linked to event and verify in financials" failed on both attempts in the last run (17.5s/22.2s total test duration, well under the 60s per-test budget), while three other tests using the same helper passed fine elsewhere in the same run.
- Bumped the wait from 10s to 20s to give it headroom. No app code change — this is the last item from the [30736808835](https://github.com/PeterC66/Beacon2026/actions/runs/30736808835) run; everything else in that run either passed outright or was flaky-but-passed-on-retry (Playwright's built-in CI retry already covers those).

## Test plan
- [ ] CI green
- [ ] Re-run E2E workflow against staging and confirm full suite is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)