### PR TITLE
Fix inactivity timeout not actually ending the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ that still says "Unreleased".
   groupStdMessages.js`, `backend/src/utils/templateOwnership.js`,
   `backend/src/utils/groupLeader.js`).
 
+### Fixed
+- **Inactivity timeout did not actually end the session.** The idle timer
+  cleared the frontend's React state and logged a `session_timeout` audit
+  entry, but never revoked the refresh token or cleared the
+  `beacon2026_refresh` cookie — so a page reload after an idle "timeout"
+  silently re-authenticated the user via `/auth/refresh` with no further
+  audit trail, and the 30-day refresh token stayed live regardless of how
+  long the browser sat idle. `POST /auth/session-timeout`
+  (`backend/src/routes/auth.js`) now revokes the refresh token and clears the
+  cookie, exactly like `/auth/logout`; the frontend's `auth:expired` handler
+  (`frontend/src/context/AuthContext.jsx`) now also clears the in-memory
+  access token via `clearAuth()`.
+
 ---
 
 ## [Unreleased] — 2026-08-03

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -182,6 +182,21 @@ detect on its own) all write to `audit_log` with actions `'login'`,
 tell a real timeout apart from a generic refresh-token failure (the latter is
 not separately audited — it's a revoked/expired session, not a user action).
 
+`/auth/session-timeout` also revokes the refresh token and clears the
+`beacon2026_refresh` cookie (calls the same `logoutUser()` as `/auth/logout`),
+and the frontend's `auth:expired` handler calls `clearAuth()` in addition to
+resetting React state. Before 2026-08-04 the route was audit-only, so a page
+reload right after an idle timeout silently re-authenticated the user via
+`/auth/refresh` with no further audit entry — the timeout looked real in the
+log but didn't actually end the session. See CHANGELOG 2026-08-04.
+
+Note the asymmetry this still leaves: `/auth/refresh` itself (used both for
+the retry-once transparent refresh in `core.js` and for `restoreSession()` on
+app load) writes no audit entry on success. A silent session restore from the
+`beacon_last_u3a` cookie — no password, no `login` audit row — is
+indistinguishable in the log from "nobody was here". Tracked as
+`[DEFERRED]` in `KNOWN-ISSUES.md` → "Audit log — session-restore visibility".
+
 ### Personal Preferences (doc 9.1)
 
 - Frontend only: `PersonalPreferences.jsx` at `/preferences`

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -669,3 +669,23 @@ out of them.
    Reports' `ReportList.jsx`). Reassignment today requires either a group/team
    leader deleting and recreating the template under their own group's Std
    Emails/Letters tab, or a direct API call.
+
+## Audit log — session-restore visibility (added 2026-08-04)
+
+1. `[DEFERRED]` **Silent session restores are not audited.** On app load,
+   `AuthContext.jsx` calls `restoreSession()`, which does a `POST
+   /auth/refresh` using the httpOnly `beacon2026_refresh` cookie (valid up to
+   `JWT_REFRESH_EXPIRES_DAYS`, default 30) and re-authenticates with no
+   password prompt. Only a real credential login through `loginUser()` writes
+   an `action: 'login'` audit entry — `/auth/refresh` writes nothing — so the
+   audit log cannot show that a session was active on a given day if the user
+   never re-typed their password, only reloaded the page. This was surfaced
+   alongside the `session_timeout` revocation fix (see CHANGELOG 2026-08-04):
+   that fix stops idle timeouts from being silently bypassed by a reload, but
+   does not address the separate, older gap of legitimate multi-day sessions
+   being invisible in the log. Fixing this means adding a distinct audit
+   action (e.g. `session_resume`) to `/auth/refresh` on success — deferred
+   because every access-token refresh (roughly every 15 minutes while active)
+   would otherwise flood the log; it needs throttling to once per browser
+   session (e.g. only log when no prior resume/login exists within some
+   window) before it's worth shipping.

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -113,12 +113,19 @@ router.post('/logout', requireAuth, async (req, res, next) => {
 });
 
 // ─── POST /auth/session-timeout ───────────────────────────────────────────
-// Fired by the frontend when a session ends due to inactivity, purely so the
-// event is recorded — the frontend has already cleared its own state by the
-// time this call is made (fire-and-forget).
+// Fired by the frontend when a session ends due to inactivity (fire-and-forget
+// — the access token is still valid at this point, only the idle timer fired).
+// Beyond recording the event, this must actually end the session: revoke the
+// refresh token and clear the cookie, exactly like /logout does. Previously
+// this route only wrote an audit entry while leaving the refresh cookie live,
+// so a reload after an idle "timeout" silently re-authenticated the user via
+// /auth/refresh with no further audit trail — the timeout was cosmetic only.
 
 router.post('/session-timeout', requireAuth, async (req, res, next) => {
   try {
+    const refreshToken = req.cookies?.[COOKIE_NAME];
+    await logoutUser(req.user.tenantSlug, refreshToken);
+
     logAudit(req.user.tenantSlug, {
       userId: req.user.userId,
       userName: req.user.name,
@@ -127,6 +134,8 @@ router.post('/session-timeout', requireAuth, async (req, res, next) => {
       entityId: req.user.userId,
       entityName: req.user.name,
     });
+
+    res.clearCookie(COOKIE_NAME);
     res.json({ message: 'Recorded.' });
   } catch (err) {
     next(err);

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -95,8 +95,12 @@ export function AuthProvider({ children }) {
       if (e?.detail?.reason === 'timeout') {
         // Best-effort — the access token is still valid at this point
         // (only the idle timer fired), so this call can still authenticate.
+        // The backend revokes the refresh token and clears the cookie here,
+        // so a page reload after this can't silently re-authenticate the
+        // user the way it could before this route did real revocation.
         authApi.sessionTimeout().catch(() => {});
       }
+      clearAuth();
       setUser(null);
       setTenant(null);
       setPrivs([]);


### PR DESCRIPTION
## Summary
- `POST /auth/session-timeout` was audit-only: it never revoked the refresh token or cleared the `beacon2026_refresh` cookie, so a page reload right after an idle "timeout" silently re-authenticated the user via `/auth/refresh` — no password, no further audit entry — even though the log showed a `session_timeout` event. The 30-day refresh token stayed live regardless of idle duration.
- `session-timeout` now revokes the refresh token and clears the cookie, exactly like `/auth/logout`. The frontend's `auth:expired` handler now also clears the in-memory access token via `clearAuth()`.
- Docs updated: `CHANGELOG.md`, `CLAUDE-REFERENCE.md` (audit-events section), `KNOWN-ISSUES.md` (new deferred item: `/auth/refresh` silent session restores still aren't audited — separate, older gap, not fixed here).

## Test plan
- [x] `cd backend && npm test` — 689 passed
- [x] `cd frontend && npm test` — 200 passed
- [x] `cd backend && npm run lint` — clean
- [x] `cd frontend && npm run lint` — 0 errors, only pre-existing `react-hooks/exhaustive-deps` warnings
- [x] Prettier check on both touched files (LF-normalised diff) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)