### PR TITLE
Fix floating scroll arrows not appearing until the mouse moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,15 @@ that still says "Unreleased".
   which scrolled the table container into view rather than the page —
   visually indistinguishable from doing nothing on most layouts. Now calls
   `window.scrollTo(...)` to actually scroll the page to the top/bottom.
+- **Floating scroll arrows didn't appear until you moved the mouse.** Many
+  list pages render their table only after an async fetch resolves
+  (`{!loading && <Table ref={containerRef} />}`), but `ScrollButtons.jsx`
+  checked `containerRef.current` only once on mount and via `scroll`/`resize`
+  listeners — since the table hadn't mounted yet at that point, the buttons
+  stayed hidden until the next scroll/resize event (which moving the mouse
+  can coincidentally trigger via wheel movement, masking the real cause).
+  Now also rechecks on every render, so the buttons appear correctly as soon
+  as the table itself mounts.
 - **Inactivity timeout did not actually end the session.** The idle timer
   cleared the frontend's React state and logged a `session_timeout` audit
   entry, but never revoked the refresh token or cleared the

--- a/frontend/src/__tests__/ScrollButtons.test.jsx
+++ b/frontend/src/__tests__/ScrollButtons.test.jsx
@@ -1,0 +1,62 @@
+// beacon2026/frontend/src/__tests__/ScrollButtons.test.jsx
+// Regression test for the "buttons only appear after you move the mouse"
+// bug: many list pages render their table container only after an async
+// fetch resolves (`{!loading && <Table ref={containerRef} />}`), which
+// happens *after* ScrollButtons' mount effect has already run once and
+// found containerRef.current still null. Without a per-render recheck, the
+// buttons stayed hidden until the next window 'scroll'/'resize' event.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
+import ScrollButtons from '../components/ScrollButtons.jsx';
+
+function Harness({ mountContainer }) {
+  const containerRef = useRef(null);
+  return (
+    <div>
+      {mountContainer && <div ref={containerRef} data-testid="container" />}
+      <ScrollButtons containerRef={containerRef} />
+    </div>
+  );
+}
+
+const originalRect = Element.prototype.getBoundingClientRect;
+const originalInnerHeight = window.innerHeight;
+
+beforeEach(() => {
+  window.innerHeight = 800;
+  // Simulate a container much taller than the viewport, scrolled so both
+  // the top and bottom edges are off-screen — both buttons should show.
+  Element.prototype.getBoundingClientRect = () => ({
+    top: -100,
+    bottom: 1000,
+    height: 1100,
+    left: 0,
+    right: 0,
+    width: 0,
+    x: 0,
+    y: -100,
+    toJSON() {},
+  });
+});
+
+afterEach(() => {
+  Element.prototype.getBoundingClientRect = originalRect;
+  window.innerHeight = originalInnerHeight;
+});
+
+describe('ScrollButtons', () => {
+  it('shows nothing while the watched container has not mounted yet', () => {
+    render(<Harness mountContainer={false} />);
+    expect(screen.queryByTitle('Scroll to top')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Scroll to bottom')).not.toBeInTheDocument();
+  });
+
+  it('shows the buttons as soon as the container mounts, with no scroll/resize event', async () => {
+    const { rerender } = render(<Harness mountContainer={false} />);
+    rerender(<Harness mountContainer />);
+
+    await waitFor(() => expect(screen.getByTitle('Scroll to top')).toBeInTheDocument());
+    expect(screen.getByTitle('Scroll to bottom')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ScrollButtons.jsx
+++ b/frontend/src/components/ScrollButtons.jsx
@@ -74,7 +74,6 @@ export default function ScrollButtons({ containerRef }) {
   }, [containerRef]);
 
   useEffect(() => {
-    update();
     window.addEventListener('scroll', update, { passive: true });
     window.addEventListener('resize', update, { passive: true });
 
@@ -92,6 +91,20 @@ export default function ScrollButtons({ containerRef }) {
       if (ro) ro.disconnect();
     };
   }, [update, containerRef]);
+
+  // The container this component watches (containerRef.current) is often
+  // still null on first mount — many list pages render the table only after
+  // an async fetch resolves (`{!loading && <Table ref={containerRef} />}`),
+  // which happens after the effect above has already run once and skipped
+  // attaching the ResizeObserver. Re-running the check on every render
+  // (rather than only on mount/scroll/resize) means the buttons appear
+  // correctly as soon as the table shows up, instead of only after the next
+  // scroll/resize event (which moving the mouse can coincidentally trigger
+  // via wheel movement, masking the bug). setShowTop/setShowBottom bail out
+  // of re-rendering when the value is unchanged, so this doesn't loop.
+  useEffect(() => {
+    update();
+  });
 
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });


### PR DESCRIPTION
## Summary
- `ScrollButtons.jsx`'s visibility check ran once on mount and on `window` `scroll`/`resize` events. On list pages (Members, Groups, Teams, Users, etc.) the table container mounts only after an async fetch resolves (`{!loading && <Table ref={containerRef} />}`) — which happens *after* that mount check already ran and found `containerRef.current` still `null`. The buttons then stayed hidden until the next scroll/resize event, which moving the mouse can coincidentally trigger via wheel movement — masking the real cause and making it look tied to cursor movement.
- Added a second effect (no dependency array) that reruns the visibility check on every render, so the buttons appear as soon as the table container actually mounts. `setShowTop`/`setShowBottom` bail out on an unchanged value, so this doesn't loop.
- Added `ScrollButtons.test.jsx`, a regression test asserting the buttons appear once a watched container mounts on a later render, with no scroll/resize event fired.

## Test plan
- [x] New regression test: fails against the old code (verified by reasoning through the stable-dependency-array mount effect), passes with the fix
- [x] `cd frontend && npm test` — 207 passed (run 3x to rule out flakiness)
- [x] `cd frontend && npm run lint` — 0 errors (pre-existing warnings only)
- [x] Prettier clean on touched files
- [ ] Live click-through in a running app (not done — needs Postgres + backend + seeded tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)