### PR TITLE
Add unsaved-changes warning to group/team Events, Ledger, and Std Emails/Letters tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ that still says "Unreleased".
   line), the same simplification `StdLettersTab.jsx` already used for letters
   — editing a richly-formatted email from either of those screens flattens
   its formatting.
+- **Unsaved-changes warning extended to every group/team record tab.**
+  Previously only the Details tab warned before navigating away with
+  unsaved edits; the Events, Group/Team Cash, and Std Emails/Std Letters
+  tabs silently discarded in-progress form edits. `Schedule.jsx`,
+  `GroupLedger.jsx`/`TeamLedger.jsx`, and `StdEmailsTab.jsx`/
+  `StdLettersTab.jsx` now call the existing `useUnsavedChanges()` hook the
+  same way `GroupDetails.jsx`/`TeamDetails.jsx` already did.
 
 ### Changed
 - **"Save as standard email/letter" removed from the compose screens.**

--- a/docs/UX-Improvements-Plan-2026-08-04.md
+++ b/docs/UX-Improvements-Plan-2026-08-04.md
@@ -28,7 +28,7 @@
 | 5 | Seed St Ives's own standard emails/letters into the existing tenant | NOT STARTED — data action, not new code |
 | 6 | Un-cap table-heavy tab widths (e.g. group Members) | NOT STARTED |
 | 8 | "Add Events" panel submit button: "Add Events" → "Save" | NOT STARTED |
-| 9 | Unsaved-changes warning on all group/team tabs, not just Details | NOT STARTED |
+| 9 | Unsaved-changes warning on all group/team tabs, not just Details | DONE — see below |
 | 10 | Per-tenant switch: A–Z buttons = Filter vs Jump-to-first-record | NOT STARTED |
 
 ---
@@ -239,6 +239,23 @@ Plan: wire `markDirty()`/`markClean()` into each of those the same way
 Details does — mark dirty on any field edit, call `markClean()` before
 navigating away after a successful save (per the hook's own doc comment,
 `markClean()` must run *before* `navigate()` in save handlers).
+
+**Built:** wired into all four as planned. None of these tabs navigate away
+on save (they stay on the same page/tab), so the ordering constraint from the
+hook's doc comment didn't apply here — `markClean()` is simply called
+after each successful save/add and in each cancel handler.
+`Schedule.jsx` (shared group/team Events tab): `markDirty()` in the Add
+Events form's `setAdd()`, `markClean()` after a successful add.
+`GroupLedger.jsx`/`TeamLedger.jsx`: introduced small `setAdd(patch)`/
+`setEdit(patch)` wrappers (replacing the repeated inline
+`setAddForm((p) => ...)`/`setEditForm((p) => ...)` lambdas) that call
+`markDirty()` before updating state; `markClean()` after a successful
+add/edit save and in `cancelEdit()`. `StdEmailsTab.jsx`/
+`StdLettersTab.jsx`: same pattern via a `set(field, value)` wrapper.
+Note: switching between tabs on the same record page does not itself
+trigger the warning (no route/URL change happens), matching the existing
+Details-tab behaviour — the guard only fires on in-app navigation away from
+the page and on browser refresh/close.
 
 ---
 

--- a/frontend/src/components/Schedule.jsx
+++ b/frontend/src/components/Schedule.jsx
@@ -14,9 +14,11 @@ import { venues as venuesApi } from '../lib/api.js';
 import { useAuth } from '../context/AuthContext.jsx';
 import RequiredMark from './RequiredMark.jsx';
 import { fmtDate, fmtTime } from '../lib/dateFormatters.js';
