### PR TITLE
Add per-tenant switch: A-Z buttons jump to record vs filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,15 @@ that still says "Unreleased".
   `GroupLedger.jsx`/`TeamLedger.jsx`, and `StdEmailsTab.jsx`/
   `StdLettersTab.jsx` now call the existing `useUnsavedChanges()` hook the
   same way `GroupDetails.jsx`/`TeamDetails.jsx` already did.
+- **A-Z buttons on Members/Groups/Teams can jump to a record instead of
+  filtering.** New opt-out feature-config toggle "A-Z buttons jump to
+  record" (`azButtonsJumpToRecord`, on by default, matching classic
+  Beacon) under Feature Configuration → Other. When on, clicking a letter
+  scrolls to and briefly highlights the first record starting with that
+  letter instead of filtering the list down to only that letter; when off,
+  the previous filter-only behaviour is unchanged. New shared
+  `useLetterJump.js` hook used by `MemberList.jsx`, `GroupList.jsx`, and
+  `TeamList.jsx`.
 
 ### Changed
 - **"Save as standard email/letter" removed from the compose screens.**

--- a/docs/UX-Improvements-Plan-2026-08-04.md
+++ b/docs/UX-Improvements-Plan-2026-08-04.md
@@ -29,7 +29,7 @@
 | 6 | Un-cap table-heavy tab widths (e.g. group Members) | DONE — see below |
 | 8 | "Add Events" panel submit button: "Add Events" → "Save" | DONE — see below |
 | 9 | Unsaved-changes warning on all group/team tabs, not just Details | DONE — see below |
-| 10 | Per-tenant switch: A–Z buttons = Filter vs Jump-to-first-record | NOT STARTED |
+| 10 | Per-tenant switch: A–Z buttons = Filter vs Jump-to-first-record | DONE — see below |
 
 ---
 
@@ -298,3 +298,47 @@ record, matching classic Beacon, per Peter's explicit instruction that this
 should be the default). When on, clicking a letter scrolls to/selects the
 first record starting with that letter instead of filtering the list down to
 only that letter.
+
+**Built:** new opt-out feature-config key `azButtonsJumpToRecord` (camelCase,
+matching every other key's convention rather than the plan's illustrative
+snake_case), added to `ALL_FEATURE_KEYS` in
+[`shared/constants.js`](../shared/constants.js) (automatically defaults to
+`true` in every `STANDARD_IMPLEMENTATIONS` preset via `buildStandardFeatures`)
+and a toggle in the "Other" section of
+[`FeatureConfig.jsx`](../frontend/src/pages/settings/FeatureConfig.jsx). All
+three screens using the `ALPHABET`/letter-button pattern were covered —
+[`MemberList.jsx`](../frontend/src/pages/members/MemberList.jsx),
+[`GroupList.jsx`](../frontend/src/pages/groups/GroupList.jsx),
+[`TeamList.jsx`](../frontend/src/pages/teams/TeamList.jsx) — no others use it.
+New shared hook
+[`useLetterJump.js`](../frontend/src/hooks/useLetterJump.js) (real
+duplication across three near-identical pages, unlike the plan's original
+per-page framing) exposes `rowRef(id)` / `jumpToLetter(list, field, letter)` /
+`highlightId`: each page attaches `rowRef(id)` to its table rows, and in jump
+mode `handleLetterClick` calls `jumpToLetter(sorted, field, letter)` instead
+of setting the `letter` filter state — `field` is `'surname'` for members
+(matching the server's existing surname-based `letter` filter and the
+default sort) and `'name'` for groups/teams (matching the server's
+name-based filter and its `ORDER BY g.name`). The match is against whatever
+order the table is currently showing (`sorted`, respecting the user's active
+column sort, not forced back to surname/name order), so "first record
+starting with that letter" means the first one currently visible from the
+top, not necessarily alphabetically first if the user has re-sorted by
+another column — this only matters when a column sort other than the default
+is active. On jump, the target row gets a 1.5s amber highlight ring
+(`ring-2 ring-amber-400`) distinct from the existing blue bulk-selection
+outline, so the user can see where they landed. The "All" button (which has
+no meaning in jump mode — there is no filter to clear) is hidden when the
+toggle is on; the floating scroll-to-top/bottom arrows from item 2 already
+cover top-of-page navigation. `MemberListTable.jsx`'s pre-existing but
+never-read `rowRefs.current[surname[0]] = el` (dead infrastructure, keyed by
+letter and overwritten on every matching row so it only ever kept the last
+one) was replaced by the hook's per-id refs, which is what jump-to-*first*-
+record actually needs. `GroupList.jsx`/`TeamList.jsx` had no per-row refs at
+all before this. Existing `GroupList.test.jsx`/`MemberList.test.jsx` mocks
+of `useAuth()` were missing `hasFeature` (not previously called
+unconditionally at the top of either component) — added
+`hasFeature: vi.fn().mockReturnValue(true)` to both. Not yet click-tested in
+a live browser (no local Postgres/seeded tenant available in-session, same
+constraint as items 4/6/7/9) — verified via lint, format, and the full
+frontend/backend test suites (all green).

