### PR TITLE
Widen table-heavy tabs on group/team/event records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,13 @@ that still says "Unreleased".
   the Std Emails/Letters tabs.
 - **Home menu label "Poll" → "Polls"** (`Home.jsx`), matching the plural used
   elsewhere in the app.
+- **Table-heavy tabs on group/team/event records no longer capped at
+  max-w-4xl.** `GroupRecord.jsx`, `TeamRecord.jsx`, and `EventRecord.jsx`
+  hard-coded the same `max-w-4xl` (~896px) wrapper for the whole page,
+  cramping the Members/Events/Group Cash/Std Emails/Std Letters/Financials
+  tables into a form-width column regardless of viewport. The wrapper width
+  is now conditional on the active tab: `max-w-4xl` for the Details form,
+  `max-w-7xl` for every other tab.
 
 ### Fixed
 - **Floating scroll arrows scrolled the table, not the page.** The

--- a/docs/UX-Improvements-Plan-2026-08-04.md
+++ b/docs/UX-Improvements-Plan-2026-08-04.md
@@ -26,7 +26,7 @@
 | 3 | Home menu: "Poll" → "Polls" | DONE — see below |
 | 4 | Rich formatting for emails (bring to parity with letters) | DONE — see below |
 | 5 | Seed St Ives's own standard emails/letters into the existing tenant | NOT STARTED — data action, not new code |
-| 6 | Un-cap table-heavy tab widths (e.g. group Members) | NOT STARTED |
+| 6 | Un-cap table-heavy tab widths (e.g. group Members) | DONE — see below |
 | 8 | "Add Events" panel submit button: "Add Events" → "Save" | NOT STARTED |
 | 9 | Unsaved-changes warning on all group/team tabs, not just Details | NOT STARTED |
 | 10 | Per-tenant switch: A–Z buttons = Filter vs Jump-to-first-record | NOT STARTED |
@@ -214,6 +214,19 @@ a quick sweep once started. Plan: widen data-table-heavy tabs (Members,
 Events, Ledger, Std Emails/Letters) to `max-w-6xl`/`max-w-7xl` or drop the
 cap entirely on a laptop-sized viewport, while keeping the Details form tab
 narrower (a long form doesn't benefit from full width the way a table does).
+
+**Built:** confirmed `TeamRecord.jsx` had the identical `max-w-4xl` wrapper.
+Also swept and found the same tabbed-record pattern in
+[`EventRecord.jsx`](../frontend/src/pages/calendar/EventRecord.jsx)
+(Details/Members/Financials) and included it. All three now compute a
+`wrapperMaxW` local (`max-w-4xl` on the Details tab, `max-w-7xl` on every
+other tab) and interpolate it into the outer wrapper's className, instead of
+a hard-coded class — the wrapper width now responds to which tab is active.
+No other record-style pages (Member, Venue, Event Type, etc.) share this
+multi-tab table-heavy pattern, so they were left untouched. Not yet visually
+checked in a live browser (no local Postgres/seeded tenant available
+in-session, same constraint as items 4/7) — verified via lint, format, and
+the full frontend test suite (all green).
 
 ---
 

--- a/frontend/src/pages/calendar/EventRecord.jsx
+++ b/frontend/src/pages/calendar/EventRecord.jsx
@@ -115,12 +115,16 @@ export default function EventRecord() {
 
   const title = event.topic || event.group_name || event.event_type_name || 'Event';
 
+  // Details is a form and doesn't benefit from full width; Members/Financials
+  // are table-heavy and get a wider cap so their columns aren't cramped.
+  const wrapperMaxW = activeTab !== 'details' ? 'max-w-7xl' : 'max-w-4xl';
+
   return (
     <div className="min-h-screen pb-10">
       <PageHeader tenant={tenant} />
       <NavBar links={navLinks} />
 
-      <div className="max-w-4xl mx-auto px-4 py-4">
+      <div className={`${wrapperMaxW} mx-auto px-4 py-4`}>
         <p className="text-xs font-semibold tracking-widest text-slate-500 uppercase text-center mb-1">
           Event
         </p>

--- a/frontend/src/pages/groups/GroupRecord.jsx
+++ b/frontend/src/pages/groups/GroupRecord.jsx
@@ -109,12 +109,16 @@ export default function GroupRecord() {
     },
   ];
 
+  // Details is a long form and doesn't benefit from full width; the other
+  // tabs are table-heavy and get a wider cap so their columns aren't cramped.
+  const wrapperMaxW = !isNew && activeTab !== 'details' ? 'max-w-7xl' : 'max-w-4xl';
+
   return (
     <div className="min-h-screen pb-10">
       <PageHeader tenant={tenant} />
       <NavBar links={navLinks} />
 
-      <div className="max-w-4xl mx-auto px-4 py-4">
+      <div className={`${wrapperMaxW} mx-auto px-4 py-4`}>
         {/* Title */}
         <h1 className="text-xl font-bold text-center mb-3">
           {isNew ? 'Add New Group' : groupName || 'Group Record'}

--- a/frontend/src/pages/teams/TeamRecord.jsx
+++ b/frontend/src/pages/teams/TeamRecord.jsx
@@ -87,12 +87,16 @@ export default function TeamRecord() {
     },
   ];
 
+  // Details is a long form and doesn't benefit from full width; the other
+  // tabs are table-heavy and get a wider cap so their columns aren't cramped.
+  const wrapperMaxW = !isNew && activeTab !== 'details' ? 'max-w-7xl' : 'max-w-4xl';
+
   return (
     <div className="min-h-screen pb-10">
       <PageHeader tenant={tenant} />
       <NavBar links={navLinks} />
 
-      <div className="max-w-4xl mx-auto px-4 py-4">
+      <div className={`${wrapperMaxW} mx-auto px-4 py-4`}>
         {/* Title */}
         <h1 className="text-xl font-bold text-center mb-3">
           {isNew ? 'Add New Team' : teamName || 'Team Record'}


### PR DESCRIPTION
## Summary
- Item 6 of the UX Improvements plan (docs/UX-Improvements-Plan-2026-08-04.md)
- `GroupRecord.jsx`/`TeamRecord.jsx` hard-coded `max-w-4xl` (~896px) on the whole page wrapper, capping the Members/Events/Group Cash/Std Emails/Std Letters tables to the same width as the Details form
- Also swept `EventRecord.jsx` (Details/Members/Financials), the same tabbed-record pattern, per the plan's note to check "other record-style pages" once started
- Wrapper width is now conditional on the active tab: `max-w-4xl` stays for the Details form (a long form doesn't benefit from full width), `max-w-7xl` applies to every other, table-heavy tab

## Test plan
- [x] `npm test` (frontend) — 60 files, 201 tests passed
- [x] `npm run lint` — 0 errors (pre-existing warning count unchanged: 36)
- [x] `prettier --check` on all touched files — clean (LF-normalised diff)
- [ ] Manual visual check (no local Postgres/seeded tenant available in-session, same constraint noted on items 4/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)