### PR TITLE
Rich formatting for emails, bringing them to parity with letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ that still says "Unreleased".
   `GET/POST/DELETE /email/standard-messages` and `/letters/standard-letters`
   routes (no backend changes needed), gated on `email_standard_messages_all`
   / `letters_standard_messages_all`.
+- **Rich formatting for emails, bringing them to parity with letters.**
+  `EmailCompose.jsx` now uses the same TipTap rich-text editor as
+  `LetterCompose.jsx` (bold/italic/underline, paragraph alignment, font size)
+  instead of a plain `<textarea>`; both compose screens now share one editor
+  implementation (`components/RichTextEditor.jsx`). Email bodies are stored
+  and sent as a TipTap JSON document, resolved per recipient into a real HTML
+  part plus a plain-text fallback (`backend/src/utils/richEmailBody.js`) —
+  sending real multipart email instead of plain-text-only, with `#TOKEN`
+  values HTML-escaped so member-supplied data can't inject markup into a
+  broadcast. `POST /email/send`'s `body` field is now a TipTap doc object
+  (previously a plain string) — matching `POST /letters/download`'s existing
+  shape. The group/team "Std Emails" tab and the tenant-wide Standard
+  Messages admin screen edit these bodies as plain text (one paragraph per
+  line), the same simplification `StdLettersTab.jsx` already used for letters
+  — editing a richly-formatted email from either of those screens flattens
+  its formatting.
 
 ### Changed
 - **"Save as standard email/letter" removed from the compose screens.**

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-backend",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@sendgrid/mail": "^8.1.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-backend",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "beacon2026 API server",
   "type": "module",
   "main": "src/app.js",

--- a/backend/src/__tests__/email.test.js
+++ b/backend/src/__tests__/email.test.js
@@ -7,7 +7,7 @@ import supertest from 'supertest';
 import { makeAuthHeader, TEST_TENANT } from './helpers.js';
 
 vi.mock('../utils/db.js', () => ({
-  prisma: { $disconnect: vi.fn() },
+  prisma: { $disconnect: vi.fn(), sysTenant: { findUnique: vi.fn() } },
   tenantQuery: vi.fn(),
   withTenant: vi.fn(),
 }));
@@ -15,7 +15,10 @@ vi.mock('../utils/redis.js', () => ({
   isSessionInvalidated: vi.fn().mockResolvedValue(false),
 }));
 
-const { tenantQuery } = await import('../utils/db.js');
+const sgSend = vi.fn().mockResolvedValue([{ headers: { 'x-message-id': 'sg-1' } }]);
+vi.mock('@sendgrid/mail', () => ({ default: { setApiKey: vi.fn(), send: sgSend } }));
+
+const { tenantQuery, prisma } = await import('../utils/db.js');
 const { default: app } = await import('../app.js');
 const request = supertest(app);
 const auth = makeAuthHeader();
