### PR TITLE
Remove "Save as standard email/letter" buttons from compose screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ that still says "Unreleased".
   routes (no backend changes needed), gated on `email_standard_messages_all`
   / `letters_standard_messages_all`.
 
+### Changed
+- **"Save as standard email/letter" removed from the compose screens.**
+  `EmailCompose.jsx` and `LetterCompose.jsx` no longer have a save-as-standard
+  button/inline name row — creating and editing org-wide standard
+  emails/letters now goes exclusively through the new admin screen (see
+  above). The "Load standard message/letter" dropdown, and (on the letters
+  page) the "Delete standard letter" button, are unchanged. Group/team
+  leaders are unaffected — they still manage their own group's templates via
+  the Std Emails/Letters tabs.
+
 ### Fixed
 - **Inactivity timeout did not actually end the session.** The idle timer
   cleared the frontend's React state and logged a `session_timeout` audit

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -663,12 +663,15 @@ out of them.
 2. `[DEFERRED]` **No dedicated "reassign owner" screen for Administration.**
    Site Administrators can set/clear/reassign a template's `owner_group_id`
    by including `ownerGroupId` in the existing `POST /email/standard-messages`
-   / `POST /letters/standard-letters` body, but neither compose page's simple
-   load/save bar exposes an owner picker or an "Owner" column — there is no
-   tenant-wide list/edit screen for these templates (unlike, say, SQL
-   Reports' `ReportList.jsx`). Reassignment today requires either a group/team
-   leader deleting and recreating the template under their own group's Std
-   Emails/Letters tab, or a direct API call.
+   / `POST /letters/standard-letters` body, but there is still no owner
+   picker or "Owner" column anywhere in the UI. **Partially addressed
+   2026-08-04:** unowned (org-wide) templates now have a full tenant-wide
+   list/create/edit/delete screen (`StandardMessages.jsx`, `/standard-
+   messages`, Home → Set up → "Std emails & letters") — the gap that
+   remains is specifically *reassignment* (moving a template between
+   unowned and a specific group/team, or between groups/teams), which still
+   requires either a group/team leader deleting and recreating the template
+   under their own group's Std Emails/Letters tab, or a direct API call.
 
 ## Audit log — session-restore visibility (added 2026-08-04)
 

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -154,8 +154,11 @@ beacon2026 is a ground-up rebuild with these goals:
 - **Email compose** — member selection, token substitution, attachments (SendGrid)
 - **Standard messages** — CRUD templates; owned by a group/team or unowned
   (Administration-only); two seeded on tenant creation (New Member Welcome,
-  Renewal Confirmation); managed tenant-wide (Administration, unowned only)
-  from the compose page, or per-group/team via that group/team's Std Emails tab
+  Renewal Confirmation); unowned templates managed tenant-wide via the admin
+  screen at `/standard-messages` (Home → Set up → "Std emails & letters"),
+  or per-group/team via that group/team's Std Emails tab. The compose page's
+  "Load standard message" dropdown remains for using a template while
+  composing.
 - **Email delivery** — batch list; per-recipient status; SendGrid Activity refresh
 - **Email unblocker** — admin tool to remove from bounce/spam lists
 
@@ -163,9 +166,11 @@ beacon2026 is a ground-up rebuild with these goals:
 - **Letter compose** (docs 6.2, 6.2.1, 6.2.2) — compose letters with member selection,
   token substitution, print/download PDF
 - **Standard letters** — same ownership model as Standard Email Messages; one