+import { useUnsavedChanges } from '../hooks/useUnsavedChanges.js';
 
 export default function Schedule({ entityId, api, privilege = 'group_records_all' }) {
   const { can } = useAuth();
+  const { markDirty, markClean } = useUnsavedChanges();
   const [events, setEvents] = useState([]);
   const [venues, setVenues] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -69,6 +71,7 @@ export default function Schedule({ entityId, api, privilege = 'group_records_all
   }
 
   function setAdd(field, value) {
+    markDirty();
     setAddForm((prev) => ({ ...prev, [field]: value }));
   }
 
@@ -95,6 +98,7 @@ export default function Schedule({ entityId, api, privilege = 'group_records_all
       }
       await api.createEvents(entityId, payload);
       setAddForm(EMPTY_EV);
+      markClean();
       await load();
     } catch (err) {
       setAddError(err.message);

--- a/frontend/src/components/StdEmailsTab.jsx
+++ b/frontend/src/components/StdEmailsTab.jsx
@@ -16,11 +16,13 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext.jsx';
 import { textToTiptapDoc, tiptapDocToText } from '../lib/simpleTiptapDoc.js';
+import { useUnsavedChanges } from '../hooks/useUnsavedChanges.js';
 
 const EMPTY = { name: '', subject: '', body: '' };
 
 export default function StdEmailsTab({ entityId, api }) {
   const { can } = useAuth();
+  const { markDirty, markClean } = useUnsavedChanges();
   const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -69,6 +71,12 @@ export default function StdEmailsTab({ entityId, api }) {
     setEditingId(null);
     setForm(EMPTY);
     setSaveError(null);
+    markClean();
+  }
+
+  function set(field, value) {
+    markDirty();
+    setForm((p) => ({ ...p, [field]: value }));
   }
 
   async function handleSave(e) {
@@ -82,6 +90,7 @@ export default function StdEmailsTab({ entityId, api }) {
         subject: form.subject,
         body: JSON.stringify(textToTiptapDoc(form.body)),
       });
+      markClean();
       cancelEdit();
       await load();
     } catch (err) {
@@ -184,7 +193,7 @@ export default function StdEmailsTab({ entityId, api }) {
                 id="std-email-name"
                 className={`${inputCls} w-full`}
                 value={form.name}
-                onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+                onChange={(e) => set('name', e.target.value)}
                 disabled={!!editingId}
               />
             </div>
@@ -196,7 +205,7 @@ export default function StdEmailsTab({ entityId, api }) {
                 id="std-email-subject"
                 className={`${inputCls} w-full`}
                 value={form.subject}
-                onChange={(e) => setForm((p) => ({ ...p, subject: e.target.value }))}
+                onChange={(e) => set('subject', e.target.value)}
               />
             </div>
           </div>
@@ -209,7 +218,7 @@ export default function StdEmailsTab({ entityId, api }) {
               rows={8}
               className={`${inputCls} w-full font-mono text-xs`}
               value={form.body}
-              onChange={(e) => setForm((p) => ({ ...p, body: e.target.value }))}
+              onChange={(e) => set('body', e.target.value)}
             />
           </div>
           <div className="flex gap-2">

--- a/frontend/src/components/StdLettersTab.jsx
+++ b/frontend/src/components/StdLettersTab.jsx
@@ -15,11 +15,13 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext.jsx';
 import { textToTiptapDoc, tiptapDocToText } from '../lib/simpleTiptapDoc.js';
+import { useUnsavedChanges } from '../hooks/useUnsavedChanges.js';
 
 const EMPTY = { name: '', body: '' };
 
 export default function StdLettersTab({ entityId, api }) {
   const { can } = useAuth();
+  const { markDirty, markClean } = useUnsavedChanges();
   const [letters, setLetters] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -68,6 +70,12 @@ export default function StdLettersTab({ entityId, api }) {
     setEditingId(null);
     setForm(EMPTY);
     setSaveError(null);
+    markClean();
+  }
+
+  function set(field, value) {
+    markDirty();
+    setForm((p) => ({ ...p, [field]: value }));
   }
 
   async function handleSave(e) {
@@ -80,6 +88,7 @@ export default function StdLettersTab({ entityId, api }) {
         name: form.name.trim(),
         body: JSON.stringify(textToTiptapDoc(form.body)),
       });
+      markClean();
       cancelEdit();
       await load();
     } catch (err) {
@@ -177,7 +186,7 @@ export default function StdLettersTab({ entityId, api }) {
               id="std-letter-name"
               className={`${inputCls} w-full`}
               value={form.name}
-              onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+              onChange={(e) => set('name', e.target.value)}
               disabled={!!editingId}
             />
           </div>
@@ -190,7 +199,7 @@ export default function StdLettersTab({ entityId, api }) {
               rows={10}
               className={`${inputCls} w-full font-mono text-xs`}
               value={form.body}
-              onChange={(e) => setForm((p) => ({ ...p, body: e.target.value }))}
+              onChange={(e) => set('body', e.target.value)}
             />
           </div>
           <div className="flex gap-2">

--- a/frontend/src/pages/groups/GroupLedger.jsx
+++ b/frontend/src/pages/groups/GroupLedger.jsx
@@ -7,10 +7,12 @@ import { groups as groupsApi, requestBlob } from '../../lib/api.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import RequiredMark from '../../components/RequiredMark.jsx';
 import { fmtDate } from '../../lib/dateFormatters.js';
+import { useUnsavedChanges } from '../../hooks/useUnsavedChanges.js';
 
 export default function GroupLedger({ groupId }) {
   const { can } = useAuth();
   const navigate = useNavigate();
+  const { markDirty, markClean } = useUnsavedChanges();
 
   const thisYear = new Date().getFullYear();
   const [fromDate, setFromDate] = useState(`${thisYear}-01-01`);
@@ -74,6 +76,16 @@ export default function GroupLedger({ groupId }) {
     });
   }
 
+  function setAdd(patch) {
+    markDirty();
+    setAddForm((p) => ({ ...p, ...patch }));
+  }
+
+  function setEdit(patch) {
+    markDirty();
+    setEditForm((p) => ({ ...p, ...patch }));
+  }
+
   function startEdit(entry) {
     setEditId(entry.id);
     setEditForm({
@@ -90,6 +102,7 @@ export default function GroupLedger({ groupId }) {
     setEditId(null);
     setEditForm({});
     setEditError(null);
+    markClean();
   }
 
   async function handleSaveEdit(entryId) {
@@ -103,6 +116,7 @@ export default function GroupLedger({ groupId }) {
         moneyIn: editForm.moneyIn ? parseFloat(editForm.moneyIn) : null,
         moneyOut: editForm.moneyOut ? parseFloat(editForm.moneyOut) : null,
       });
+      markClean();
       cancelEdit();
       await load();
     } catch (err) {
@@ -136,6 +150,7 @@ export default function GroupLedger({ groupId }) {
         moneyOut: addForm.moneyOut ? parseFloat(addForm.moneyOut) : null,
       });
       setAddForm(EMPTY_ENTRY);
+      markClean();
       await load();
     } catch (err) {
       setAddError(err.message);
@@ -299,9 +314,7 @@ export default function GroupLedger({ groupId }) {
                             type="date"
                             className={inputCls}
                             value={editForm.entryDate}
-                            onChange={(e) =>
-                              setEditForm((p) => ({ ...p, entryDate: e.target.value }))
-                            }
+                            onChange={(e) => setEdit({ entryDate: e.target.value })}
                           />
                         </div>
                         <div className="flex-1 min-w-32">
@@ -313,7 +326,7 @@ export default function GroupLedger({ groupId }) {
                             name="payee"
                             className={`${inputCls} w-full`}
                             value={editForm.payee}
-                            onChange={(e) => setEditForm((p) => ({ ...p, payee: e.target.value }))}
+                            onChange={(e) => setEdit({ payee: e.target.value })}
                           />
                         </div>
                         <div className="flex-1 min-w-40">
@@ -325,7 +338,7 @@ export default function GroupLedger({ groupId }) {
                             name="detail"
                             className={`${inputCls} w-full`}
                             value={editForm.detail}
-                            onChange={(e) => setEditForm((p) => ({ ...p, detail: e.target.value }))}
+                            onChange={(e) => setEdit({ detail: e.target.value })}
                           />
                         </div>
                         <div className="w-24">
@@ -340,9 +353,7 @@ export default function GroupLedger({ groupId }) {
                             step="0.01"
                             className={inputCls}
                             value={editForm.moneyIn}
-                            onChange={(e) =>
-                              setEditForm((p) => ({ ...p, moneyIn: e.target.value, moneyOut: '' }))
-                            }
+                            onChange={(e) => setEdit({ moneyIn: e.target.value, moneyOut: '' })}
                           />
                         </div>
                         <div className="w-24">
@@ -357,9 +368,7 @@ export default function GroupLedger({ groupId }) {
                             step="0.01"
                             className={inputCls}
                             value={editForm.moneyOut}
-                            onChange={(e) =>
-                              setEditForm((p) => ({ ...p, moneyOut: e.target.value, moneyIn: '' }))
-                            }
+                            onChange={(e) => setEdit({ moneyOut: e.target.value, moneyIn: '' })}
                           />
                         </div>
                         <div className="flex gap-2">
@@ -442,7 +451,7 @@ export default function GroupLedger({ groupId }) {
                 required
                 className={inputCls}
                 value={addForm.entryDate}
-                onChange={(e) => setAddForm((p) => ({ ...p, entryDate: e.target.value }))}
+                onChange={(e) => setAdd({ entryDate: e.target.value })}
               />
             </div>
             <div className="flex-1 min-w-32">
@@ -454,7 +463,7 @@ export default function GroupLedger({ groupId }) {
                 name="payee"
                 className={`${inputCls} w-full`}
                 value={addForm.payee}
-                onChange={(e) => setAddForm((p) => ({ ...p, payee: e.target.value }))}
+                onChange={(e) => setAdd({ payee: e.target.value })}
               />
             </div>
             <div className="flex-1 min-w-40">
@@ -466,7 +475,7 @@ export default function GroupLedger({ groupId }) {
                 name="detail"
                 className={`${inputCls} w-full`}
                 value={addForm.detail}
-                onChange={(e) => setAddForm((p) => ({ ...p, detail: e.target.value }))}
+                onChange={(e) => setAdd({ detail: e.target.value })}
               />
             </div>
             <div className="w-24">
@@ -481,9 +490,7 @@ export default function GroupLedger({ groupId }) {
                 step="0.01"
                 className={inputCls}
                 value={addForm.moneyIn}
-                onChange={(e) =>
-                  setAddForm((p) => ({ ...p, moneyIn: e.target.value, moneyOut: '' }))
-                }
+                onChange={(e) => setAdd({ moneyIn: e.target.value, moneyOut: '' })}
               />
             </div>
             <div className="w-24">
@@ -498,9 +505,7 @@ export default function GroupLedger({ groupId }) {
                 step="0.01"
                 className={inputCls}
                 value={addForm.moneyOut}
-                onChange={(e) =>
-                  setAddForm((p) => ({ ...p, moneyOut: e.target.value, moneyIn: '' }))
-                }
+                onChange={(e) => setAdd({ moneyOut: e.target.value, moneyIn: '' })}
               />
             </div>
             <button

--- a/frontend/src/pages/teams/TeamLedger.jsx
+++ b/frontend/src/pages/teams/TeamLedger.jsx
@@ -6,10 +6,12 @@ import { useNavigate } from 'react-router-dom';
 import { teams as teamsApi, requestBlob } from '../../lib/api.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import RequiredMark from '../../components/RequiredMark.jsx';
+import { useUnsavedChanges } from '../../hooks/useUnsavedChanges.js';
 
 export default function TeamLedger({ teamId }) {
   const { can } = useAuth();
   const navigate = useNavigate();
+  const { markDirty, markClean } = useUnsavedChanges();
 
   const thisYear = new Date().getFullYear();
   const [fromDate, setFromDate] = useState(`${thisYear}-01-01`);
@@ -77,6 +79,16 @@ export default function TeamLedger({ teamId }) {
     });
   }
 
+  function setAdd(patch) {
+    markDirty();
+    setAddForm((p) => ({ ...p, ...patch }));
+  }
+
+  function setEdit(patch) {
+    markDirty();
+    setEditForm((p) => ({ ...p, ...patch }));
+  }
+
   function startEdit(entry) {
     setEditId(entry.id);
     setEditForm({
@@ -93,6 +105,7 @@ export default function TeamLedger({ teamId }) {
     setEditId(null);
     setEditForm({});
     setEditError(null);
+    markClean();
   }
 
   async function handleSaveEdit(entryId) {
@@ -106,6 +119,7 @@ export default function TeamLedger({ teamId }) {
         moneyIn: editForm.moneyIn ? parseFloat(editForm.moneyIn) : null,
         moneyOut: editForm.moneyOut ? parseFloat(editForm.moneyOut) : null,
       });
+      markClean();
       cancelEdit();
       await load();
     } catch (err) {
@@ -139,6 +153,7 @@ export default function TeamLedger({ teamId }) {
         moneyOut: addForm.moneyOut ? parseFloat(addForm.moneyOut) : null,
       });
       setAddForm(EMPTY_ENTRY);
+      markClean();
       await load();
     } catch (err) {
       setAddError(err.message);
@@ -300,9 +315,7 @@ export default function TeamLedger({ teamId }) {
                             type="date"
                             className={inputCls}
                             value={editForm.entryDate}
-                            onChange={(e) =>
-                              setEditForm((p) => ({ ...p, entryDate: e.target.value }))
-                            }
+                            onChange={(e) => setEdit({ entryDate: e.target.value })}
                           />
                         </div>
                         <div className="flex-1 min-w-32">
@@ -314,7 +327,7 @@ export default function TeamLedger({ teamId }) {
                             name="payee"
                             className={`${inputCls} w-full`}
                             value={editForm.payee}
-                            onChange={(e) => setEditForm((p) => ({ ...p, payee: e.target.value }))}
+                            onChange={(e) => setEdit({ payee: e.target.value })}
                           />
                         </div>
                         <div className="flex-1 min-w-40">
@@ -326,7 +339,7 @@ export default function TeamLedger({ teamId }) {
                             name="detail"
                             className={`${inputCls} w-full`}
                             value={editForm.detail}
-                            onChange={(e) => setEditForm((p) => ({ ...p, detail: e.target.value }))}
+                            onChange={(e) => setEdit({ detail: e.target.value })}
                           />
                         </div>
                         <div className="w-24">
@@ -341,9 +354,7 @@ export default function TeamLedger({ teamId }) {
                             step="0.01"
                             className={inputCls}
                             value={editForm.moneyIn}
-                            onChange={(e) =>
-                              setEditForm((p) => ({ ...p, moneyIn: e.target.value, moneyOut: '' }))
-                            }
+                            onChange={(e) => setEdit({ moneyIn: e.target.value, moneyOut: '' })}
                           />
                         </div>
                         <div className="w-24">
@@ -358,9 +369,7 @@ export default function TeamLedger({ teamId }) {
                             step="0.01"
                             className={inputCls}
                             value={editForm.moneyOut}
-                            onChange={(e) =>
-                              setEditForm((p) => ({ ...p, moneyOut: e.target.value, moneyIn: '' }))
-                            }
+                            onChange={(e) => setEdit({ moneyOut: e.target.value, moneyIn: '' })}
                           />
                         </div>
                         <div className="flex gap-2">
@@ -442,7 +451,7 @@ export default function TeamLedger({ teamId }) {
                 required
                 className={inputCls}
                 value={addForm.entryDate}
-                onChange={(e) => setAddForm((p) => ({ ...p, entryDate: e.target.value }))}
+                onChange={(e) => setAdd({ entryDate: e.target.value })}
               />
             </div>
             <div className="flex-1 min-w-32">
@@ -454,7 +463,7 @@ export default function TeamLedger({ teamId }) {
                 name="payee"
                 className={`${inputCls} w-full`}
                 value={addForm.payee}
-                onChange={(e) => setAddForm((p) => ({ ...p, payee: e.target.value }))}
+                onChange={(e) => setAdd({ payee: e.target.value })}
               />
             </div>
             <div className="flex-1 min-w-40">
@@ -466,7 +475,7 @@ export default function TeamLedger({ teamId }) {
                 name="detail"
                 className={`${inputCls} w-full`}
                 value={addForm.detail}
-                onChange={(e) => setAddForm((p) => ({ ...p, detail: e.target.value }))}
+                onChange={(e) => setAdd({ detail: e.target.value })}
               />
             </div>
             <div className="w-24">
@@ -481,9 +490,7 @@ export default function TeamLedger({ teamId }) {
                 step="0.01"
                 className={inputCls}
                 value={addForm.moneyIn}
-                onChange={(e) =>
-                  setAddForm((p) => ({ ...p, moneyIn: e.target.value, moneyOut: '' }))
-                }
+                onChange={(e) => setAdd({ moneyIn: e.target.value, moneyOut: '' })}
               />
             </div>
             <div className="w-24">
@@ -498,9 +505,7 @@ export default function TeamLedger({ teamId }) {
                 step="0.01"
                 className={inputCls}
                 value={addForm.moneyOut}
-                onChange={(e) =>
-                  setAddForm((p) => ({ ...p, moneyOut: e.target.value, moneyIn: '' }))
-                }
+                onChange={(e) => setAdd({ moneyOut: e.target.value, moneyIn: '' })}
               />
             </div>
             <button


### PR DESCRIPTION
## Summary
- Item 9 of the UX Improvements plan (docs/UX-Improvements-Plan-2026-08-04.md)
- `useUnsavedChanges()` was only wired into `GroupDetails.jsx`/`TeamDetails.jsx`; the other group/team-record tabs let in-progress edits be silently discarded on navigation
- Wired `markDirty()`/`markClean()` into:
  - `Schedule.jsx` (shared group/team Events tab) — dirty on Add-Event form field changes, clean after a successful add
  - `GroupLedger.jsx` / `TeamLedger.jsx` — dirty on add/edit form field changes, clean after successful save or cancel
  - `StdEmailsTab.jsx` / `StdLettersTab.jsx` — dirty on add/edit form field changes, clean after successful save or cancel
- `markClean()` called before/around the save action per the hook's own doc comment

## Test plan
- [x] `npm test` (frontend) — 60 files, 201 tests passed
- [x] `npm run lint` — 0 errors (pre-existing warning count unchanged: 36)
- [x] `prettier --check` on all touched files — clean (LF-normalised diff)
- [ ] Manual click-test (no local Postgres/seeded tenant available in-session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)