--- a/frontend/src/__tests__/GroupList.test.jsx
+++ b/frontend/src/__tests__/GroupList.test.jsx
@@ -8,6 +8,7 @@ vi.mock('../context/AuthContext.jsx', () => ({
   useAuth: () => ({
     tenant: 'test-u3a',
     can: vi.fn().mockReturnValue(true),
+    hasFeature: vi.fn().mockReturnValue(true),
   }),
 }));
 

--- a/frontend/src/__tests__/MemberList.test.jsx
+++ b/frontend/src/__tests__/MemberList.test.jsx
@@ -8,6 +8,7 @@ vi.mock('../context/AuthContext.jsx', () => ({
   useAuth: () => ({
     tenant: 'test-u3a',
     can: vi.fn().mockReturnValue(true),
+    hasFeature: vi.fn().mockReturnValue(true),
   }),
 }));
 

--- a/frontend/src/hooks/useLetterJump.js
+++ b/frontend/src/hooks/useLetterJump.js
@@ -1,0 +1,43 @@
+// beacon2026/frontend/src/hooks/useLetterJump.js
+//
+// Shared behaviour for the A-Z buttons above Members/Groups/Teams lists,
+// used when the 'azButtonsJumpToRecord' feature toggle is on: clicking a
+// letter scrolls to the first record starting with that letter instead of
+// filtering the list down to it (the alternative, filter-based behaviour
+// stays in each page's own `letter` state / API param).
+//
+// Usage:
+//   const { rowRef, jumpToLetter, highlightId } = useLetterJump();
+//   <tr ref={rowRef(item.id)} className={highlightId === item.id ? '...' : ''}>
+//   <button onClick={() => jumpToLetter(sorted, 'surname', l)}>{l}</button>
+
+import { useRef, useState } from 'react';
+
+const HIGHLIGHT_MS = 1500;
+
+export function useLetterJump() {
+  const rowRefs = useRef({});
+  const [highlightId, setHighlightId] = useState(null);
+  const highlightTimer = useRef(null);
+
+  function rowRef(id) {
+    return (el) => {
+      if (el) rowRefs.current[id] = el;
+    };
+  }
+
+  function jumpToLetter(list, field, letter) {
+    const target = (list ?? []).find(
+      (item) => (item[field]?.[0] ?? '').toUpperCase() === letter.toUpperCase(),
+    );
+    if (!target) return;
+    const el = rowRefs.current[target.id];
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    clearTimeout(highlightTimer.current);
+    setHighlightId(target.id);
+    highlightTimer.current = setTimeout(() => setHighlightId(null), HIGHLIGHT_MS);
+  }
+
+  return { rowRef, jumpToLetter, highlightId };
+}

--- a/frontend/src/pages/groups/GroupList.jsx
+++ b/frontend/src/pages/groups/GroupList.jsx
@@ -15,6 +15,7 @@ import PageHeader from '../../components/PageHeader.jsx';
 import SortableHeader from '../../components/SortableHeader.jsx';
 import ScrollButtons from '../../components/ScrollButtons.jsx';
 import { useSortedData } from '../../hooks/useSortedData.js';