-  seeded on tenant creation (Annual Data Check Form); managed tenant-wide
-  (Administration, unowned only) from the compose page's rich-text editor, or
-  per-group/team via that group/team's Std Letters tab (plain text only there)
+  seeded on tenant creation (Annual Data Check Form); unowned templates
+  managed tenant-wide via the same `/standard-messages` admin screen (plain
+  text only there), or per-group/team via that group/team's Std Letters tab
+  (also plain text only). The compose page's "Load standard letter" dropdown
+  and "Delete standard letter" button remain for use while composing.
 
 ### Set-up module
 - **Feature configuration** — per-u3a feature toggles (25 toggles across 7

--- a/docs/BeaconUG-Comparison.md
+++ b/docs/BeaconUG-Comparison.md
@@ -461,7 +461,7 @@
 |--------|--------|-------|
 | CRUD email templates | Built | — |
 | **beacon2026 extra:** Group/team ownership | beacon2026 extra | A template is unowned (Administration-only) or owned by a group/team (that group/team's leaders + Administration can manage it); viewing/using any template is unrestricted for everyone. Managed via a "Std Emails" tab on the group/team record. Added 2026-08-04. |
-| **beacon2026 extra:** Admin CRUD for unowned templates | beacon2026 extra | Org-wide (unowned) templates now have a dedicated admin screen — Home → Set up → "Std emails & letters" (`/standard-messages`) — instead of only being creatable as a side effect of "Save as standard email" while composing. Administration-only (`email_standard_messages_all`). Added 2026-08-04. |
+| **beacon2026 extra:** Admin CRUD for unowned templates | beacon2026 extra | Org-wide (unowned) templates now have a dedicated admin screen — Home → Set up → "Std emails & letters" (`/standard-messages`). The compose-screen "Save as standard email" button has been removed; the admin screen is the sole way to create/edit/delete them. Administration-only (`email_standard_messages_all`). Added 2026-08-04. |
 
 ---
 
@@ -513,7 +513,7 @@
 |--------|--------|-------|
 | Standard letter templates | Built | — |
 | **beacon2026 extra:** Group/team ownership | beacon2026 extra | Same ownership model as Standard Email Messages (see 6.1.2); managed via a "Std Letters" tab on the group/team record, editable there as plain text only (not the full rich-text editor). Added 2026-08-04. |
-| **beacon2026 extra:** Admin CRUD for unowned templates | beacon2026 extra | Same admin screen as Standard Email Messages (see 6.1.2) — Home → Set up → "Std emails & letters" (`/standard-messages`). Administration-only (`letters_standard_messages_all`). Added 2026-08-04. |
+| **beacon2026 extra:** Admin CRUD for unowned templates | beacon2026 extra | Same admin screen as Standard Email Messages (see 6.1.2) — Home → Set up → "Std emails & letters" (`/standard-messages`). The compose-screen "Save as standard letter" button has been removed (the "Load standard letter" dropdown and "Delete standard letter" button remain). Administration-only (`letters_standard_messages_all`). Added 2026-08-04. |
 
 ---
 

--- a/docs/UX-Improvements-Plan-2026-08-04.md
+++ b/docs/UX-Improvements-Plan-2026-08-04.md
@@ -21,7 +21,7 @@
 | # | Item | Status |
 |---|------|--------|
 | 7 | Admin CRUD screen for org-wide (unowned) standard emails/letters | DONE — see below |
-| 1 | Remove "Save as standard email/letter" buttons from compose screens | NOT STARTED — do after #7 |
+| 1 | Remove "Save as standard email/letter" buttons from compose screens | DONE — see below |
 | 2 | Floating scroll arrows: scope trigger to table, fix target to full page | NOT STARTED |
 | 3 | Home menu: "Poll" → "Polls" | NOT STARTED |
 | 4 | Rich formatting for emails (bring to parity with letters) | NOT STARTED — approved, larger piece |
@@ -80,6 +80,20 @@ the save-as-standard button and its inline save-name row from
 `EmailCompose.jsx` (~L349-370) and `LetterCompose.jsx` (~L396-425). Leave the
 "Load standard message/letter" dropdown and delete-from-dropdown control in
 place — those are for *using* a template while composing, unaffected.
+
+**Built:** removed `handleSaveMsg`/`saveName`/`showSaveRow`/"Save as standard
+message" button+row from
+[`EmailCompose.jsx`](../frontend/src/pages/email/EmailCompose.jsx) (also
+dropped the now-unused `canManageStdMessages`/`can` since nothing else in the
+file used them), and the equivalent
+`handleSaveLetter`/`saveName`/`showSaveRow`/"Save as standard letter"
+button+row from
+[`LetterCompose.jsx`](../frontend/src/pages/letters/LetterCompose.jsx). Left
+the "Load standard message/letter" dropdown and (on the letters page) the
+"Delete standard letter" button untouched — creating/editing org-wide
+templates now goes exclusively through the item #7 admin screen; group/team
+leaders still create/edit their own group's templates via the Std
+Emails/Letters tabs, unaffected by this change.
 
 ---
 

--- a/frontend/src/pages/email/EmailCompose.jsx
+++ b/frontend/src/pages/email/EmailCompose.jsx
@@ -62,8 +62,7 @@ const PARTNER_TOKENS = [
 ];
 
 export default function EmailCompose() {
-  const { tenant, can } = useAuth();
-  const canManageStdMessages = can('email_standard_messages_all', 'create');
+  const { tenant } = useAuth();
 
   const [memberIds, setMemberIds] = useState([]);
   const [recipients, setRecipients] = useState([]); // { id, forenames, surname, email }
@@ -76,9 +75,7 @@ export default function EmailCompose() {
   const [copyToSelf, setCopyToSelf] = useState(() => loadEmailPrefs().copyToSelf || false);
   const [attachments, setAttachments] = useState([]); // File[]
 
-  const [saveName, setSaveName] = useState('');
   const [loadMsgId, setLoadMsgId] = useState('');
-  const [showSaveRow, setShowSaveRow] = useState(false);
 
   const [sending, setSending] = useState(false);
   const [error, setError] = useState(null);
@@ -169,21 +166,6 @@ export default function EmailCompose() {
       setBody(msg.body);
     }
     setLoadMsgId('');
-  }
-
-  async function handleSaveMsg() {
-    if (!saveName.trim()) return;
-    try {
-      const saved = await emailApi.saveStandardMessage({ name: saveName.trim(), subject, body });
-      setStdMessages((prev) => {
-        const filtered = prev.filter((m) => m.name !== saved.name);
-        return [...filtered, saved].sort((a, b) => a.name.localeCompare(b.name));
-      });
-      setSaveName('');
-      setShowSaveRow(false);
-    } catch (err) {
-      setError(err.message);
-    }
   }
 
   async function handleSend(e) {
@@ -345,42 +327,6 @@ export default function EmailCompose() {
                   </option>
                 ))}
               </select>
-              {canManageStdMessages && (
-                <button
-                  type="button"
-                  onClick={() => setShowSaveRow((v) => !v)}
-                  className="border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-3 py-1.5 text-sm"
-                >
-                  Save as standard message
-                </button>
-              )}
-              {canManageStdMessages && showSaveRow && (
-                <div className="flex gap-2 w-full mt-1">
-                  <input
-                    type="text"
-                    name="saveName"
-                    value={saveName}
-                    onChange={(e) => setSaveName(e.target.value)}
-                    placeholder="Message name"
-                    className="flex-1 border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                  <button
-                    onClick={handleSaveMsg}
-                    className="bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-1.5 text-sm"
-                  >
-                    Save
-                  </button>
-                  <button
-                    onClick={() => {
-                      setShowSaveRow(false);
-                      setSaveName('');
-                    }}
-                    className="border border-slate-300 text-slate-700 rounded px-3 py-1.5 text-sm"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              )}
             </div>
 
             {/* Subject + Body */}

--- a/frontend/src/pages/letters/LetterCompose.jsx
+++ b/frontend/src/pages/letters/LetterCompose.jsx
@@ -179,8 +179,6 @@ export default function LetterCompose() {
   const [recipients, setRecipients] = useState([]);
   const [stdLetters, setStdLetters] = useState([]);
   const [loadLetterId, setLoadLetterId] = useState('');
-  const [showSaveRow, setShowSaveRow] = useState(false);
-  const [saveName, setSaveName] = useState('');
   const [downloading, setDownloading] = useState(false);
   const [error, setError] = useState(null);
   const [downloaded, setDownloaded] = useState(false);
@@ -251,22 +249,6 @@ export default function LetterCompose() {
       }
     }
     setLoadLetterId('');
-  }
-
-  async function handleSaveLetter() {
-    if (!saveName.trim() || !editor) return;
-    try {
-      const bodyJson = JSON.stringify(editor.getJSON());
-      const saved = await lettersApi.saveStandardLetter({ name: saveName.trim(), body: bodyJson });
-      setStdLetters((prev) => {
-        const filtered = prev.filter((l) => l.name !== saved.name);
-        return [...filtered, saved].sort((a, b) => a.name.localeCompare(b.name));
-      });
-      setSaveName('');
-      setShowSaveRow(false);
-    } catch (err) {
-      setError(err.message);
-    }
   }
 
   async function handleDeleteLetter() {
@@ -400,42 +382,6 @@ export default function LetterCompose() {
                   >
                     Delete standard letter
                   </button>
-                )}
-                {can('letters_standard_messages_all', 'create') && (
-                  <button
-                    type="button"
-                    onClick={() => setShowSaveRow((v) => !v)}
-                    className="border border-slate-300 text-slate-700 hover:bg-slate-50 rounded px-3 py-1.5 text-sm"
-                  >
-                    Save as standard letter
-                  </button>
-                )}
-                {can('letters_standard_messages_all', 'create') && showSaveRow && (
-                  <div className="flex gap-2 w-full mt-1">
-                    <input
-                      type="text"
-                      name="saveName"
-                      value={saveName}
-                      onChange={(e) => setSaveName(e.target.value)}
-                      placeholder="Letter name"
-                      className="flex-1 border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                    <button
-                      onClick={handleSaveLetter}
-                      className="bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-1.5 text-sm"
-                    >
-                      Save
-                    </button>
-                    <button
-                      onClick={() => {
-                        setShowSaveRow(false);
-                        setSaveName('');
-                      }}
-                      className="border border-slate-300 text-slate-700 rounded px-3 py-1.5 text-sm"
-                    >
-                      Cancel
-                    </button>
-                  </div>
                 )}
               </div>
             )}

