### PR TITLE
Fix floating scroll-arrow target and rename Poll to Polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,17 @@ that still says "Unreleased".
   routes (no backend changes needed), gated on `email_standard_messages_all`
   / `letters_standard_messages_all`.
 
+### Changed
+- **Home menu label "Poll" → "Polls"** (`Home.jsx`), matching the plural used
+  elsewhere in the app.
+
 ### Fixed
+- **Floating scroll arrows scrolled the table, not the page.** The
+  scroll-to-top/scroll-to-bottom buttons on long tables
+  (`ScrollButtons.jsx`) called `containerRef.current.scrollIntoView(...)`,
+  which scrolled the table container into view rather than the page —
+  visually indistinguishable from doing nothing on most layouts. Now calls
+  `window.scrollTo(...)` to actually scroll the page to the top/bottom.
 - **Inactivity timeout did not actually end the session.** The idle timer
   cleared the frontend's React state and logged a `session_timeout` audit
   entry, but never revoked the refresh token or cleared the

--- a/docs/UX-Improvements-Plan-2026-08-04.md
+++ b/docs/UX-Improvements-Plan-2026-08-04.md
@@ -22,8 +22,8 @@
 |---|------|--------|
 | 7 | Admin CRUD screen for org-wide (unowned) standard emails/letters | DONE — see below |
 | 1 | Remove "Save as standard email/letter" buttons from compose screens | NOT STARTED — do after #7 |
-| 2 | Floating scroll arrows: scope trigger to table, fix target to full page | NOT STARTED |
-| 3 | Home menu: "Poll" → "Polls" | NOT STARTED |
+| 2 | Floating scroll arrows: scope trigger to table, fix target to full page | DONE — see below |
+| 3 | Home menu: "Poll" → "Polls" | DONE — see below |
 | 4 | Rich formatting for emails (bring to parity with letters) | NOT STARTED — approved, larger piece |
 | 5 | Seed St Ives's own standard emails/letters into the existing tenant | NOT STARTED — data action, not new code |
 | 6 | Un-cap table-heavy tab widths (e.g. group Members) | NOT STARTED |
@@ -94,11 +94,20 @@ separate bugs matching what was reported:
   `window.scrollTo({ top: 0, behavior: 'smooth' })` and
   `window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' })`.
 
+**Built:** `scrollToTop`/`scrollToBottom` in `ScrollButtons.jsx` now call
+`window.scrollTo(...)` exactly as planned above, instead of
+`containerRef.current.scrollIntoView(...)`. No other change — visibility
+scoping was already correct. No dedicated test file existed for this
+component.
+
 ---
 
 ## 3. "Poll" → "Polls"
 
 One-line label change, [`Home.jsx:349`](../frontend/src/pages/Home.jsx).
+
+**Built:** the `label:` field in the "Set up" nav item for `/polls` changed
+from `'Poll'` to `'Polls'`. No test referenced the old label text.
 
 ---
 

--- a/frontend/src/components/ScrollButtons.jsx
+++ b/frontend/src/components/ScrollButtons.jsx
@@ -94,13 +94,11 @@ export default function ScrollButtons({ containerRef }) {
   }, [update, containerRef]);
 
   const scrollToTop = () => {
-    const el = containerRef?.current;
-    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const scrollToBottom = () => {
-    const el = containerRef?.current;
-    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
   };
 
   if (!showTop && !showBottom) return null;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -356,7 +356,7 @@ export default function Home() {
           to: can('member_statuses', 'view') ? '/membership/statuses' : null,
         },
         {
-          label: 'Poll',
+          label: 'Polls',
           tip: 'Set up and manage membership polls',
           to: can('poll_set_up', 'view') ? '/polls' : null,
           f: 'polls',


### PR DESCRIPTION
## Summary
- Item #2 of `docs/UX-Improvements-Plan-2026-08-04.md`: `ScrollButtons.jsx`'s scroll-to-top/scroll-to-bottom buttons called `containerRef.current.scrollIntoView(...)`, which scrolled the table container into view rather than the page — visually a no-op on most layouts. Changed both handlers to `window.scrollTo(...)`. Visibility scoping (only showing when the table overflows the viewport) was already correct, no change needed there.
- Item #3: Home menu label "Poll" → "Polls" (`Home.jsx`), matching the plural used elsewhere in the app.
- Both are small, independent items with no shared code, bundled into one PR since they were requested together.

## Test plan
- [x] `npm run lint` — 0 errors (same pre-existing warning count)
- [x] `cd frontend && npm test` — 60 files / 200 tests passing (no test covered either exact string/behaviour, so nothing needed updating)
- [ ] Live click-through in a browser — not done this session (no local Postgres/seeded tenant available); worth a quick manual check that the arrows now actually move the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)