### PR TITLE
Rename Add Events panel button to Save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ that still says "Unreleased".
   the Std Emails/Letters tabs.
 - **Home menu label "Poll" → "Polls"** (`Home.jsx`), matching the plural used
   elsewhere in the app.
+- **Calendar "Add Events" panel submit button relabelled "Save"**
+  (`Calendar.jsx`), no longer duplicating the "+ Add Event" header button's
+  label.
 
 ### Fixed
 - **Floating scroll arrows scrolled the table, not the page.** The

--- a/docs/UX-Improvements-Plan-2026-08-04.md
+++ b/docs/UX-Improvements-Plan-2026-08-04.md
@@ -27,7 +27,7 @@
 | 4 | Rich formatting for emails (bring to parity with letters) | DONE — see below |
 | 5 | Seed St Ives's own standard emails/letters into the existing tenant | NOT STARTED — data action, not new code |
 | 6 | Un-cap table-heavy tab widths (e.g. group Members) | NOT STARTED |
-| 8 | "Add Events" panel submit button: "Add Events" → "Save" | NOT STARTED |
+| 8 | "Add Events" panel submit button: "Add Events" → "Save" | DONE — see below |
 | 9 | Unsaved-changes warning on all group/team tabs, not just Details | NOT STARTED |
 | 10 | Per-tenant switch: A–Z buttons = Filter vs Jump-to-first-record | NOT STARTED |
 
@@ -223,6 +223,12 @@ narrower (a long form doesn't benefit from full width the way a table does).
 submit button inside the Add Events panel (`{addSaving ? 'Adding...' : 'Add
 Events'}`). Change to "Save" (and probably "Saving..." for the in-flight
 state). Leave the "+ Add Event" header button (L329, opens the panel) alone.
+
+**Built:** the button now reads `{addSaving ? 'Saving...' : 'Save'}`. No
+other change — the header "+ Add Event" button was untouched, and no test
+referenced the old text. The equivalent button on the group/team Events tab
+(`components/Schedule.jsx`, a separate copy) was left as "Add Events" since
+it wasn't named in this item's scope.
 
 ---
 

--- a/frontend/src/pages/calendar/Calendar.jsx
+++ b/frontend/src/pages/calendar/Calendar.jsx
@@ -893,7 +893,7 @@ export default function Calendar() {
               disabled={addSaving || !addForm.eventDate}
               className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white rounded px-5 py-2 text-sm font-medium transition-colors"
             >
-              {addSaving ? 'Adding...' : 'Add Events'}
+              {addSaving ? 'Saving...' : 'Save'}
             </button>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- Item 8 of the UX Improvements plan (docs/UX-Improvements-Plan-2026-08-04.md)
- The Add Events panel's submit button read "Add Events" / "Adding...", duplicating the header "+ Add Event" button's label — changed to "Save" / "Saving..."
- Header "+ Add Event" button (opens the panel) left unchanged

## Test plan
- [x] `npm test` (frontend) — 60 files, 201 tests passed
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [ ] Manual click-test (no local Postgres/seeded tenant available in-session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)