### PR TITLE
Document lessons learned from the UX-Improvements-Plan session

### DIFF
--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -1316,6 +1316,24 @@ render(<MemoryRouter><MyPage /></MemoryRouter>);
 expect(getByText('Page Title')).toBeInTheDocument();
 ```
 
+### Gotcha: an incomplete `useAuth()` mock breaks the moment a component calls that field unconditionally
+
+A hand-written `vi.mock('../context/AuthContext.jsx', () => ({ useAuth: () => ({ tenant, can }) }))`
+only needs to include the context fields the component under test actually
+*calls* — but "actually calls" can change silently as a component evolves.
+`GroupList.jsx`/`TeamList.jsx`/`MemberList.jsx` previously only ever passed
+`hasFeature` down as a prop (never called it directly), so their mocks in
+`GroupList.test.jsx`/`MemberList.test.jsx` omitted it with no failure. Adding
+a `const azJump = hasFeature('azButtonsJumpToRecord');` at the top of each
+component (unconditional, not inside a callback) made `hasFeature` undefined
+under the old mock, and calling `undefined(...)` threw on the very first
+render — both tests' "renders without crashing" case failed immediately, not
+with a subtle assertion mismatch. When adding a *new* top-level call to any
+`useAuth()` field (`hasFeature`, `can`, etc.) in a component, check every
+test file that mocks `useAuth` for that component and add the field, even if
+it feels unrelated to what that specific test is asserting. (Hit adding the
+A-Z jump-to-record feature, PR #511, 2026-08-04.)
+
 ### Multiple text instances
 
 When heading appears in NavBar AND `<h1>`, use `getAllByText` not `getByText`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,22 @@ is only for pulling newly-uploaded reference docs into the *current* branch
 mid-task — it is not a substitute for starting the *next* task from a fresh
 branch.
 
+**Independent same-day PRs that each update a shared status doc (a work-plan
+table, `CHANGELOG.md`) will conflict on merge even with zero overlapping code
+files.** Each branch's diff inserts a new line at the same anchor point (the
+next-blank-line in a status table, the next bullet under the same `###
+Changed` heading) — pure independent insertions at the same location are a
+textbook git merge conflict, not something `git merge`'s three-way algorithm
+resolves silently. Expect this whenever multiple `claude/*` branches are
+prepared from the same session's work-plan doc and merged back-to-back. Fix:
+after merging the first PR, `git checkout` each remaining branch, `git merge
+origin/main --no-edit`, resolve by keeping both sides' content (the doc
+sections themselves — the "Built:" prose paragraphs — auto-merge fine; only
+the table-row / bullet-insertion point conflicts), then push and merge as
+normal. (Hit for real 2026-08-04 merging PRs #508/#509/#510, all editing
+`docs/UX-Improvements-Plan-2026-08-04.md`'s status table and
+`CHANGELOG.md`'s `### Changed` section.)
+
 ---
 
 ## Reviewing the codebase (lessons from past reviews)

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -173,10 +173,11 @@ beacon2026 is a ground-up rebuild with these goals:
   and "Delete standard letter" button remain for use while composing.
 
 ### Set-up module
-- **Feature configuration** — per-u3a feature toggles (25 toggles across 7
+- **Feature configuration** — per-u3a feature toggles (29 toggles across 7
   sections — 6 master modules plus the Membership and Other sub-feature groups);
   expandable-sections UI; system-admin-only toggles for features requiring
-  external service setup; opt-out model (everything on by default).
+  external service setup; opt-out model (everything on by default, except
+  `giftAid`/`groupLedger`/`siteworks`/`publicApi` which default off).
   **All toggles are backend-enforced**: turning one off returns 403 from every
   matching API route (via `requireFeature()` / `isFeatureEnabled()`), not just
   hiding the nav item.

--- a/docs/BeaconUG-Comparison.md
+++ b/docs/BeaconUG-Comparison.md
@@ -99,7 +99,7 @@
 | Bulk actions (add to poll, add to group, send email, send letter) | Built | — |
 | Download (Excel/PDF/email CSV) | Built | — |
 | Sortable columns | Built | Via `useSortedData` hook (supports compound sort keys) |
-| **beacon2026 extra:** Letter filter | beacon2026 extra | Filter members by letter assignment |
+| **beacon2026 extra:** A-Z buttons jump to record | beacon2026 extra | Clicking a letter scrolls to and briefly highlights the first member whose surname starts with it, matching classic Beacon (default; opt-out toggle `azButtonsJumpToRecord` in Feature Configuration → Other). When the toggle is off, the buttons instead filter the list down to that letter. Changed 2026-08-04. |
 | **beacon2026 extra:** Consolidated name column | beacon2026 extra | Single "Name" column showing `forenames (known_as) surname`; sortable by name or by surname; member number and name both link to member record |
 | **beacon2026 extra:** Telephone + mobile columns | beacon2026 extra | Separate telephone and mobile columns shown instead of email |
 
@@ -359,7 +359,7 @@
 | Aspect | Status | Notes |
 |--------|--------|-------|
 | **beacon2026 extra:** Teams concept | Built | Teams are like groups but without faculties, max members, waiting list, or online join. Implemented via `type` column on `groups` table. |
-| Team List page | Built | Separate list with letter filter, status filter, bulk actions (email leaders, download, add to poll); "Switch to Groups" link |
+| Team List page | Built | Separate list with A-Z jump/filter (see 4.1), status filter, bulk actions (email leaders, download, add to poll); "Switch to Groups" link |
 | Team Record: Details tab | Built | Name, status, information, notes, show-addresses toggle |
 | Team Record: Members tab | Built | Add/remove members, mark leaders, bulk actions (email, download, remove, add to another team) |
 | Team Record: Schedule tab | Built | Same features as group schedule — single + recurring events, inline edit, bulk delete; shared `Schedule` component |


### PR DESCRIPTION
## Summary
- Docs-only, closing out the session wrap-up obligations for the 10-item UX Improvements plan (items 1-10, all now merged)
- `CLAUDE.md`: new workflow lesson — independent same-day PRs that each edit a shared status doc (a work-plan table, `CHANGELOG.md`) conflict on merge even with zero overlapping code files (hit merging #508/#509/#510)
- `CLAUDE-REFERENCE.md` §12: new testing gotcha — an incomplete `useAuth()` mock only breaks once a component calls that field unconditionally, not while it's merely passed through as a prop (hit adding item 10's A-Z jump feature, PR #511)
- `docs/BeaconUG-Comparison.md`: updated the Members/Teams list rows to describe the new A-Z jump-vs-filter toggle instead of the now-stale "letter filter" wording
- `beacon2026 Project Definition.md`: feature-toggle count 25 → 29 (was already stale before this session; also folds in the count for `azButtonsJumpToRecord`)

## Test plan
- Docs-only change — no test suite run needed per `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)