### PR TITLE
Seed default Standard Email Messages and Standard Letters for new tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ that still says "Unreleased".
   create/edit/delete saved reports, the ad-hoc SQL editor, and the
   read-only/row/time safety limits. Linked from the index and from
   `docs/BeaconUG-Comparison.md`.
+- **Default Standard Email Messages and Standard Letters for new tenants.**
+  Every new u3a tenant previously started with an empty template list. Now
+  seeds two email templates ("New Member Welcome", "Renewal Confirmation",
+  adapted from the original Beacon User Guide's doc 6.1.2) and one letter
+  ("Annual Data Check Form"), each generic with bracketed placeholders for
+  u3a-specific details (website links, postal address, phone, contact
+  email). `backend/src/seed/defaultTemplates.js`, wired into
+  `createTenantSchema()`. Documented in `docs/Beacon2026UG/36-standard-email-messages.md`.
 
 ### Changed
 - **Add Events form now shows the selected category.** The category

--- a/backend/src/__tests__/defaultTemplates.test.js
+++ b/backend/src/__tests__/defaultTemplates.test.js
@@ -1,0 +1,130 @@
+// beacon2026/backend/src/__tests__/defaultTemplates.test.js
+// Sanity checks for the Standard Email/Letter templates seeded into every
+// new tenant — every #TOKEN used must be one emailTokens.js actually
+// resolves, and no tenant-specific detail (a real u3a's own address/phone/
+// email) should have leaked into what's meant to be a generic default.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import supertest from 'supertest';
+import { makeAuthHeader } from './helpers.js';
+import { buildTokenMap } from '../utils/emailTokens.js';
+import { DEFAULT_STANDARD_MESSAGES, DEFAULT_STANDARD_LETTERS } from '../seed/defaultTemplates.js';
+
+vi.mock('../utils/db.js', () => ({
+  prisma: { $disconnect: vi.fn() },
+  tenantQuery: vi.fn(),
+  withTenant: vi.fn(),
+}));
+vi.mock('../utils/redis.js', () => ({
+  isSessionInvalidated: vi.fn().mockResolvedValue(false),
+}));
+
+const { tenantQuery } = await import('../utils/db.js');
+const { default: app } = await import('../app.js');
+const request = supertest(app);
+const auth = makeAuthHeader();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const KNOWN_TOKENS = new Set(Object.keys(buildTokenMap({}, 'Test u3a')));
+
+function tokensUsedIn(text) {
+  return [...text.matchAll(/#[A-Z0-9]+/g)].map((m) => m[0]);
+}
+
+describe('default Standard Email Messages', () => {
+  it.each(DEFAULT_STANDARD_MESSAGES)('$name only uses known tokens', ({ subject, body }) => {
+    for (const token of tokensUsedIn(`${subject} ${body}`)) {
+      expect(KNOWN_TOKENS.has(token)).toBe(true);
+    }
+  });
+
+  it('has the two expected default messages', () => {
+    const names = DEFAULT_STANDARD_MESSAGES.map((m) => m.name);
+    expect(names).toEqual(['New Member Welcome', 'Renewal Confirmation']);
+  });
+});
+
+function textOfTiptapDoc(doc) {
+  const parts = [];
+  for (const node of doc.content || []) {
+    for (const child of node.content || []) {
+      if (child.type === 'text') parts.push(child.text);
+    }
+  }
+  return parts.join(' ');
+}
+
+describe('default Standard Letters', () => {
+  it('body is a valid Tiptap doc (as required by tiptapToPdfContent)', () => {
+    for (const letter of DEFAULT_STANDARD_LETTERS) {
+      const doc = JSON.parse(letter.body);
+      expect(doc.type).toBe('doc');
+      expect(Array.isArray(doc.content)).toBe(true);
+    }
+  });
+
+  it.each(DEFAULT_STANDARD_LETTERS)('$name only uses known tokens', ({ body }) => {
+    const text = textOfTiptapDoc(JSON.parse(body));
+    for (const token of tokensUsedIn(text)) {
+      expect(KNOWN_TOKENS.has(token)).toBe(true);
+    }
+  });
+
+  it('does not contain a real u3a’s own contact details', () => {
+    const body = DEFAULT_STANDARD_LETTERS.find((l) => l.name === 'Annual Data Check Form').body;
+    expect(body).not.toMatch(/u3aivo\.uk/);
+    expect(body).not.toMatch(/07458 ?197372/);
+    expect(body).not.toMatch(/Needingworth/i);
+    expect(body).not.toMatch(/Spinney Way/i);
+  });
+
+  it('actually generates a PDF via /letters/download', async () => {
+    const doc = JSON.parse(
+      DEFAULT_STANDARD_LETTERS.find((l) => l.name === 'Annual Data Check Form').body,
+    );
+    tenantQuery.mockResolvedValueOnce([
+      {
+        id: 'm1',
+        membership_number: 1,
+        title: 'Mr',
+        forenames: 'John',
+        surname: 'Smith',
+        known_as: null,
+        email: 'john@test.com',
+        mobile: '07700',
+        next_renewal: null,
+        home_u3a: null,
+        class_name: 'Individual',
+        house_no: '1',
+        street: 'High St',
+        add_line1: null,
+        add_line2: null,
+        town: 'Oxford',
+        county: 'Oxon',
+        postcode: 'OX1 1AA',
+        telephone: '01234',
+        p_id: null,
+        p_title: null,
+        p_forenames: null,
+        p_surname: null,
+        p_known_as: null,
+        p_email: null,
+        p_mobile: null,
+        p_telephone: null,
+      },
+    ]);
+    tenantQuery.mockResolvedValueOnce([{ display_name: 'Test u3a' }]);
+
+    const res = await request
+      .post('/letters/download')
+      .set('Authorization', auth)
+      .send({ memberIds: ['m1'], body: doc });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/pdf/);
+    expect(res.body.toString('ascii', 0, 5)).toBe('%PDF-');
+  });
+});

--- a/backend/src/seed/createTenant.js
+++ b/backend/src/seed/createTenant.js
@@ -10,6 +10,7 @@ import { hashPassword } from '../utils/password.js';
 import { splitSQL } from '../utils/migrate.js';
 import { PRIVILEGE_RESOURCES } from './privilegeResources.js';
 import { DEFAULT_ROLES } from './defaultRoles.js';
+import { DEFAULT_STANDARD_MESSAGES, DEFAULT_STANDARD_LETTERS } from './defaultTemplates.js';
 import { logger } from '../utils/logger.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -20,7 +21,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  *  2. Create the PostgreSQL schema
  *  3. Seed privilege resources
  *  4. Seed default roles with their default privileges
- *  5. Create the first admin user
+ *  5. Seed default member statuses and member class
+ *  6. Seed default Standard Email Messages and Standard Letters
+ *  7. Create the first admin user
  *
  * @param {{ name, slug, adminEmail, adminName, adminPassword, adminUsername }} params
  */
@@ -94,7 +97,25 @@ export async function createTenantSchema({
     ['Individual'],
   );
 
-  // 7. Create first admin user (gets the Administration role)
+  // 7. Seed default Standard Email Messages and Standard Letters
+  for (const msg of DEFAULT_STANDARD_MESSAGES) {
+    await tenantQuery(
+      slug,
+      `INSERT INTO standard_messages (name, subject, body) VALUES ($1, $2, $3)
+       ON CONFLICT (name) DO NOTHING`,
+      [msg.name, msg.subject, msg.body],
+    );
+  }
+  for (const letter of DEFAULT_STANDARD_LETTERS) {
+    await tenantQuery(
+      slug,
+      `INSERT INTO standard_letters (name, body) VALUES ($1, $2)
+       ON CONFLICT (name) DO NOTHING`,
+      [letter.name, letter.body],
+    );
+  }
+
+  // 8. Create first admin user (gets the Administration role)
   const passwordHash = await hashPassword(adminPassword);
   const [user] = await tenantQuery(
     slug,

--- a/backend/src/seed/defaultTemplates.js
+++ b/backend/src/seed/defaultTemplates.js
@@ -1,0 +1,147 @@
+// beacon2026/backend/src/seed/defaultTemplates.js
+// Default Standard Email Messages and Standard Letters seeded for every new
+// u3a tenant, adapted from the original Beacon User Guide's "Templates for
+// Copying" (doc 6.1.2) and the Annual Data Check Form used by u3as running
+// Beacon. Every u3a-specific detail (postal address, phone number, contact
+// email) is left as a bracketed placeholder for that u3a to fill in — see
+// CHANGELOG.md for the date these were added.
+
+export const DEFAULT_STANDARD_MESSAGES = [
+  {
+    name: 'New Member Welcome',
+    subject: 'Welcome to #U3ANAME',
+    body: `WELCOME TO #U3ANAME
+
+Dear #FAM,
+
+We would like to welcome you as a new member of #U3ANAME.
+
+Please check that your details shown below are correct and let us know by return email if any changes are required or if there is any additional information that can be added.
+
+You can find out more about #U3ANAME on [add a link to your u3a website].
+
+If you go to [add a link to the page on your website about the Members Portal] you will see details of how you can log in to the Members Portal where you can update your personal details and view additional Groups & Calendar information that is not available to the general public.
+
+We look forward to seeing you at our future meetings and events,
+
+Best regards,
+
+The Membership Team
+#U3ANAME
+
+-----------------------------------------------------
+
+Name: #TITLE #FORENAME #SURNAME
+Familiar name: #FAM
+Address: #ADDRESSV
+Email address: #EMAIL
+Home phone: #TELEPHONE
+Mobile Phone: #MOBILE
+Emergency Contact: #EMERGENCY
+Membership number: #MEMNO
+Affiliation: #AFFILIATION
+Membership Class: #MEMCLASS
+Membership Renewal Date: #RENEW`,
+  },
+  {
+    name: 'Renewal Confirmation',
+    subject: 'Membership renewal confirmation — #U3ANAME',
+    body: `MEMBERSHIP RENEWAL CONFIRMATION
+
+Dear #FAM,
+
+Thank you for renewing your membership of #U3ANAME. Please check the details about you below and let us know by return email if any changes are required or if there is any additional information that can be added.
+
+Best regards,
+
+The Membership Team
+#U3ANAME
+
+-----------------------------------------------------
+
+Name: #TITLE #FORENAME #SURNAME
+Familiar name: #FAM
+Address: #ADDRESSV
+Email address: #EMAIL
+Home phone: #TELEPHONE
+Mobile phone: #MOBILE
+Emergency contact: #EMERGENCY
+Membership class: #MEMCLASS
+Membership number: #MEMNO
+Affiliation: #AFFILIATION
+Next renewal date: #RENEW`,
+  },
+];
+
+// Standard Letters store `body` as a serialised Tiptap document
+// (`{ type: 'doc', content: [...] }`), not plain text — see
+// `tiptapToPdfContent()` in `backend/src/routes/letters.js`. Each paragraph
+// below renders as one line/block in the generated PDF; empty paragraphs
+// render as blank lines.
+function para(text, { bold = false, heading = false } = {}) {
+  if (text === '') return { type: 'paragraph' };
+  const node = {
+    type: heading ? 'heading' : 'paragraph',
+    content: [{ type: 'text', text, ...(bold ? { marks: [{ type: 'bold' }] } : {}) }],
+  };
+  if (heading) node.attrs = { level: 2 };
+  return node;
+}
+
+function labelledPara(label, value) {
+  return {
+    type: 'paragraph',
+    content: [
+      { type: 'text', text: label, marks: [{ type: 'bold' }] },
+      { type: 'text', text: value },
+    ],
+  };
+}
+
+const annualDataCheckDoc = {
+  type: 'doc',
+  content: [
+    para('#U3ANAME Annual Data Check', { heading: true }),
+    para(''),
+    labelledPara('Membership Number: ', '#MEMNO'),
+    para(''),
+    para(
+      'Please check that these details are correct, and make any required amendments in CAPITAL LETTERS.',
+    ),
+    para(''),
+    labelledPara('Name: ', '#TITLE #FORENAME #SURNAME'),
+    para(''),
+    labelledPara('Known As: ', '#FAM'),
+    para(''),
+    para('Address:', { bold: true }),
+    para('#ADDRESSV'),
+    para(''),
+    labelledPara('Telephone: ', '#TELEPHONE'),
+    para(''),
+    labelledPara('Mobile: ', '#MOBILE'),
+    para(''),
+    para(''),
+    para(
+      'If you do not want group convenors to see your contact details, put a cross in the box below. (Bear in mind that if you do this then, as you do not have an email address, group convenors and outings organisers will be unable to communicate with you using Beacon.)',
+    ),
+    para('I do not want group convenors to see my contact details:  [ ]'),
+    para(''),
+    para(''),
+    para(
+      "This form can be returned at a Members Open Meeting, or posted to the Membership Secretary at [add your Membership Secretary's postal address]. Alternatively, you can telephone [add a contact phone number] to tell us of any changes.",
+    ),
+    para(''),
+    para(
+      'You are receiving this request by letter because we do not have an email address for you. If you have an email address that you use regularly, and would prefer us to contact you that way, please email [add your membership contact email address] (quoting ref: #MEMNO) to let us know.',
+    ),
+    para(''),
+    para("If there are no changes, then you don't need to do anything."),
+  ],
+};
+
+export const DEFAULT_STANDARD_LETTERS = [
+  {
+    name: 'Annual Data Check Form',
+    body: JSON.stringify(annualDataCheckDoc),
+  },
+];

--- a/docs/Beacon2026UG/36-standard-email-messages.md
+++ b/docs/Beacon2026UG/36-standard-email-messages.md
@@ -53,6 +53,17 @@ To remove a template you no longer need:
 
 ---
 
+## Default templates on a new u3a
+
+Every new beacon2026 tenant starts with two ready-made templates, adapted from
+the original Beacon User Guide: **New Member Welcome** and **Renewal
+Confirmation**. Both include bracketed placeholders (e.g. "[add a link to
+your u3a website]") for the handful of details that are specific to your own
+u3a. Edit, rename or delete these like any other Standard Message -- they are
+a starting point, not fixed content.
+
+---
+
 ## Tips
 
 - Templates can include **personalisation tokens** (e.g. `#FAM`, `#SURNAME`). When


### PR DESCRIPTION
## Summary
- New u3a tenants previously started with an empty Standard Messages/Letters list. `createTenantSchema()` now seeds:
  - **New Member Welcome** and **Renewal Confirmation** email templates, adapted from the original Beacon User Guide's doc 6.1.2 "Templates for Copying".
  - **Annual Data Check Form** standard letter.
- All three are generic — bracketed placeholders (e.g. `[add a link to your u3a website]`, `[add your Membership Secretary's postal address]`) stand in for anything specific to one u3a, rather than baking in any one u3a's real contact details. Each u3a edits them after tenant creation, same as any other Standard Message/Letter.
- Standard letters store `body` as a serialised Tiptap document (not plain text) — `backend/src/routes/letters.js`'s `tiptapToPdfContent()` walks `{type:'doc', content:[...]}`. The Annual Data Check Form is built as a proper Tiptap doc and verified with a real `/letters/download` PDF-generation smoke test, not just a token-substitution check.
- Documents the two default email templates in `docs/Beacon2026UG/36-standard-email-messages.md`.

## Test plan
- [x] New `backend/src/__tests__/defaultTemplates.test.js` (7 tests): only known `#TOKEN`s used, Tiptap doc shape is valid, no leaked u3a-specific contact details, and a real PDF is generated end-to-end via `/letters/download`.
- [x] `cd backend && npm test` — 662/662 passing
- [x] `npm run lint` clean; prettier diff clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)