### PR TITLE
Add admin CRUD screen for org-wide standard emails/letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ that still says "Unreleased".
   message/letter" buttons are now Administration-only (`backend/src/routes/
   groupStdMessages.js`, `backend/src/utils/templateOwnership.js`,
   `backend/src/utils/groupLeader.js`).
+- **Admin CRUD screen for org-wide standard emails/letters.** New page at
+  Home → Set up → "Std emails & letters" (`/standard-messages`,
+  `StandardMessages.jsx`) lists, adds, edits and deletes the org-wide
+  (unowned) standard emails/letters that were previously only creatable as a
+  side effect of "Save as standard email/letter" while composing — no edit
+  or delete existed for them before. Reuses the existing tenant-wide
+  `GET/POST/DELETE /email/standard-messages` and `/letters/standard-letters`
+  routes (no backend changes needed), gated on `email_standard_messages_all`
+  / `letters_standard_messages_all`.
 
 ### Fixed
 - **Inactivity timeout did not actually end the session.** The idle timer

--- a/docs/BeaconUG-Comparison.md
+++ b/docs/BeaconUG-Comparison.md
@@ -461,6 +461,7 @@
 |--------|--------|-------|
 | CRUD email templates | Built | — |
 | **beacon2026 extra:** Group/team ownership | beacon2026 extra | A template is unowned (Administration-only) or owned by a group/team (that group/team's leaders + Administration can manage it); viewing/using any template is unrestricted for everyone. Managed via a "Std Emails" tab on the group/team record. Added 2026-08-04. |
+| **beacon2026 extra:** Admin CRUD for unowned templates | beacon2026 extra | Org-wide (unowned) templates now have a dedicated admin screen — Home → Set up → "Std emails & letters" (`/standard-messages`) — instead of only being creatable as a side effect of "Save as standard email" while composing. Administration-only (`email_standard_messages_all`). Added 2026-08-04. |
 
 ---
 
@@ -512,6 +513,7 @@
 |--------|--------|-------|
 | Standard letter templates | Built | — |
 | **beacon2026 extra:** Group/team ownership | beacon2026 extra | Same ownership model as Standard Email Messages (see 6.1.2); managed via a "Std Letters" tab on the group/team record, editable there as plain text only (not the full rich-text editor). Added 2026-08-04. |
+| **beacon2026 extra:** Admin CRUD for unowned templates | beacon2026 extra | Same admin screen as Standard Email Messages (see 6.1.2) — Home → Set up → "Std emails & letters" (`/standard-messages`). Administration-only (`letters_standard_messages_all`). Added 2026-08-04. |
 
 ---
 

--- a/docs/UX-Improvements-Plan-2026-08-04.md
+++ b/docs/UX-Improvements-Plan-2026-08-04.md
@@ -20,7 +20,7 @@
 
 | # | Item | Status |
 |---|------|--------|
-| 7 | Admin CRUD screen for org-wide (unowned) standard emails/letters | NOT STARTED — build first |
+| 7 | Admin CRUD screen for org-wide (unowned) standard emails/letters | DONE — see below |
 | 1 | Remove "Save as standard email/letter" buttons from compose screens | NOT STARTED — do after #7 |
 | 2 | Floating scroll arrows: scope trigger to table, fix target to full page | NOT STARTED |
 | 3 | Home menu: "Poll" → "Polls" | NOT STARTED |
@@ -55,6 +55,21 @@ exist, granted to Administration per PR #498's ownership work). Lists every
 org-wide standard email/letter with add/edit/delete — same shape as
 `StdEmailsTab`/`StdLettersTab` but without an `entityId`. This becomes the
 sole path for org-wide templates once #1 removes the compose-screen buttons.
+
+**Built:** [`StandardMessages.jsx`](../frontend/src/pages/settings/StandardMessages.jsx),
+route `/standard-messages` ([`App.jsx`](../frontend/src/App.jsx)), nav entry
+"Std emails & letters" under Home → Set up
+([`Home.jsx`](../frontend/src/pages/Home.jsx)). Two sections (Std Emails, Std
+Letters) mirroring `StdEmailsTab`/`StdLettersTab`'s list+inline-form pattern,
+each filtering the existing `GET /email/standard-messages` /
+`GET /letters/standard-letters` responses to `owner_group_id == null`
+client-side (no server-side filter param exists) and always saving with
+`ownerGroupId: null`. Gated per-section on `hasFeature('email'|'letters')` and
+`can('..._all','view')`; add/edit further gated on `create`, delete on
+`delete`. No backend changes needed — the tenant-wide CRUD routes already
+existed. Not yet click-tested in a live browser (no local Postgres/seeded
+tenant available in-session) — verified via lint, format, and the full
+frontend/backend test suites (all green).
 
 ---
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -63,6 +63,7 @@ const EmailDelivery = lazy(() => import('./pages/email/EmailDelivery.jsx'));
 const EmailDeliveryDetail = lazy(() => import('./pages/email/EmailDeliveryDetail.jsx'));
 const EmailUnblocker = lazy(() => import('./pages/email/EmailUnblocker.jsx'));
 const SystemMessages = lazy(() => import('./pages/settings/SystemMessages.jsx'));
+const StandardMessages = lazy(() => import('./pages/settings/StandardMessages.jsx'));
 const PublicLinks = lazy(() => import('./pages/settings/PublicLinks.jsx'));
 const Calendar = lazy(() => import('./pages/calendar/Calendar.jsx'));
 const EventRecord = lazy(() => import('./pages/calendar/EventRecord.jsx'));
@@ -730,6 +731,14 @@ const router = createBrowserRouter([
           <ProtectedFeatureRoute feature="email">
             <SystemMessages />
           </ProtectedFeatureRoute>
+        ),
+      },
+      {
+        path: '/standard-messages',
+        element: (
+          <ProtectedRoute>
+            <StandardMessages />
+          </ProtectedRoute>
         ),
       },
       // Letters — PDF generation, does not require SendGrid

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -324,6 +324,16 @@ export default function Home() {
           f: 'email',
         },
         {
+          label: 'Std emails & letters',
+          tip: 'Manage org-wide standard email and letter templates',
+          to:
+            (hasFeature('email') && can('email_standard_messages_all', 'view')) ||
+            (hasFeature('letters') && can('letters_standard_messages_all', 'view'))
+              ? '/standard-messages'
+              : null,
+          isNew: true,
+        },
+        {
           label: 'Finance accounts',
           tip: 'Set up bank accounts and payment methods',
           to: can('finance_accounts', 'view') ? '/finance/accounts' : null,

--- a/frontend/src/pages/settings/StandardMessages.jsx
+++ b/frontend/src/pages/settings/StandardMessages.jsx
@@ -1,0 +1,445 @@
+// beacon2026/frontend/src/pages/settings/StandardMessages.jsx
+// Admin CRUD for org-wide (unowned) standard emails and standard letters —
+// the only place these can be edited or deleted, and (once the compose-screen
+// "Save as standard" buttons are removed — see UX-Improvements-Plan item #1)
+// the only place they can be created. Group/team-owned templates are managed
+// instead from the group/team's own Std Emails/Std Letters tabs
+// (StdEmailsTab.jsx / StdLettersTab.jsx).
+//
+// The GET endpoints return every template (owned and unowned); this page
+// filters to owner_group_id == null and always saves with ownerGroupId: null.
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '../../context/AuthContext.jsx';
+import { email as emailApi, letters as lettersApi } from '../../lib/api.js';
+import { textToTiptapDoc, tiptapDocToText } from '../../lib/simpleTiptapDoc.js';
+import NavBar from '../../components/NavBar.jsx';
+import PageHeader from '../../components/PageHeader.jsx';
+import { inputCls, labelCls } from '../../components/ui/Input.jsx';
+
+const navLinks = [{ label: 'Home', to: '/' }];
+
+function StdEmailsSection() {
+  const { can } = useAuth();
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const [form, setForm] = useState({ name: '', subject: '', body: '' });
+  const [editingId, setEditingId] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
+
+  const canManage = can('email_standard_messages_all', 'create');
+  const canDelete = can('email_standard_messages_all', 'delete');
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const all = await emailApi.listStandardMessages();
+      setMessages(all.filter((m) => m.owner_group_id == null));
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function startEdit(msg) {
+    setEditingId(msg.id);
+    setForm({ name: msg.name, subject: msg.subject ?? '', body: msg.body ?? '' });
+    setSaveError(null);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setForm({ name: '', subject: '', body: '' });
+    setSaveError(null);
+  }
+
+  async function handleSave(e) {
+    e.preventDefault();
+    if (!form.name.trim()) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await emailApi.saveStandardMessage({
+        name: form.name.trim(),
+        subject: form.subject,
+        body: form.body,
+        ownerGroupId: null,
+      });
+      cancelEdit();
+      await load();
+    } catch (err) {
+      setSaveError(err.body?.error || err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id, name) {
+    if (!window.confirm(`Delete standard email "${name}"?`)) return;
+    try {
+      await emailApi.deleteStandardMessage(id);
+      await load();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div className="bg-white/90 rounded-lg shadow-sm p-4 mb-6">
+      <h2 className="text-lg font-semibold mb-1">Std Emails</h2>
+      <p className="text-xs text-slate-600 mb-3">
+        Org-wide standard email messages, available to everyone composing an email. Group/team-owned
+        templates are managed from the group or team's own Std Emails tab instead.
+      </p>
+
+      {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
+
+      {loading ? (
+        <p className="text-slate-500 text-sm">Loading…</p>
+      ) : messages.length === 0 ? (
+        <p className="text-slate-500 text-sm mb-4">No org-wide standard emails yet.</p>
+      ) : (
+        <div className="overflow-x-auto mb-4">
+          <table className="min-w-max w-full text-sm border-collapse">
+            <thead>
+              <tr className="bg-slate-50 text-left">
+                <th className="px-3 py-2 font-medium text-slate-700 border-b border-slate-200">
+                  Name
+                </th>
+                <th className="px-3 py-2 font-medium text-slate-700 border-b border-slate-200">
+                  Subject
+                </th>
+                {(canManage || canDelete) && (
+                  <th className="px-3 py-2 border-b border-slate-200"></th>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {messages.map((m, i) => (
+                <tr key={m.id} className={i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}>
+                  <td className="px-3 py-1.5 border-b border-slate-100">{m.name}</td>
+                  <td className="px-3 py-1.5 border-b border-slate-100">{m.subject}</td>
+                  {(canManage || canDelete) && (
+                    <td className="px-3 py-1.5 border-b border-slate-100 whitespace-nowrap">
+                      {canManage && (
+                        <button
+                          onClick={() => startEdit(m)}
+                          className="text-blue-600 hover:underline text-sm mr-3"
+                        >
+                          edit
+                        </button>
+                      )}
+                      {canDelete && (
+                        <button
+                          onClick={() => handleDelete(m.id, m.name)}
+                          className="text-red-600 hover:underline text-sm"
+                        >
+                          delete
+                        </button>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {canManage && (
+        <form onSubmit={handleSave} className="border-t border-slate-200 pt-4">
+          <h3 className="text-sm font-semibold text-slate-700 mb-3">
+            {editingId ? 'Edit Std Email' : 'Add Std Email'}
+          </h3>
+          {saveError && <p className="text-red-600 text-sm mb-2">{saveError}</p>}
+          <div className="flex flex-wrap gap-3 mb-3">
+            <div className="flex-1 min-w-40">
+              <label htmlFor="std-email-name" className={labelCls}>
+                Name
+              </label>
+              <input
+                id="std-email-name"
+                className={`${inputCls} w-full`}
+                value={form.name}
+                onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+                disabled={!!editingId}
+              />
+            </div>
+            <div className="flex-1 min-w-40">
+              <label htmlFor="std-email-subject" className={labelCls}>
+                Subject
+              </label>
+              <input
+                id="std-email-subject"
+                className={`${inputCls} w-full`}
+                value={form.subject}
+                onChange={(e) => setForm((p) => ({ ...p, subject: e.target.value }))}
+              />
+            </div>
+          </div>
+          <div className="mb-3">
+            <label htmlFor="std-email-body" className={labelCls}>
+              Message body
+            </label>
+            <textarea
+              id="std-email-body"
+              rows={8}
+              className={`${inputCls} w-full font-mono text-xs`}
+              value={form.body}
+              onChange={(e) => setForm((p) => ({ ...p, body: e.target.value }))}
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={saving || !form.name.trim()}
+              className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            {editingId && (
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-4 py-2 text-sm"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function StdLettersSection() {
+  const { can } = useAuth();
+  const [letterList, setLetterList] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const [form, setForm] = useState({ name: '', body: '' });
+  const [editingId, setEditingId] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
+
+  const canManage = can('letters_standard_messages_all', 'create');
+  const canDelete = can('letters_standard_messages_all', 'delete');
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const all = await lettersApi.listStandardLetters();
+      setLetterList(all.filter((l) => l.owner_group_id == null));
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function startEdit(letter) {
+    setEditingId(letter.id);
+    let text = '';
+    try {
+      text = tiptapDocToText(JSON.parse(letter.body));
+    } catch {
+      text = '';
+    }
+    setForm({ name: letter.name, body: text });
+    setSaveError(null);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setForm({ name: '', body: '' });
+    setSaveError(null);
+  }
+
+  async function handleSave(e) {
+    e.preventDefault();
+    if (!form.name.trim()) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await lettersApi.saveStandardLetter({
+        name: form.name.trim(),
+        body: JSON.stringify(textToTiptapDoc(form.body)),
+        ownerGroupId: null,
+      });
+      cancelEdit();
+      await load();
+    } catch (err) {
+      setSaveError(err.body?.error || err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id, name) {
+    if (!window.confirm(`Delete standard letter "${name}"?`)) return;
+    try {
+      await lettersApi.deleteStandardLetter(id);
+      await load();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div className="bg-white/90 rounded-lg shadow-sm p-4">
+      <h2 className="text-lg font-semibold mb-1">Std Letters</h2>
+      <p className="text-xs text-slate-600 mb-3">
+        Org-wide standard letters, available to everyone composing a letter. Group/team-owned
+        templates are managed from the group or team's own Std Letters tab instead. Editing here is
+        plain text only — bold/italic/underline formatting from the full letter editor is not
+        preserved if you save changes here.
+      </p>
+
+      {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
+
+      {loading ? (
+        <p className="text-slate-500 text-sm">Loading…</p>
+      ) : letterList.length === 0 ? (
+        <p className="text-slate-500 text-sm mb-4">No org-wide standard letters yet.</p>
+      ) : (
+        <div className="overflow-x-auto mb-4">
+          <table className="min-w-max w-full text-sm border-collapse">
+            <thead>
+              <tr className="bg-slate-50 text-left">
+                <th className="px-3 py-2 font-medium text-slate-700 border-b border-slate-200">
+                  Name
+                </th>
+                {(canManage || canDelete) && (
+                  <th className="px-3 py-2 border-b border-slate-200"></th>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {letterList.map((l, i) => (
+                <tr key={l.id} className={i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'}>
+                  <td className="px-3 py-1.5 border-b border-slate-100">{l.name}</td>
+                  {(canManage || canDelete) && (
+                    <td className="px-3 py-1.5 border-b border-slate-100 whitespace-nowrap">
+                      {canManage && (
+                        <button
+                          onClick={() => startEdit(l)}
+                          className="text-blue-600 hover:underline text-sm mr-3"
+                        >
+                          edit
+                        </button>
+                      )}
+                      {canDelete && (
+                        <button
+                          onClick={() => handleDelete(l.id, l.name)}
+                          className="text-red-600 hover:underline text-sm"
+                        >
+                          delete
+                        </button>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {canManage && (
+        <form onSubmit={handleSave} className="border-t border-slate-200 pt-4">
+          <h3 className="text-sm font-semibold text-slate-700 mb-3">
+            {editingId ? 'Edit Std Letter' : 'Add Std Letter'}
+          </h3>
+          {saveError && <p className="text-red-600 text-sm mb-2">{saveError}</p>}
+          <div className="mb-3">
+            <label htmlFor="std-letter-name" className={labelCls}>
+              Name
+            </label>
+            <input
+              id="std-letter-name"
+              className={`${inputCls} w-full`}
+              value={form.name}
+              onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+              disabled={!!editingId}
+            />
+          </div>
+          <div className="mb-3">
+            <label htmlFor="std-letter-body" className={labelCls}>
+              Letter body (one paragraph per line)
+            </label>
+            <textarea
+              id="std-letter-body"
+              rows={10}
+              className={`${inputCls} w-full font-mono text-xs`}
+              value={form.body}
+              onChange={(e) => setForm((p) => ({ ...p, body: e.target.value }))}
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={saving || !form.name.trim()}
+              className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            {editingId && (
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-4 py-2 text-sm"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+export default function StandardMessages() {
+  const { can, hasFeature, tenant } = useAuth();
+
+  const showEmails = hasFeature('email') && can('email_standard_messages_all', 'view');
+  const showLetters = hasFeature('letters') && can('letters_standard_messages_all', 'view');
+
+  return (
+    <div className="min-h-screen pb-10">
+      <PageHeader tenant={tenant} />
+      <NavBar links={navLinks} />
+
+      <div className="max-w-3xl mx-auto px-4 py-4">
+        <h1 className="text-xl font-bold text-center mb-4">Standard Emails &amp; Letters</h1>
+
+        {!showEmails && !showLetters ? (
+          <p className="text-center text-slate-500 py-8">You do not have access to this page.</p>
+        ) : (
+          <>
+            {showEmails && <StdEmailsSection />}
+            {showLetters && <StdLettersSection />}
+          </>
+        )}
+      </div>
+
+      <NavBar links={navLinks} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Item #7 of `docs/UX-Improvements-Plan-2026-08-04.md`: a new admin page (`/standard-messages`, Home → Set up → "Std emails & letters") lists, adds, edits and deletes the org-wide (unowned) standard email/letter templates.
- Previously these could only be *created* as a side effect of "Save as standard email/letter" while composing — no edit or delete existed for them anywhere.
- No backend changes: reuses the existing tenant-wide `GET/POST/DELETE /email/standard-messages` and `/letters/standard-letters` routes, which already support `ownerGroupId: null`. The page filters the (all-templates) GET response to `owner_group_id == null` client-side and always saves with `ownerGroupId: null`.
- Gated per-section on the existing `email_standard_messages_all` / `letters_standard_messages_all` privileges (already granted to Administration) and the `email`/`letters` feature flags.
- Sets up item #1 (removing the compose-screen "Save as standard" buttons), which depends on this landing first per the plan doc.

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only, same as before)
- [x] `format:check` — new/changed files diff clean against prettier output (line-ending normalised)
- [x] `cd frontend && npm test` — 60 files / 200 tests passing
- [x] `cd backend && npm test` — 51 files / 689 tests passing
- [ ] Live click-through in a browser — not done this session (no local Postgres/seeded tenant available); should be spot-checked before/при deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)