+import { useLetterJump } from '../../hooks/useLetterJump.js';
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
@@ -30,7 +31,7 @@ const DOWNLOAD_FIELDS = [
 ];
 
 export default function GroupList() {
-  const { can, tenant } = useAuth();
+  const { can, tenant, hasFeature } = useAuth();
   const navigate = useNavigate();
   const [groupList, setGroupList] = useState([]);
   const { sorted, sortKey, sortDir, onSort } = useSortedData(groupList);
@@ -40,6 +41,8 @@ export default function GroupList() {
   const [error, setError] = useState(null);
 
   const tableRef = useRef(null);
+  const azJump = hasFeature('azButtonsJumpToRecord');
+  const { rowRef, jumpToLetter, highlightId } = useLetterJump();
 
   const [activeOnly, setActiveOnly] = useState(true);
   const [facultyId, setFacultyId] = useState('');
@@ -90,6 +93,10 @@ export default function GroupList() {
   }
 
   function handleLetterClick(l) {
+    if (azJump) {
+      jumpToLetter(sorted, 'name', l);
+      return;
+    }
     setLetter(l === letter ? '' : l);
   }
 
@@ -232,17 +239,20 @@ export default function GroupList() {
 
         {/* ── Letter navigation ─────────────────────────────────────── */}
         <div className="flex flex-wrap gap-1 mb-3">
-          <button
-            onClick={() => handleLetterClick('')}
-            className={`px-2 py-0.5 text-sm rounded border ${letter === '' ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
-          >
-            All
-          </button>
+          {!azJump && (
+            <button
+              onClick={() => handleLetterClick('')}
+              className={`px-2 py-0.5 text-sm rounded border ${letter === '' ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+            >
+              All
+            </button>
+          )}
           {ALPHABET.map((l) => (
             <button
               key={l}
               onClick={() => handleLetterClick(l)}
-              className={`px-2 py-0.5 text-sm rounded border ${letter === l ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+              title={azJump ? `Jump to first group starting ${l}` : undefined}
+              className={`px-2 py-0.5 text-sm rounded border ${letter === l && !azJump ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
             >
               {l}
             </button>
@@ -336,7 +346,8 @@ export default function GroupList() {
                     {sorted.map((g, i) => (
                       <tr
                         key={g.id}
-                        className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'} ${selected.has(g.id) ? 'outline outline-2 outline-blue-400' : ''}`}
+                        ref={rowRef(g.id)}
+                        className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'} ${selected.has(g.id) ? 'outline outline-2 outline-blue-400' : ''} ${highlightId === g.id ? 'ring-2 ring-amber-400 ring-offset-1' : ''}`}
                       >
                         <td className="px-2 py-2">
                           <input

--- a/frontend/src/pages/members/MemberList.jsx
+++ b/frontend/src/pages/members/MemberList.jsx
@@ -21,6 +21,7 @@ import NavBar from '../../components/NavBar.jsx';
 import PageHeader from '../../components/PageHeader.jsx';
 import ScrollButtons from '../../components/ScrollButtons.jsx';
 import { useSortedData } from '../../hooks/useSortedData.js';
+import { useLetterJump } from '../../hooks/useLetterJump.js';
 import { DOWNLOAD_FIELDS, ALPHABET } from './memberListConstants.js';
 import MemberListFilters from './MemberListFilters.jsx';
 import MemberListTable from './MemberListTable.jsx';
@@ -70,9 +71,9 @@ export default function MemberList() {
   const [downloading, setDownloading] = useState(false);
   const [dlError, setDlError] = useState(null);
 
-  // Row refs for letter-jump
-  const rowRefs = useRef({});
   const tableRef = useRef(null);
+  const azJump = hasFeature('azButtonsJumpToRecord');
+  const { rowRef, jumpToLetter, highlightId } = useLetterJump();
 
   // Load statuses, classes, polls, groups once
   useEffect(() => {
@@ -168,6 +169,10 @@ export default function MemberList() {
   }
 
   function handleLetterClick(l) {
+    if (azJump) {
+      jumpToLetter(sorted, 'surname', l);
+      return;
+    }
     setLetter(l === letter ? '' : l);
     setActiveSearch('');
     setSearchInput('');
@@ -361,17 +366,20 @@ export default function MemberList() {
 
         {/* ── Letter navigation ─────────────────────────────────────── */}
         <div className="flex flex-wrap gap-1 mb-3">
-          <button
-            onClick={() => handleLetterClick('')}
-            className={`px-2 py-0.5 text-sm rounded border ${letter === '' ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
-          >
-            All
-          </button>
+          {!azJump && (
+            <button
+              onClick={() => handleLetterClick('')}
+              className={`px-2 py-0.5 text-sm rounded border ${letter === '' ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+            >
+              All
+            </button>
+          )}
           {ALPHABET.map((l) => (
             <button
               key={l}
               onClick={() => handleLetterClick(l)}
-              className={`px-2 py-0.5 text-sm rounded border ${letter === l ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+              title={azJump ? `Jump to first surname starting ${l}` : undefined}
+              className={`px-2 py-0.5 text-sm rounded border ${letter === l && !azJump ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
             >
               {l}
             </button>
@@ -404,7 +412,8 @@ export default function MemberList() {
                 selectPortalPassword={selectPortalPassword}
                 selectNoPortalPassword={selectNoPortalPassword}
                 selectEmailNotConfirmed={selectEmailNotConfirmed}
-                rowRefs={rowRefs}
+                rowRef={rowRef}
+                highlightId={highlightId}
                 tableRef={tableRef}
                 can={can}
                 navigate={navigate}

--- a/frontend/src/pages/members/MemberListTable.jsx
+++ b/frontend/src/pages/members/MemberListTable.jsx
@@ -26,7 +26,8 @@ export default function MemberListTable({
   selectPortalPassword,
   selectNoPortalPassword,
   selectEmailNotConfirmed,
-  rowRefs,
+  rowRef,
+  highlightId,
   tableRef,
   can,
   navigate,
@@ -154,10 +155,8 @@ export default function MemberListTable({
             {sorted.map((m, i) => (
               <tr
                 key={m.id}
-                ref={(el) => {
-                  if (el) rowRefs.current[m.surname?.[0]?.toUpperCase()] = el;
-                }}
-                className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'} ${selected.has(m.id) ? 'outline outline-2 outline-blue-400' : ''}`}
+                ref={rowRef(m.id)}
+                className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'} ${selected.has(m.id) ? 'outline outline-2 outline-blue-400' : ''} ${highlightId === m.id ? 'ring-2 ring-amber-400 ring-offset-1' : ''}`}
               >
                 <td className="px-2 py-2">
                   <input

--- a/frontend/src/pages/settings/FeatureConfig.jsx
+++ b/frontend/src/pages/settings/FeatureConfig.jsx
@@ -247,6 +247,12 @@ const SECTIONS = [
         defaultValue: false,
         tip: 'Lets your website read your groups, events, venues and interest areas. It only ever shows what you have already ticked as public below — and never member details.',
       },
+      {
+        key: 'azButtonsJumpToRecord',
+        label: 'A-Z buttons jump to record',
+        defaultValue: true,
+        tip: 'On the Members/Groups/Teams lists, clicking a letter scrolls to the first matching record (classic Beacon behaviour). Turn off to filter the list down to that letter instead.',
+      },
     ],
   },
 ];

--- a/frontend/src/pages/teams/TeamList.jsx
+++ b/frontend/src/pages/teams/TeamList.jsx
@@ -9,6 +9,7 @@ import PageHeader from '../../components/PageHeader.jsx';
 import SortableHeader from '../../components/SortableHeader.jsx';
 import ScrollButtons from '../../components/ScrollButtons.jsx';
 import { useSortedData } from '../../hooks/useSortedData.js';
+import { useLetterJump } from '../../hooks/useLetterJump.js';
 import { SS_EMAIL_COMPOSE_MEMBER_IDS } from '../../lib/storageKeys.js';
 import { ROUTES } from '../../lib/routes.js';
 
@@ -23,7 +24,7 @@ const DOWNLOAD_FIELDS = [
 ];
 
 export default function TeamList() {
-  const { can, tenant } = useAuth();
+  const { can, tenant, hasFeature } = useAuth();
   const navigate = useNavigate();
   const [teamList, setTeamList] = useState([]);
   const { sorted, sortKey, sortDir, onSort } = useSortedData(teamList);
@@ -32,6 +33,8 @@ export default function TeamList() {
   const [error, setError] = useState(null);
 
   const tableRef = useRef(null);
+  const azJump = hasFeature('azButtonsJumpToRecord');
+  const { rowRef, jumpToLetter, highlightId } = useLetterJump();
 
   const [activeOnly, setActiveOnly] = useState(true);
   const [letter, setLetter] = useState('');
@@ -77,6 +80,10 @@ export default function TeamList() {
   }
 
   function handleLetterClick(l) {
+    if (azJump) {
+      jumpToLetter(sorted, 'name', l);
+      return;
+    }
     setLetter(l === letter ? '' : l);
   }
 
@@ -197,17 +204,20 @@ export default function TeamList() {
 
         {/* ── Letter navigation ─────────────────────────────────────── */}
         <div className="flex flex-wrap gap-1 mb-3">
-          <button
-            onClick={() => handleLetterClick('')}
-            className={`px-2 py-0.5 text-sm rounded border ${letter === '' ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
-          >
-            All
-          </button>
+          {!azJump && (
+            <button
+              onClick={() => handleLetterClick('')}
+              className={`px-2 py-0.5 text-sm rounded border ${letter === '' ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+            >
+              All
+            </button>
+          )}
           {ALPHABET.map((l) => (
             <button
               key={l}
               onClick={() => handleLetterClick(l)}
-              className={`px-2 py-0.5 text-sm rounded border ${letter === l ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
+              title={azJump ? `Jump to first team starting ${l}` : undefined}
+              className={`px-2 py-0.5 text-sm rounded border ${letter === l && !azJump ? 'bg-blue-600 text-white border-blue-600' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
             >
               {l}
             </button>
@@ -283,7 +293,8 @@ export default function TeamList() {
                     {sorted.map((t, i) => (
                       <tr
                         key={t.id}
-                        className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'} ${selected.has(t.id) ? 'outline outline-2 outline-blue-400' : ''}`}
+                        ref={rowRef(t.id)}
+                        className={`border-b border-slate-100 ${i % 2 === 0 ? 'bg-yellow-50' : 'bg-white'} ${selected.has(t.id) ? 'outline outline-2 outline-blue-400' : ''} ${highlightId === t.id ? 'ring-2 ring-amber-400 ring-offset-1' : ''}`}
                       >
                         <td className="px-2 py-2">
                           <input

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -79,6 +79,7 @@ export const ALL_FEATURE_KEYS = Object.freeze([
   'reports',
   'publicPages',
   'publicApi',
+  'azButtonsJumpToRecord',
 ]);
 
 // ── Public read API ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Item 10 of the UX Improvements plan (docs/UX-Improvements-Plan-2026-08-04.md)
- The A-Z buttons above Members/Groups/Teams only ever filtered the list down to one letter, unlike classic Beacon's jump-to-first-record behaviour
- New opt-out feature-config toggle **"A-Z buttons jump to record"** (`azButtonsJumpToRecord`, Feature Configuration → Other), **defaulting to `true`** per Peter's explicit instruction
- When on: clicking a letter scrolls to and briefly highlights (amber ring, 1.5s) the first matching record instead of filtering; the redundant "All" button is hidden (there's no filter to clear — the item 2 floating scroll arrows already cover top-of-page)
- When off: unchanged filter-only behaviour
- New shared `useLetterJump.js` hook (real duplication across `MemberList.jsx`/`GroupList.jsx`/`TeamList.jsx`, all three now covered) — repurposes `MemberListTable.jsx`'s pre-existing but dead `rowRefs` infrastructure (previously keyed by letter and silently kept only the *last* matching row, never read)
- Matches against members' `surname` / groups'+teams' `name`, mirroring the server's existing `letter` filter fields and default `ORDER BY`

## Test plan
- [x] `npm test` (frontend) — 60 files, 201 tests passed
- [x] `npm test` (backend) — 52 files, 701 tests passed
- [x] `npm run lint` (frontend) — 0 errors (pre-existing warning count unchanged: 36)
- [x] `npm run lint` (backend) — clean
- [x] `prettier --check` on all touched files — clean
- [ ] Manual click-test (no local Postgres/seeded tenant available in-session, same constraint noted on items 4/6/7/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)