--- a/frontend/src/pages/settings/StandardMessages.jsx
+++ b/frontend/src/pages/settings/StandardMessages.jsx
@@ -1,8 +1,8 @@
 // beacon2026/frontend/src/pages/settings/StandardMessages.jsx
 // Admin CRUD for org-wide (unowned) standard emails and standard letters —
-// the only place these can be edited or deleted, and (once the compose-screen
-// "Save as standard" buttons are removed — see UX-Improvements-Plan item #1)
-// the only place they can be created. Group/team-owned templates are managed
+// the sole place these can be created, edited or deleted, now that the
+// compose-screen "Save as standard" buttons have been removed (see
+// UX-Improvements-Plan item #1). Group/team-owned templates are managed
 // instead from the group/team's own Std Emails/Std Letters tabs
 // (StdEmailsTab.jsx / StdLettersTab.jsx).
 //


### PR DESCRIPTION
## Summary
- Item #1 of `docs/UX-Improvements-Plan-2026-08-04.md`, now unblocked since item #7 (#503) merged.
- Removed the "Save as standard message" button + inline save-name row from `EmailCompose.jsx` (also dropped the now-unused `can`/`canManageStdMessages`, since nothing else in the file needed them).
- Removed the "Save as standard letter" button + inline save-name row from `LetterCompose.jsx`.
- Left untouched: the "Load standard message/letter" dropdown on both pages, and the "Delete standard letter" button on the letters page — those are for *using*/removing a template while composing, unaffected by this change.
- Creating/editing org-wide (unowned) standard emails/letters now goes exclusively through the new admin screen from #503 (`/standard-messages`). Group/team leaders are unaffected — they still manage their own group's templates via the Std Emails/Letters tabs.
- Docs updated: `UX-Improvements-Plan-2026-08-04.md`, `CHANGELOG.md`, `BeaconUG-Comparison.md`.

## Test plan
- [x] `npm run lint` — 0 errors (same pre-existing warning count as before)
- [x] `format:check` — changed files diff clean against prettier output
- [x] `cd frontend && npm test` — 60 files / 200 tests passing (confirmed stable across two reruns; one earlier flaky failure was in an unrelated file, `TransferMoney.test.jsx`)
- [ ] Live click-through in a browser — not done this session (no local Postgres/seeded tenant available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)