@@ -97,5 +100,76 @@ describe('DELETE /email/standard-messages/:id (tenant-wide — Administration on
       .set('Authorization', leaderOnly);
     expect(res.status).toBe(403);
     expect(tenantQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /email/send (rich TipTap body)', () => {
+  beforeEach(() => {
+    prisma.sysTenant.findUnique.mockResolvedValue({ slug: TEST_TENANT, name: 'Test u3a' });
+  });
+
+  const richBody = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'Hi #FORENAME, ' },
+          { type: 'text', text: 'welcome', marks: [{ type: 'bold' }] },
+        ],
+      },
+    ],
+  };
+
+  it('sends a personalised HTML + text email built from the TipTap doc', async () => {
+    tenantQuery
+      .mockResolvedValueOnce([{ member_id: 'mem-officer', name: 'Test User' }]) // users lookup
+      .mockResolvedValueOnce([{ email: 'officer@example.com', forenames: 'Test', surname: 'User' }]) // member lookup
+      .mockResolvedValueOnce([]) // offices lookup
+      .mockResolvedValueOnce([
+        { id: 'm1', forenames: 'Jo', surname: 'Bloggs', email: 'jo@example.com' },
+      ]) // fetchMembersForEmail
+      .mockResolvedValueOnce([{ id: 'batch-1' }]) // createBatch insert
+      .mockResolvedValueOnce([]); // storeRecipients insert
+
+    const res = await request
+      .post('/email/send')
+      .set('Authorization', auth)
+      .send({
+        memberIds: ['m1'],
+        subject: 'Hello #FORENAME',
+        body: richBody,
+        fromEmail: 'officer@example.com',
+        replyTo: 'officer@example.com',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ batchId: 'batch-1', sent: 1, failed: 0 });
+    expect(sgSend).toHaveBeenCalledTimes(1);
+    const [msg] = sgSend.mock.calls[0];
+    expect(msg.subject).toBe('Hello Jo');
+    expect(msg.html).toBe('<p>Hi Jo, <strong>welcome</strong></p>');
+    expect(msg.text).toBe('Hi Jo, welcome');
+
+    // email_batches.body is stored as a JSON string of the TipTap doc
+    const createBatchCall = tenantQuery.mock.calls.find((c) =>
+      String(c[1]).includes('INSERT INTO email_batches'),
+    );
+    expect(JSON.parse(createBatchCall[2][2])).toEqual(richBody);
+  });
+
+  it('rejects a plain-string body (the pre-rich-formatting shape) with a validation error', async () => {
+    const res = await request
+      .post('/email/send')
+      .set('Authorization', auth)
+      .send({
+        memberIds: ['m1'],
+        subject: 'Hi',
+        body: 'plain text body',
+        fromEmail: 'officer@example.com',
+        replyTo: 'officer@example.com',
+      });
+    expect(res.status).toBe(422);
+    expect(sgSend).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/__tests__/richEmailBody.test.js
+++ b/backend/src/__tests__/richEmailBody.test.js
@@ -1,0 +1,111 @@
+// beacon2026/backend/src/__tests__/richEmailBody.test.js
+// Unit coverage for resolveRichBody() — the TipTap-doc-to-HTML/text resolver
+// backing the rich-formatted Email Compose screen (UX-Improvements-Plan item 4).
+
+import { describe, it, expect } from 'vitest';
+import { resolveRichBody } from '../utils/richEmailBody.js';
+
+const MEMBER = {
+  forenames: 'Jo',
+  surname: 'Bloggs',
+  known_as: null,
+  address: { house_no: '1', street: 'High St', town: 'St Ives', postcode: 'PE27 1AA' },
+};
+
+function doc(...content) {
+  return { type: 'doc', content };
+}
+
+function para(children, attrs) {
+  return { type: 'paragraph', content: children, ...(attrs ? { attrs } : {}) };
+}
+
+function text(t, marks) {
+  return { type: 'text', text: t, ...(marks ? { marks } : {}) };
+}
+
+describe('resolveRichBody', () => {
+  it('renders plain paragraphs to matching HTML and text', () => {
+    const body = doc(para([text('Hello there.')]));
+    const { html, text: plain } = resolveRichBody('Subject', body, MEMBER, 'St Ives u3a');
+    expect(html).toBe('<p>Hello there.</p>');
+    expect(plain).toBe('Hello there.');
+  });
+
+  it('wraps marks (bold/italic/underline/fontSize) in the HTML output only', () => {
+    const body = doc(
+      para([
+        text('bold', [{ type: 'bold' }]),
+        text(' plain '),
+        text('big', [{ type: 'textStyle', attrs: { fontSize: '18' } }]),
+      ]),
+    );
+    const { html, text: plain } = resolveRichBody('S', body, MEMBER, 'u3a');
+    expect(html).toBe('<p><strong>bold</strong> plain <span style="font-size:18pt">big</span></p>');
+    expect(plain).toBe('bold plain big');
+  });
+
+  it('applies paragraph text-align as inline style, omitting it for left (default)', () => {
+    const centred = doc(para([text('mid')], { textAlign: 'center' }));
+    const left = doc(para([text('mid')], { textAlign: 'left' }));
+    expect(resolveRichBody('S', centred, MEMBER, 'u3a').html).toBe(
+      '<p style="text-align:center">mid</p>',
+    );
+    expect(resolveRichBody('S', left, MEMBER, 'u3a').html).toBe('<p>mid</p>');
+  });
+
+  it('converts hardBreak nodes to <br> in HTML and \\n in text', () => {
+    const body = doc(para([text('line1'), { type: 'hardBreak' }, text('line2')]));
+    const { html, text: plain } = resolveRichBody('S', body, MEMBER, 'u3a');
+    expect(html).toBe('<p>line1<br>line2</p>');
+    expect(plain).toBe('line1\nline2');
+  });
+
+  it('substitutes #TOKENs in subject, html and text for a given member', () => {
+    const body = doc(para([text('Hi #FORENAME, welcome to #U3ANAME.')]));
+    const {
+      subject,
+      html,
+      text: plain,
+    } = resolveRichBody('Renewal for #FORENAME', body, MEMBER, 'St Ives u3a');
+    expect(subject).toBe('Renewal for Jo');
+    expect(html).toBe('<p>Hi Jo, welcome to St Ives u3a.</p>');
+    expect(plain).toBe('Hi Jo, welcome to St Ives u3a.');
+  });
+
+  it('HTML-escapes both admin-authored text and substituted token values', () => {
+    const evilMember = { ...MEMBER, forenames: '<script>alert(1)</script>' };
+    const body = doc(para([text('Tom & Jerry say hi to #FORENAME')]));
+    const { html } = resolveRichBody('S', body, evilMember, 'u3a');
+    expect(html).toBe('<p>Tom &amp; Jerry say hi to &lt;script&gt;alert(1)&lt;/script&gt;</p>');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('turns embedded newlines from multi-line token values (e.g. #ADDRESSV) into <br>', () => {
+    const body = doc(para([text('#ADDRESSV')]));
+    const { html, text: plain } = resolveRichBody('S', body, MEMBER, 'u3a');
+    expect(html).toBe('<p>1<br>High St<br>St Ives<br>PE27 1AA</p>');
+    expect(plain).toBe('1\nHigh St\nSt Ives\nPE27 1AA');
+  });
+
+  it('leaves #TOKENs unresolved verbatim when member is null (copy-to-self)', () => {
+    const body = doc(para([text('Hi #FORENAME')]));
+    const { subject, html, text: plain } = resolveRichBody('Subj #FORENAME', body, null);
+    expect(subject).toBe('Subj #FORENAME');
+    expect(html).toBe('<p>Hi #FORENAME</p>');
+    expect(plain).toBe('Hi #FORENAME');
+  });
+
+  it('joins multiple paragraphs with a newline in the text fallback', () => {
+    const body = doc(para([text('First.')]), para([text('Second.')]));
+    const { text: plain, html } = resolveRichBody('S', body, MEMBER, 'u3a');
+    expect(plain).toBe('First.\nSecond.');
+    expect(html).toBe('<p>First.</p><p>Second.</p>');
+  });
+
+  it('renders an empty paragraph as a non-collapsing &nbsp;', () => {
+    const body = doc(para([]));
+    const { html } = resolveRichBody('S', body, MEMBER, 'u3a');
+    expect(html).toBe('<p>&nbsp;</p>');
+  });
+});

--- a/backend/src/routes/email.js
+++ b/backend/src/routes/email.js
@@ -8,7 +8,8 @@ import { tenantQuery, prisma } from '../utils/db.js';
 import { requirePrivilege } from '../middleware/requirePrivilege.js';
 import { requireAuth } from '../middleware/auth.js';
 import { requireFeature } from '../middleware/requireFeature.js';
-import { resolveTokens, fmtDate } from '../utils/emailTokens.js';
+import { fmtDate } from '../utils/emailTokens.js';
+import { resolveRichBody } from '../utils/richEmailBody.js';
 import {
   sanitizeAttachmentFilename,
   mimeFileFilter,
@@ -304,7 +305,10 @@ router.get('/from-addresses', requirePrivilege('email', 'send'), async (req, res
 const sendSchema = z.object({
   memberIds: z.array(z.string()).min(1),
   subject: z.string().min(1).max(500),
-  body: z.string().min(1),
+  body: z.object({
+    type: z.literal('doc'),
+    content: z.array(z.any()),
+  }),
   fromEmail: z.string().email(),
   replyTo: z.string().email(),
   copyToSelf: z.boolean().default(false),
@@ -400,7 +404,7 @@ router.post(
         req.user.tenantSlug,
         req.user.userId,
         subject,
-        body,
+        JSON.stringify(body),
         fromEmail,
         replyTo,
         recipients.length,
@@ -422,21 +426,16 @@ router.post(
           }
           const {
             subject: resolvedSubject,
-            body: resolvedBody,
-            bodyHtml: resolvedBodyHtml,
-          } = resolveTokens(subject, body, member, u3aName, extraTokens);
-          // text/ field keeps raw values; html/ field uses the value-escaped
-          // variant so a member with `<a href="...">` in their name can't
-          // inject markup into a templated broadcast that resolves their
-          // forename token for partners or other recipients.
-          const htmlBody = resolvedBodyHtml.replace(/\n/g, '<br>');
+            text: resolvedText,
+            html: resolvedHtml,
+          } = resolveRichBody(subject, body, member, u3aName, extraTokens);
           const msg = {
             to: { email: member.email, name: `${member.forenames} ${member.surname}`.trim() },
             from: { email: FROM_ADDRESS, name: u3aName },
             replyTo: { email: replyTo, name: u3aName },
             subject: resolvedSubject,
-            text: resolvedBody,
-            html: htmlBody,
+            text: resolvedText,
+            html: resolvedHtml,
             attachments: attachments.length > 0 ? attachments : undefined,
             customArgs: { batch_id: batchId },
           };
@@ -477,15 +476,17 @@ router.post(
 
       await storeRecipients(req.user.tenantSlug, batchId, recipientRows);
 
-      // Optional copy to self (no token substitution)
+      // Optional copy to self (no token substitution — resolveRichBody with
+      // member: null leaves #TOKENs in the rendered body verbatim)
       if (copyToSelf && replyTo) {
+        const { text: copyText, html: copyHtml } = resolveRichBody(subject, body, null);
         const selfMsg = {
           to: replyTo,
           from: { email: FROM_ADDRESS, name: u3aName },
           replyTo: { email: replyTo, name: u3aName },
           subject: `[COPY] ${subject}`,
-          text: body,
-          html: body.replace(/\n/g, '<br>'),
+          text: copyText,
+          html: copyHtml,
           attachments: attachments.length > 0 ? attachments : undefined,
         };
         await sgMail.send(selfMsg).catch(() => {});

--- a/backend/src/utils/emailTokens.js
+++ b/backend/src/utils/emailTokens.js
@@ -143,4 +143,4 @@ export function resolveTokens(subject, body, member, u3aName, extraTokens) {
 /**
  * Format a date for display (exported for reuse).
  */
-export { fmtDate, buildTokenMap, applyTokens };
+export { fmtDate, buildTokenMap, applyTokens, escapeHtml };

--- a/backend/src/utils/richEmailBody.js
+++ b/backend/src/utils/richEmailBody.js
@@ -1,0 +1,90 @@
+// beacon2026/backend/src/utils/richEmailBody.js
+// Resolves a TipTap rich-text JSON document (the shape produced by
+// EmailCompose.jsx / LetterCompose.jsx's editor.getJSON()) into an HTML body
+// and a plain-text fallback, with per-recipient #TOKEN substitution.
+// Understands the same paragraph/heading/mark set as routes/letters.js's
+// tiptapToPdfContent() (bold, italic, underline, textStyle fontSize,
+// paragraph alignment, hardBreak) so an email composed with the same editor
+// renders consistently with a downloaded letter.
+
+import { applyTokens, buildTokenMap, escapeHtml } from './emailTokens.js';
+
+/**
+ * Render one paragraph/heading node's children to { html, text }.
+ * Admin-authored text is HTML-escaped before token substitution (tokens
+ * match fine post-escape, since `#FOO` contains no characters escapeHtml
+ * touches); each substituted token *value* is escaped individually so
+ * member-supplied data (partner name, etc.) can't inject markup into a
+ * broadcast that resolves other recipients' tokens.
+ */
+function renderNode(child, tokenMap) {
+  if (child.type === 'hardBreak') return { html: '<br>', text: '\n' };
+  if (child.type !== 'text' || !child.text) return { html: '', text: '' };
+
+  const html = tokenMap
+    ? applyTokens(escapeHtml(child.text), tokenMap, { valueEscapeHtml: true })
+    : escapeHtml(child.text);
+  const text = tokenMap ? applyTokens(child.text, tokenMap) : child.text;
+
+  const marks = child.marks || [];
+  let wrapped = html;
+  if (marks.some((m) => m.type === 'bold')) wrapped = `<strong>${wrapped}</strong>`;
+  if (marks.some((m) => m.type === 'italic')) wrapped = `<em>${wrapped}</em>`;
+  if (marks.some((m) => m.type === 'underline')) wrapped = `<u>${wrapped}</u>`;
+  const styleMark = marks.find((m) => m.type === 'textStyle');
+  if (styleMark?.attrs?.fontSize) {
+    wrapped = `<span style="font-size:${parseInt(styleMark.attrs.fontSize, 10)}pt">${wrapped}</span>`;
+  }
+
+  return { html: wrapped, text };
+}
+
+/**
+ * Resolve a TipTap doc + subject for one recipient.
+ *
+ * @param {string} subject - raw subject template (may contain #TOKENs)
+ * @param {object} doc - TipTap JSON document ({ type: 'doc', content: [...] })
+ * @param {object|null} member - member row for token resolution, or null to
+ *   leave #TOKENs unresolved verbatim (used for the "copy to self" send,
+ *   which intentionally skips personalisation)
+ * @param {string} [u3aName] - tenant display name, ignored when member is null
+ * @param {object} [extraTokens] - extra token map (e.g. Gift Aid tokens)
+ * @returns {{ subject: string, html: string, text: string }}
+ */
+export function resolveRichBody(subject, doc, member, u3aName, extraTokens) {
+  const tokenMap = member ? { ...buildTokenMap(member, u3aName), ...extraTokens } : null;
+  const resolvedSubject = tokenMap ? applyTokens(subject, tokenMap) : subject;
+
+  const htmlParts = [];
+  const textParts = [];
+  for (const node of doc?.content || []) {
+    if (node.type !== 'paragraph' && node.type !== 'heading') continue;
+
+    let html = '';
+    let text = '';
+    for (const child of node.content || []) {
+      const r = renderNode(child, tokenMap);
+      html += r.html;
+      text += r.text;
+    }
+
+    const styleParts = [];
+    if (node.attrs?.textAlign && node.attrs.textAlign !== 'left') {
+      styleParts.push(`text-align:${node.attrs.textAlign}`);
+    }
+    const styleAttr = styleParts.length ? ` style="${styleParts.join(';')}"` : '';
+    const tag = node.type === 'heading' ? `h${node.attrs?.level || 3}` : 'p';
+
+    // Token values (e.g. #ADDRESSV) can carry embedded newlines — turn those
+    // into <br> the same way an explicit hardBreak node already is.
+    const htmlContent = (html || '&nbsp;').replace(/\n/g, '<br>');
+    htmlParts.push(`<${tag}${styleAttr}>${htmlContent}</${tag}>`);
+    textParts.push(text);
+  }
+
+  return {
+    subject: resolvedSubject,
+    html: htmlParts.join(''),
+    text: textParts.join('\n'),
+  };
+}

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -1,7 +1,7 @@
 # beacon2026 — Project Definition (last reviewed 2026-06-14)
 
 > **Note:** This document describes the *current* state of the project as of
-> 2026-06-14 (version 0.12.3). It is the canonical inventory of modules, routes,
+> 2026-06-14 (version 0.12.4). It is the canonical inventory of modules, routes,
 > and pages; for a contributor-oriented repo map and quickstart see
 > [`README.md`](README.md). Read it alongside `CLAUDE.md`, `CLAUDE-STANDARDS.md`,
 > and `CLAUDE-REFERENCE.md` in the repository root, which contain coding
@@ -26,7 +26,7 @@ beacon2026 is a ground-up rebuild with these goals:
 
 ---
 
-## What has been built (as of version 0.12.3)
+## What has been built (as of version 0.12.4)
 
 ### Infrastructure and platform
 - Full multi-tenant architecture (PostgreSQL schema-per-tenant)

--- a/docs/BeaconUG-Comparison.md
+++ b/docs/BeaconUG-Comparison.md
@@ -452,6 +452,7 @@
 | Email compose with member selection | Built | — |
 | Token substitution | Built | — |
 | Attachments | Built | Via SendGrid |
+| **beacon2026 extra:** Rich-text formatting | beacon2026 extra | Compose editor uses the same TipTap rich-text editor as letters (bold/italic/underline, alignment, font size) instead of plain text; sends real multipart email (HTML + plain-text fallback). Added 2026-08-04. |
 
 ---
 

--- a/docs/UX-Improvements-Plan-2026-08-04.md
+++ b/docs/UX-Improvements-Plan-2026-08-04.md
@@ -24,7 +24,7 @@
 | 1 | Remove "Save as standard email/letter" buttons from compose screens | DONE — see below |
 | 2 | Floating scroll arrows: scope trigger to table, fix target to full page | DONE — see below |
 | 3 | Home menu: "Poll" → "Polls" | DONE — see below |
-| 4 | Rich formatting for emails (bring to parity with letters) | NOT STARTED — approved, larger piece |
+| 4 | Rich formatting for emails (bring to parity with letters) | DONE — see below |
 | 5 | Seed St Ives's own standard emails/letters into the existing tenant | NOT STARTED — data action, not new code |
 | 6 | Un-cap table-heavy tab widths (e.g. group Members) | NOT STARTED |
 | 8 | "Add Events" panel submit button: "Add Events" → "Save" | NOT STARTED |
@@ -147,6 +147,38 @@ substitution used in templates) needs an HTML-aware variant — flagged as a
 latent gap for a related flow in `KNOWN-ISSUES.md` Security #23
 (`resolveTokens` callers using `body` not `bodyHtml`), worth resolving as
 part of this same piece of work rather than separately.
+
+**Built:** `EmailCompose.jsx` now uses the same TipTap editor as
+`LetterCompose.jsx` — the shared config/toolbar was pulled out into
+[`components/RichTextEditor.jsx`](../frontend/src/components/RichTextEditor.jsx)
+so both compose screens share one implementation (`LetterCompose.jsx` was
+refactored to use it too, no behaviour change there). Body is stored/sent as
+the TipTap JSON-doc shape (matching `POST /letters/download`'s existing
+schema) rather than HTML — `POST /email/send`'s `body` field changed from
+`z.string()` to the doc-object schema. Per-recipient resolution moved into a
+new [`backend/src/utils/richEmailBody.js`](../backend/src/utils/richEmailBody.js)
+(`resolveRichBody()`), which walks the doc the same way
+`tiptapToPdfContent()` does for letters (paragraph/heading, bold/italic/
+underline, `textStyle` fontSize, alignment, hardBreak) and produces a real
+HTML part plus a plain-text fallback, with `#TOKEN` values HTML-escaped so
+member-supplied data can't inject markup into a broadcast — `sgMail.send()`
+now gets distinct `text`/`html` instead of the old `body.replace(/\n/g,
+'<br>')` shim. The old `resolveTokens()` (string-based) is untouched and
+still used by `routes/portal/*.js` and `routes/public/join.js`'s
+`system_messages` templates — those are a separate feature (portal/join
+confirmation emails) and were out of scope here; **`KNOWN-ISSUES.md` #23
+remains open**, it was never about `email.js`/`standard_messages`. The
+group/team "Std Emails" tab and the tenant-wide Standard Messages admin
+screen (item 7) edit these bodies as plain text (one paragraph per line) via
+`simpleTiptapDoc.js`, the same simplification already used for
+`StdLettersTab.jsx` — editing a richly-formatted email from either of those
+screens flattens its formatting, same trade-off letters already made. Not
+yet click-tested in a live browser (no local Postgres/seeded tenant available
+in-session, same constraint as item 7) — verified via lint, format, and the
+full frontend/backend test suites (all green), including new unit tests for
+`resolveRichBody()` (marks, alignment, hardBreak, token substitution/
+escaping, multi-line token values) and an integration test for `POST
+/email/send` asserting the SendGrid payload's `subject`/`html`/`text`.
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beacon2026-frontend",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "dependencies": {
         "@tiptap/extension-text-align": "^3.27.3",
         "@tiptap/extension-text-style": "^3.27.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon2026-frontend",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/__tests__/EmailCompose.test.jsx
+++ b/frontend/src/__tests__/EmailCompose.test.jsx
@@ -42,4 +42,15 @@ describe('EmailCompose page', () => {
     );
     expect(screen.getByText('Send Email')).toBeTruthy();
   });
+
+  it('renders the rich-text editor toolbar (UX-Improvements-Plan item 4)', () => {
+    render(
+      <MemoryRouter>
+        <EmailCompose />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTitle('Bold')).toBeTruthy();
+    expect(screen.getByTitle('Underline')).toBeTruthy();
+    expect(screen.getByTitle('Font size')).toBeTruthy();
+  });
 });

--- a/frontend/src/components/RichTextEditor.jsx
+++ b/frontend/src/components/RichTextEditor.jsx
@@ -1,0 +1,145 @@
+// beacon2026/frontend/src/components/RichTextEditor.jsx
+// Shared TipTap rich-text editor setup used by both LetterCompose.jsx and
+// EmailCompose.jsx (UX-Improvements-Plan item 4 — bring email formatting to
+// parity with letters). Exports the extension list + a font-size toolbar
+// control so both compose screens use exactly one rich-text editor
+// implementation.
+
+import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
+import TextAlign from '@tiptap/extension-text-align';
+import { TextStyle } from '@tiptap/extension-text-style';
+import { Extension } from '@tiptap/core';
+
+// ── Font size extension ──────────────────────────────────────────────────
+
+export const FontSize = Extension.create({
+  name: 'fontSize',
+  addGlobalAttributes() {
+    return [
+      {
+        types: ['textStyle'],
+        attributes: {
+          fontSize: {
+            default: null,
+            parseHTML: (el) => el.style.fontSize?.replace(/[^0-9]/g, '') || null,
+            renderHTML: (attrs) => {
+              if (!attrs.fontSize) return {};
+              return { style: `font-size: ${attrs.fontSize}pt` };
+            },
+          },
+        },
+      },
+    ];
+  },
+});
+
+export const FONT_SIZES = [
+  { label: 'Small (10pt)', value: '10' },
+  { label: 'Normal (12pt)', value: '12' },
+  { label: 'Large (14pt)', value: '14' },
+  { label: 'Huge (18pt)', value: '18' },
+];
+
+/** Editor extension list shared by every rich-text compose screen. */
+export const RICH_TEXT_EXTENSIONS = [
+  StarterKit.configure({ heading: false }),
+  Underline,
+  TextAlign.configure({ types: ['paragraph'] }),
+  TextStyle,
+  FontSize,
+];
+
+// ── Toolbar ───────────────────────────────────────────────────────────────
+
+export function ToolbarButton({ onClick, active, title, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={`px-2 py-1 rounded text-sm font-medium border transition-colors ${
+        active
+          ? 'bg-blue-100 text-blue-700 border-blue-300'
+          : 'bg-white text-slate-600 border-slate-200 hover:bg-slate-50'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function EditorToolbar({ editor }) {
+  if (!editor) return null;
+
+  const currentSize = editor.getAttributes('textStyle').fontSize || '12';
+
+  return (
+    <div className="flex flex-wrap gap-1 border-b border-slate-200 pb-2 mb-2">
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        active={editor.isActive('bold')}
+        title="Bold"
+      >
+        <strong>B</strong>
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        active={editor.isActive('italic')}
+        title="Italic"
+      >
+        <em>I</em>
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleUnderline().run()}
+        active={editor.isActive('underline')}
+        title="Underline"
+      >
+        <span className="underline">U</span>
+      </ToolbarButton>
+
+      <span className="border-l border-slate-300 mx-1" />
+
+      <ToolbarButton
+        onClick={() => editor.chain().focus().setTextAlign('left').run()}
+        active={editor.isActive({ textAlign: 'left' })}
+        title="Align left"
+      >
+        &#8676;
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().setTextAlign('center').run()}
+        active={editor.isActive({ textAlign: 'center' })}
+        title="Align centre"
+      >
+        &#8596;
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().setTextAlign('right').run()}
+        active={editor.isActive({ textAlign: 'right' })}
+        title="Align right"
+      >
+        &#8677;
+      </ToolbarButton>
+
+      <span className="border-l border-slate-300 mx-1" />
+
+      <select
+        name="fontSize"
+        value={currentSize}
+        onChange={(e) => {
+          const size = e.target.value;
+          editor.chain().focus().setMark('textStyle', { fontSize: size }).run();
+        }}
+        className="border border-slate-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        title="Font size"
+      >
+        {FONT_SIZES.map((s) => (
+          <option key={s.value} value={s.value}>
+            {s.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/StdEmailsTab.jsx
+++ b/frontend/src/components/StdEmailsTab.jsx
@@ -6,9 +6,16 @@
 //   entityId — the group or team ID
 //   api      — the API module (groups or teams), must have
 //              listStdMessages/saveStdMessage/deleteStdMessage
+//
+// Message bodies are stored as a Tiptap document (see EmailCompose.jsx /
+// backend/src/utils/richEmailBody.js), matching StdLettersTab.jsx. This tab
+// edits them as plain text (one line = one paragraph) rather than embedding
+// the full rich-text editor used on the Email Compose page — editing a
+// richly-formatted message here will flatten its formatting.
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext.jsx';
+import { textToTiptapDoc, tiptapDocToText } from '../lib/simpleTiptapDoc.js';
 
 const EMPTY = { name: '', subject: '', body: '' };
 
@@ -48,7 +55,13 @@ export default function StdEmailsTab({ entityId, api }) {
 
   function startEdit(msg) {
     setEditingId(msg.id);
-    setForm({ name: msg.name, subject: msg.subject ?? '', body: msg.body ?? '' });
+    let text = '';
+    try {
+      text = tiptapDocToText(JSON.parse(msg.body));
+    } catch {
+      text = '';
+    }
+    setForm({ name: msg.name, subject: msg.subject ?? '', body: text });
     setSaveError(null);
   }
 
@@ -67,7 +80,7 @@ export default function StdEmailsTab({ entityId, api }) {
       await api.saveStdMessage(entityId, {
         name: form.name.trim(),
         subject: form.subject,
-        body: form.body,
+        body: JSON.stringify(textToTiptapDoc(form.body)),
       });
       cancelEdit();
       await load();
@@ -98,7 +111,8 @@ export default function StdEmailsTab({ entityId, api }) {
       <p className="text-xs text-slate-600 mb-3">
         Standard email messages owned by this group/team. Anyone composing an email can load and use
         these — only this group/team's leaders (and Administration) can add, edit or delete them
-        here.
+        here. Editing here is plain text only — bold/italic/underline formatting from the full email
+        editor is not preserved if you save changes from this tab.
       </p>
 
       {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
@@ -188,7 +202,7 @@ export default function StdEmailsTab({ entityId, api }) {
           </div>
           <div className="mb-3">
             <label htmlFor="std-email-body" className={labelCls}>
-              Message body
+              Message body (one paragraph per line)
             </label>
             <textarea
               id="std-email-body"

--- a/frontend/src/pages/email/EmailCompose.jsx
+++ b/frontend/src/pages/email/EmailCompose.jsx
@@ -2,14 +2,16 @@
 // Compose and send an email to selected members.
 // Member IDs are passed via sessionStorage key 'emailComposeMemberIds'.
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Link } from 'react-router-dom';
+import { useEditor, EditorContent } from '@tiptap/react';
 import { email as emailApi, members as membersApi } from '../../lib/api.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import { hasOptionalCookieConsent } from '../../hooks/useCookieConsent.js';
 import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
 import DemoUnavailableBanner from '../../components/DemoUnavailableBanner.jsx';
+import { RICH_TEXT_EXTENSIONS, EditorToolbar } from '../../components/RichTextEditor.jsx';
 import {
   SS_EMAIL_COMPOSE_MEMBER_IDS,
   SS_EMAIL_GIFT_AID_DATES,
@@ -71,7 +73,6 @@ export default function EmailCompose() {
 
   const [fromEmail, setFromEmail] = useState('');
   const [subject, setSubject] = useState('');
-  const [body, setBody] = useState('');
   const [copyToSelf, setCopyToSelf] = useState(() => loadEmailPrefs().copyToSelf || false);
   const [attachments, setAttachments] = useState([]); // File[]
 
@@ -82,8 +83,13 @@ export default function EmailCompose() {
   const [sent, setSent] = useState(null); // { batchId, sent, failed }
   const [giftAidDates, setGiftAidDates] = useState(null); // { from, to } when sent from GA page
 
-  const bodyRef = useRef(null);
   const subjectRef = useRef(null);
+
+  const editor = useEditor({
+    extensions: RICH_TEXT_EXTENSIONS,
+    content: '<p></p>',
+  });
+  const bodyEmpty = !editor || editor.isEmpty;
 
   useEffect(() => {
     // Read member IDs from sessionStorage
@@ -132,45 +138,45 @@ export default function EmailCompose() {
       .catch(() => {});
   }, [memberIds]);
 
-  function insertToken(token) {
-    // Insert token at cursor position in the focused field
-    const el = document.activeElement;
-    if (el === subjectRef.current) {
-      const s = el.selectionStart;
-      const e = el.selectionEnd;
-      const next = subject.slice(0, s) + token + subject.slice(e);
-      setSubject(next);
-      setTimeout(() => {
-        el.setSelectionRange(s + token.length, s + token.length);
-      }, 0);
-    } else {
-      // Default: insert into body
-      const el2 = bodyRef.current;
-      if (!el2) return;
-      const s = el2.selectionStart;
-      const e = el2.selectionEnd;
-      const next = body.slice(0, s) + token + body.slice(e);
-      setBody(next);
-      setTimeout(() => {
-        el2.setSelectionRange(s + token.length, s + token.length);
-        el2.focus();
-      }, 0);
-    }
-  }
+  const insertToken = useCallback(
+    (token) => {
+      // Insert token at cursor position in the focused field
+      const el = document.activeElement;
+      if (el === subjectRef.current) {
+        const s = el.selectionStart;
+        const e = el.selectionEnd;
+        const next = subject.slice(0, s) + token + subject.slice(e);
+        setSubject(next);
+        setTimeout(() => {
+          el.setSelectionRange(s + token.length, s + token.length);
+        }, 0);
+      } else {
+        // Default: insert into body
+        if (!editor) return;
+        editor.chain().focus().insertContent(token).run();
+      }
+    },
+    [editor, subject],
+  );
 
   function handleLoadMsg(id) {
-    if (!id) return;
+    if (!id || !editor) return;
     const msg = stdMessages.find((m) => m.id === id);
     if (msg) {
       if (msg.subject) setSubject(msg.subject);
-      setBody(msg.body);
+      try {
+        editor.commands.setContent(JSON.parse(msg.body));
+      } catch {
+        // If body is not JSON (plain text), set as paragraph
+        editor.commands.setContent(`<p>${msg.body}</p>`);
+      }
     }
     setLoadMsgId('');
   }
 
   async function handleSend(e) {
     e.preventDefault();
-    if (!fromEmail || !subject.trim() || !body.trim()) {
+    if (!fromEmail || !subject.trim() || !editor || bodyEmpty) {
       setError('From address, subject, and message body are required.');
       return;
     }
@@ -182,7 +188,14 @@ export default function EmailCompose() {
     setSending(true);
     setError(null);
     try {
-      const sendData = { memberIds, subject, body, fromEmail, replyTo: fromEmail, copyToSelf };
+      const sendData = {
+        memberIds,
+        subject,
+        body: editor.getJSON(),
+        fromEmail,
+        replyTo: fromEmail,
+        copyToSelf,
+      };
       if (giftAidDates) sendData.giftAidDates = giftAidDates;
       const result = await emailApi.send(sendData, attachments);
       setSent(result);
@@ -345,15 +358,10 @@ export default function EmailCompose() {
               </div>
               <div>
                 <label className="block text-sm font-medium text-slate-700 mb-1">Message</label>
-                <textarea
-                  ref={bodyRef}
-                  name="body"
-                  value={body}
-                  onChange={(e) => setBody(e.target.value)}
-                  rows={14}
-                  className="w-full border border-slate-300 rounded px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="Type your message here. Use tokens from the panel on the right to personalise each email."
-                />
+                <EditorToolbar editor={editor} />
+                <div className="border border-slate-300 rounded min-h-[300px] px-3 py-2 text-sm focus-within:ring-2 focus-within:ring-blue-500 prose prose-sm max-w-none">
+                  <EditorContent editor={editor} />
+                </div>
               </div>
             </div>
 
@@ -400,7 +408,7 @@ export default function EmailCompose() {
               <button
                 onClick={handleSend}
                 disabled={
-                  sending || !fromEmail || !subject.trim() || !body.trim() || memberIds.length === 0
+                  sending || !fromEmail || !subject.trim() || bodyEmpty || memberIds.length === 0
                 }
                 className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium transition-colors"
               >

--- a/frontend/src/pages/letters/LetterCompose.jsx
+++ b/frontend/src/pages/letters/LetterCompose.jsx
@@ -6,47 +6,13 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useEditor, EditorContent } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
-import Underline from '@tiptap/extension-underline';
-import TextAlign from '@tiptap/extension-text-align';
-import { TextStyle } from '@tiptap/extension-text-style';
-import { Extension } from '@tiptap/core';
 import { letters as lettersApi, members as membersApi } from '../../lib/api.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
+import { RICH_TEXT_EXTENSIONS, EditorToolbar } from '../../components/RichTextEditor.jsx';
 import { SS_LETTER_COMPOSE_MEMBER_IDS } from '../../lib/storageKeys.js';
 import { ROUTES } from '../../lib/routes.js';
-
-// ── Font size extension ──────────────────────────────────────────────────
-
-const FontSize = Extension.create({
-  name: 'fontSize',
-  addGlobalAttributes() {
-    return [
-      {
-        types: ['textStyle'],
-        attributes: {
-          fontSize: {
-            default: null,
-            parseHTML: (el) => el.style.fontSize?.replace(/[^0-9]/g, '') || null,
-            renderHTML: (attrs) => {
-              if (!attrs.fontSize) return {};
-              return { style: `font-size: ${attrs.fontSize}pt` };
-            },
-          },
-        },
-      },
-    ];
-  },
-});
-
-const FONT_SIZES = [
-  { label: 'Small (10pt)', value: '10' },
-  { label: 'Normal (12pt)', value: '12' },
-  { label: 'Large (14pt)', value: '14' },
-  { label: 'Huge (18pt)', value: '18' },
-];
 
 // ── Token lists (same as email) ──────────────────────────────────────────
 
@@ -76,100 +42,6 @@ const PARTNER_TOKENS = [
   { token: '#PMOBILE', desc: "Partner's mobile" },
 ];
 
-// ── Toolbar component ────────────────────────────────────────────────────
-
-function ToolbarButton({ onClick, active, title, children }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      className={`px-2 py-1 rounded text-sm font-medium border transition-colors ${
-        active
-          ? 'bg-blue-100 text-blue-700 border-blue-300'
-          : 'bg-white text-slate-600 border-slate-200 hover:bg-slate-50'
-      }`}
-    >
-      {children}
-    </button>
-  );
-}
-
-function EditorToolbar({ editor }) {
-  if (!editor) return null;
-
-  const currentSize = editor.getAttributes('textStyle').fontSize || '12';
-
-  return (
-    <div className="flex flex-wrap gap-1 border-b border-slate-200 pb-2 mb-2">
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleBold().run()}
-        active={editor.isActive('bold')}
-        title="Bold"
-      >
-        <strong>B</strong>
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleItalic().run()}
-        active={editor.isActive('italic')}
-        title="Italic"
-      >
-        <em>I</em>
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleUnderline().run()}
-        active={editor.isActive('underline')}
-        title="Underline"
-      >
-        <span className="underline">U</span>
-      </ToolbarButton>
-
-      <span className="border-l border-slate-300 mx-1" />
-
-      <ToolbarButton
-        onClick={() => editor.chain().focus().setTextAlign('left').run()}
-        active={editor.isActive({ textAlign: 'left' })}
-        title="Align left"
-      >
-        &#8676;
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().setTextAlign('center').run()}
-        active={editor.isActive({ textAlign: 'center' })}
-        title="Align centre"
-      >
-        &#8596;
-      </ToolbarButton>
-      <ToolbarButton
-        onClick={() => editor.chain().focus().setTextAlign('right').run()}
-        active={editor.isActive({ textAlign: 'right' })}
-        title="Align right"
-      >
-        &#8677;
-      </ToolbarButton>
-
-      <span className="border-l border-slate-300 mx-1" />
-
-      <select
-        name="fontSize"
-        value={currentSize}
-        onChange={(e) => {
-          const size = e.target.value;
-          editor.chain().focus().setMark('textStyle', { fontSize: size }).run();
-        }}
-        className="border border-slate-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-        title="Font size"
-      >
-        {FONT_SIZES.map((s) => (
-          <option key={s.value} value={s.value}>
-            {s.label}
-          </option>
-        ))}
-      </select>
-    </div>
-  );
-}
-
 // ── Main component ───────────────────────────────────────────────────────
 
 export default function LetterCompose() {
@@ -184,13 +56,7 @@ export default function LetterCompose() {
   const [downloaded, setDownloaded] = useState(false);
 
   const editor = useEditor({
-    extensions: [
-      StarterKit.configure({ heading: false }),
-      Underline,
-      TextAlign.configure({ types: ['paragraph'] }),
-      TextStyle,
-      FontSize,
-    ],
+    extensions: RICH_TEXT_EXTENSIONS,
     content: '<p></p>',
   });
 

--- a/frontend/src/pages/settings/StandardMessages.jsx
+++ b/frontend/src/pages/settings/StandardMessages.jsx
@@ -52,7 +52,13 @@ function StdEmailsSection() {
 
   function startEdit(msg) {
     setEditingId(msg.id);
-    setForm({ name: msg.name, subject: msg.subject ?? '', body: msg.body ?? '' });
+    let text = '';
+    try {
+      text = tiptapDocToText(JSON.parse(msg.body));
+    } catch {
+      text = '';
+    }
+    setForm({ name: msg.name, subject: msg.subject ?? '', body: text });
     setSaveError(null);
   }
 
@@ -71,7 +77,7 @@ function StdEmailsSection() {
       await emailApi.saveStandardMessage({
         name: form.name.trim(),
         subject: form.subject,
-        body: form.body,
+        body: JSON.stringify(textToTiptapDoc(form.body)),
         ownerGroupId: null,
       });
       cancelEdit();
@@ -98,7 +104,9 @@ function StdEmailsSection() {
       <h2 className="text-lg font-semibold mb-1">Std Emails</h2>
       <p className="text-xs text-slate-600 mb-3">
         Org-wide standard email messages, available to everyone composing an email. Group/team-owned
-        templates are managed from the group or team's own Std Emails tab instead.
+        templates are managed from the group or team's own Std Emails tab instead. Editing here is
+        plain text only — bold/italic/underline formatting from the full email editor is not
+        preserved if you save changes here.
       </p>
 
       {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
@@ -188,7 +196,7 @@ function StdEmailsSection() {
           </div>
           <div className="mb-3">
             <label htmlFor="std-email-body" className={labelCls}>
-              Message body
+              Message body (one paragraph per line)
             </label>
             <textarea
               id="std-email-body"


### PR DESCRIPTION
## Summary
- `EmailCompose.jsx` now uses the same TipTap rich-text editor as `LetterCompose.jsx` (bold/italic/underline, alignment, font size) instead of a plain textarea; both compose screens share one editor implementation (`components/RichTextEditor.jsx`, extracted from letters — no behaviour change there).
- Email bodies are stored/sent as a TipTap JSON doc (matching the shape `POST /letters/download` already uses), resolved per recipient into a real HTML part plus a plain-text fallback (`backend/src/utils/richEmailBody.js`) — SendGrid now gets real multipart email instead of the old `body.replace(/\n/g, '<br>')` shim, with `#TOKEN` values HTML-escaped so member-supplied data can't inject markup into a broadcast.
- The group/team "Std Emails" tab and the tenant-wide Standard Messages admin screen edit these bodies as plain text (one paragraph per line) via the existing `simpleTiptapDoc.js` helpers — same simplification `StdLettersTab.jsx` already used for letters.
- `KNOWN-ISSUES.md` #23 is unrelated to this change (it's about `routes/portal/*.js`/`routes/public/join.js`'s separate `system_messages` templates) and remains open — noted in the plan doc to avoid future confusion.

UX-Improvements-Plan-2026-08-04.md item 4 ("approved, larger piece") — marked DONE.

## Test plan
- [x] Backend: `npx vitest run` — 52 files / 701 tests passing, including new `richEmailBody.test.js` (10 unit tests: marks, alignment, hardBreak, token substitution/escaping, multi-line token values) and 2 new `/email/send` integration tests (rich-doc send + rejects old plain-string body shape).
- [x] Frontend: `npx vitest run` — 60 files / 201 tests passing, including updated `EmailCompose.test.jsx` and unchanged `LetterCompose.test.jsx` (post-refactor).
- [x] Backend + frontend `eslint` — 0 errors (frontend has 36 pre-existing `react-hooks/exhaustive-deps` warnings, none newly introduced).
- [ ] Live browser click-test — not done this session (no local Postgres/seeded tenant available), same constraint noted on item #7 in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)