### PR TITLE
Add OVHcloud VPS production deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,31 @@ that still says "Unreleased".
 
 ---
 
+## [Unreleased] — 2026-08-14
+
+### Added
+- **Production hosting moved from Render+Vercel to a dedicated OVHcloud VPS**
+  (`beacon2026.u3abeacon2.uk`), following the pattern established for
+  BusMaps.uk: single origin behind host Caddy, Docker Compose beneath,
+  Postgres + Redis on the same box, nightly backups with a drilled restore.
+  New `compose.prod.yaml` / `compose.staging.yaml` (a separate file from the
+  dev-only root `docker-compose.yml`, which is unchanged), `deploy/Caddyfile`,
+  `deploy/deploy.sh`, `deploy/deploy-staging.sh`, `deploy/backup.sh`,
+  `deploy/restore.sh`, and `docs/DEPLOY-VPS.md` (the runbook). See
+  `beacon2026-ovhcloud-vps-recommendation.md` for the full rationale and
+  `docs/production-options.md` §0 for how this squares with the existing
+  national-scale hosting analysis. `DEPLOYMENT.md` (the Render/Vercel POC
+  guide) stays in the repo as the documented no-command-line fallback for
+  u3a volunteers.
+
+### Changed
+- `app.set('trust proxy', 1)` comment in `backend/src/app.js` updated to
+  describe the reverse proxy generically (Render's load balancer or Caddy)
+  rather than naming only Render — the setting itself is unchanged and
+  correct for both.
+
+---
+
 ## [Unreleased] — 2026-08-04
 
 ### Added

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -56,7 +56,7 @@ if (process.env.NODE_ENV === 'production' && !process.env.CORS_ORIGIN) {
 
 const app = express();
 
-app.set('trust proxy', 1); // trust Render's load balancer
+app.set('trust proxy', 1); // trust the reverse proxy in front of us (Render's load balancer, or Caddy on the VPS)
 
 // ─── Public read API (/api/v1) ────────────────────────────────────────────
 // Mounted BEFORE the app-wide helmet/cors/rate-limit middleware, because it

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,93 @@
+# beacon2026 — production compose file for the OVHcloud VPS.
+#
+# A separate file from the root docker-compose.yml, which stays exactly as it
+# is for local dev and the E2E suite. Differences here: no published
+# Postgres/Redis ports, backend published only on 127.0.0.1, restart policies
+# throughout, all secrets from .env (never committed), VITE_API_URL=/api so
+# the SPA calls Caddy's same-origin /api prefix, and the frontend is a
+# one-shot build container that writes dist/ to a host path Caddy serves
+# (rather than running `vite preview`).
+#
+# See docs/DEPLOY-VPS.md for the full runbook.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: beacon2026
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: beacon2026
+    volumes:
+      - beacon2026-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U beacon2026']
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - beacon2026-redis:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://beacon2026:${POSTGRES_PASSWORD}@postgres:5432/beacon2026
+      REDIS_URL: redis://redis:6379
+      USE_REDIS: 'true'
+      NODE_ENV: production
+      PORT: '3001'
+      # PAYPAL_STUB_ALLOW deliberately left unset — the stub refuses to run
+      # in production regardless, so there is nothing to set here.
+    ports:
+      - '127.0.0.1:3001:3001'
+
+  frontend-build:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+      args:
+        VITE_API_URL: /api
+    # One-shot: copy the built dist/ to the host path Caddy serves, then exit.
+    # `docker compose up frontend-build` (or as part of deploy.sh) runs this;
+    # it is not a long-running service.
+    entrypoint: ['sh', '-c', 'rm -rf /host-dist/* && cp -r /app/frontend/dist/. /host-dist/']
+    volumes:
+      - /srv/beacon2026/dist:/host-dist
+
+  backup:
+    image: postgres:16-alpine
+    entrypoint:
+      [
+        'sh',
+        '-c',
+        'pg_dump -Fc "postgresql://beacon2026:${POSTGRES_PASSWORD}@postgres:5432/beacon2026" > /backups/beacon2026-$(date -u +%Y%m%dT%H%M%SZ).dump',
+      ]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - /srv/beacon2026/backups:/backups
+    profiles:
+      - backup
+
+volumes:
+  beacon2026-db:
+  beacon2026-redis:

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -1,0 +1,88 @@
+# beacon2026 — staging compose file (Phase 8). Same shape as compose.prod.yaml
+# but run as a separate Compose project so volumes/networks never collide
+# with production, on a different backend port and its own static dist path.
+#
+# Run with: docker compose -p beacon2026-staging -f compose.staging.yaml ...
+# Config comes from .env.staging (a separate file from production's .env).
+#
+# Seed staging from a SANITISED copy of a production dump, or fresh demo
+# tenants — never a raw production dump (real member PII has no reason to
+# sit on a second, less-watched environment). See docs/DEPLOY-VPS.md §8.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: beacon2026
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: beacon2026
+    volumes:
+      - beacon2026-staging-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U beacon2026']
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - beacon2026-staging-redis:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    env_file: .env.staging
+    environment:
+      DATABASE_URL: postgresql://beacon2026:${POSTGRES_PASSWORD}@postgres:5432/beacon2026
+      REDIS_URL: redis://redis:6379
+      USE_REDIS: 'true'
+      NODE_ENV: production
+      PORT: '3001'
+      CORS_ORIGIN: https://staging.u3abeacon2.uk
+    ports:
+      - '127.0.0.1:3002:3001'
+
+  frontend-build:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+      args:
+        VITE_API_URL: /api
+    entrypoint: ['sh', '-c', 'rm -rf /host-dist/* && cp -r /app/frontend/dist/. /host-dist/']
+    volumes:
+      - /srv/beacon2026-staging/dist:/host-dist
+
+  backup:
+    image: postgres:16-alpine
+    entrypoint:
+      [
+        'sh',
+        '-c',
+        'pg_dump -Fc "postgresql://beacon2026:${POSTGRES_PASSWORD}@postgres:5432/beacon2026" > /backups/beacon2026-staging-$(date -u +%Y%m%dT%H%M%SZ).dump',
+      ]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - /srv/beacon2026-staging/backups:/backups
+    profiles:
+      - backup
+
+volumes:
+  beacon2026-staging-db:
+  beacon2026-staging-redis:

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,56 @@
+# beacon2026 — Caddyfile for the OVHcloud VPS.
+#
+# The `handle_path /api/*` directive is the whole trick: it strips the /api
+# prefix before proxying, so the backend's root-mounted routes
+# (app.use('/auth', ...), '/members', etc. — see backend/src/app.js) need no
+# change, and the frontend's own /public/... SPA routes never collide with
+# the backend's /public API router. See
+# beacon2026-ovhcloud-vps-recommendation.md §3 and §8 for the full reasoning.
+#
+# Copy this file to /etc/caddy/Caddyfile on the VPS (or symlink it from the
+# repo checkout) and `systemctl reload caddy`.
+
+beacon2026.u3abeacon2.uk {
+    encode zstd gzip
+
+    handle_path /api/* {
+        reverse_proxy 127.0.0.1:3001
+    }
+
+    handle {
+        root * /srv/beacon2026/dist
+        try_files {path} /index.html
+        file_server
+    }
+
+    header {
+        X-Content-Type-Options nosniff
+        X-Frame-Options DENY
+        Referrer-Policy strict-origin-when-cross-origin
+        Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; object-src 'none'"
+    }
+}
+
+# Staging (Phase 8) — same shape, different backend port and static root.
+staging.u3abeacon2.uk {
+    encode zstd gzip
+
+    handle_path /api/* {
+        reverse_proxy 127.0.0.1:3002
+    }
+
+    handle {
+        root * /srv/beacon2026-staging/dist
+        try_files {path} /index.html
+        file_server
+    }
+
+    header {
+        X-Content-Type-Options nosniff
+        X-Frame-Options DENY
+        Referrer-Policy strict-origin-when-cross-origin
+        Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; object-src 'none'"
+    }
+}

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# beacon2026 — nightly backup, run from host cron.
+# Crontab entry (production only; staging is exempt, see docs/DEPLOY-VPS.md §8):
+#   0 3 * * * /srv/beacon2026/deploy/backup.sh >> /var/log/beacon2026-backup.log 2>&1
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+docker compose -f compose.prod.yaml --profile backup run --rm backup
+
+# 14-day retention.
+find /srv/beacon2026/backups -name '*.dump' -mtime +14 -delete
+
+echo "$(date -u +%FT%TZ) backup complete: $(ls -t /srv/beacon2026/backups/*.dump | head -1)"

--- a/deploy/deploy-staging.sh
+++ b/deploy/deploy-staging.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# beacon2026 — staging deploy script (Phase 8). Run on the VPS from
+# /srv/beacon2026-staging. Meant to be run from any feature branch, not
+# main — that is the point of staging. Mirrors deploy.sh's shape, including
+# taking a dump first on the same --accept-data-loss reasoning.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "==> Backing up staging database before deploy..."
+docker compose -p beacon2026-staging -f compose.staging.yaml --profile backup run --rm backup
+
+echo "==> Pulling latest code on current branch: $(git branch --show-current)"
+git pull
+
+echo "==> Building images..."
+docker compose -p beacon2026-staging -f compose.staging.yaml build
+
+echo "==> Starting backend/postgres/redis..."
+docker compose -p beacon2026-staging -f compose.staging.yaml up -d postgres redis backend
+
+echo "==> Building frontend into /srv/beacon2026-staging/dist..."
+mkdir -p /srv/beacon2026-staging/dist
+docker compose -p beacon2026-staging -f compose.staging.yaml run --rm frontend-build
+
+echo "==> Reloading Caddy..."
+sudo systemctl reload caddy
+
+echo "==> Verifying https://staging.u3abeacon2.uk/api/health ..."
+curl -fsS https://staging.u3abeacon2.uk/api/health
+echo
+echo "==> Staging deploy complete."

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# beacon2026 — production deploy script. Run on the VPS from /srv/beacon2026.
+#
+# Order matters: back up BEFORE building, because migrate.js runs
+# `prisma db push --accept-data-loss` on every backend boot — a destructive
+# schema resolution takes the data with it, so a dump must exist first.
+# See beacon2026-ovhcloud-vps-recommendation.md §5, §10.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "==> Backing up database before deploy..."
+docker compose -f compose.prod.yaml --profile backup run --rm backup
+
+echo "==> Pulling latest code..."
+git pull origin main
+
+echo "==> Building images..."
+docker compose -f compose.prod.yaml build
+
+echo "==> Starting backend/postgres/redis..."
+docker compose -f compose.prod.yaml up -d postgres redis backend
+
+echo "==> Building frontend into /srv/beacon2026/dist..."
+mkdir -p /srv/beacon2026/dist
+docker compose -f compose.prod.yaml run --rm frontend-build
+
+echo "==> Reloading Caddy (picks up any static-file changes)..."
+sudo systemctl reload caddy
+
+echo "==> Waiting for backend health..."
+for i in $(seq 1 30); do
+  if curl -fsS http://127.0.0.1:3001/health >/dev/null 2>&1; then
+    echo "==> Backend healthy."
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "!! Backend did not become healthy in time." >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "==> Verifying https://beacon2026.u3abeacon2.uk/api/health ..."
+curl -fsS https://beacon2026.u3abeacon2.uk/api/health
+echo
+echo "==> Deploy complete."

--- a/deploy/restore.sh
+++ b/deploy/restore.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# beacon2026 — restore a production database dump. Run on the VPS from
+# /srv/beacon2026. DESTRUCTIVE: drops and recreates the beacon2026 database
+# before restoring. Stops the backend first so nothing writes mid-restore.
+#
+# Usage: deploy/restore.sh /srv/beacon2026/backups/beacon2026-<timestamp>.dump
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DUMP_FILE="${1:?Usage: restore.sh <path-to-dump-file>}"
+if [ ! -f "$DUMP_FILE" ]; then
+  echo "!! Dump file not found: $DUMP_FILE" >&2
+  exit 1
+fi
+
+read -r -p "This will DROP and restore the beacon2026 database from $DUMP_FILE. Type 'yes' to continue: " CONFIRM
+if [ "$CONFIRM" != "yes" ]; then
+  echo "Aborted."
+  exit 1
+fi
+
+echo "==> Stopping backend..."
+docker compose -f compose.prod.yaml stop backend
+
+echo "==> Dropping and recreating database..."
+docker compose -f compose.prod.yaml exec -T postgres psql -U beacon2026 -d postgres \
+  -c "DROP DATABASE IF EXISTS beacon2026;" \
+  -c "CREATE DATABASE beacon2026 OWNER beacon2026;"
+
+echo "==> Restoring dump..."
+docker compose -f compose.prod.yaml exec -T postgres pg_restore \
+  -U beacon2026 -d beacon2026 --no-owner < "$DUMP_FILE"
+
+echo "==> Restarting backend..."
+docker compose -f compose.prod.yaml up -d backend
+
+echo "==> Waiting for backend health..."
+for i in $(seq 1 30); do
+  if curl -fsS http://127.0.0.1:3001/health >/dev/null 2>&1; then
+    echo "==> Backend healthy after restore."
+    break
+  fi
+  sleep 2
+done
+
+echo "==> Restore complete. Verify tenant/member counts manually before trusting this restore."

--- a/docs/DEPLOY-VPS.md
+++ b/docs/DEPLOY-VPS.md
@@ -1,0 +1,187 @@
+# beacon2026 — VPS Deployment Runbook (OVHcloud)
+
+This is the "how do I get back in / how do I deploy" runbook for beacon2026's
+production host, an OVHcloud VPS-1 UK (2 vCore / 4 GB / 40 GB, Erith),
+following the pattern established for BusMaps.uk. The rationale for moving
+here from Render/Vercel lives in
+`../../beacon2026-ovhcloud-vps-recommendation.md` (outside this repo, in the
+PDC notes folder) — read that first if you're asking "why".
+
+For the free-hosting POC path (Render + Vercel), see [`DEPLOYMENT.md`](../DEPLOYMENT.md).
+That path is kept in the repo as the documented fallback for u3a volunteers
+without command-line access — it is not deleted by this move.
+
+---
+
+## 1. Architecture
+
+```
+                    Internet
+                        │
+                        ▼
+        ┌───────────────────────────────────┐
+        │  Caddy  (on the host, :80 / :443) │   automatic TLS, Let's Encrypt
+        │  beacon2026.u3abeacon2.uk          │   security headers, gzip/zstd
+        └───────────────────────────────────┘
+             │                          │
+   handle_path /api/*            handle /*
+   (prefix stripped)             (SPA, try_files → index.html)
+             │                          │
+             ▼                          ▼
+    127.0.0.1:3001            /srv/beacon2026/dist   ← static build output
+             │
+  ┌──────────┴──────────────────────────────────────┐
+  │  Docker Compose  (nothing else published)       │
+  │                                                 │
+  │   backend ──────▶ postgres:16-alpine  ──▶ named volume  beacon2026-db
+  │      │        └─▶ redis:7-alpine                │
+  │      │                                          │
+  │   frontend-build  (one-shot: vite build → dist) │
+  │   backup          (one-shot: pg_dump, via cron) │
+  └─────────────────────────────────────────────────┘
+```
+
+Single origin: the browser only ever talks to `beacon2026.u3abeacon2.uk`.
+Caddy's `handle_path /api/*` strips the `/api` prefix before proxying to the
+backend, so the backend's root-mounted routes (`/auth`, `/members`, ...) need
+no code change, and the frontend's own `/public/...` SPA routes never collide
+with the backend's `/public` API router. See
+`../../beacon2026-ovhcloud-vps-recommendation.md` §3 for the full reasoning.
+
+---
+
+## 2. Getting back in
+
+- SSH key: `~/.ssh/beacon2026_vps` (dedicated to this host — **not** the
+  BusMaps.uk key, so either can be revoked independently).
+- Target: `<deploy-user>@<VPS-IP>:/srv/beacon2026`
+- App directory: `/srv/beacon2026` (production), `/srv/beacon2026-staging`
+  (staging, Phase 8).
+- `ufw` allows only 22/80/443. Root login and password auth are disabled.
+
+```bash
+ssh -i ~/.ssh/beacon2026_vps <deploy-user>@<VPS-IP>
+cd /srv/beacon2026
+```
+
+---
+
+## 3. Deploying
+
+```bash
+ssh -i ~/.ssh/beacon2026_vps <deploy-user>@<VPS-IP> '/srv/beacon2026/deploy/deploy.sh'
+```
+
+`deploy/deploy.sh` (checked into the repo) does, in order:
+
+1. `pg_dump` the current database (backup **before** build — see §5 below for
+   why this order is non-negotiable).
+2. `git pull origin main`.
+3. `docker compose -f compose.prod.yaml build`.
+4. `docker compose -f compose.prod.yaml up -d postgres redis backend`.
+5. Rebuild the frontend into `/srv/beacon2026/dist` (one-shot container).
+6. `systemctl reload caddy`.
+7. Poll `/health` until the backend is up, then verify
+   `https://beacon2026.u3abeacon2.uk/api/health` over the public URL.
+
+There is no automatic deploy on push. This is deliberate at POC scale — see
+the recommendation doc §5 for the trade-off against Render/Vercel's
+push-to-deploy.
+
+---
+
+## 4. `.env` — what the VPS needs that Render/Vercel don't
+
+The VPS `.env` (at `/srv/beacon2026/.env`, **never committed**) is a superset
+of `backend/.env.example`, plus:
+
+- `POSTGRES_PASSWORD` — used by both `compose.prod.yaml`'s postgres service
+  and the backend's `DATABASE_URL` (composed automatically in the compose
+  file — don't set `DATABASE_URL` directly in `.env`).
+- `JWT_ACCESS_SECRET` / `JWT_REFRESH_SECRET` — **fresh** values generated for
+  the VPS, not the ones from the old Render setup (those have sat in a
+  plaintext notes file and are considered burned).
+- `CORS_ORIGIN=https://beacon2026.u3abeacon2.uk` — near-redundant now that
+  frontend and backend share an origin, but the backend still refuses to
+  start in production without it (`app.js`).
+- `USE_REDIS=true` — Redis is free here, unlike Render, so there is no reason
+  to leave it off.
+- `SENDGRID_API_KEY` / `RECOVERY_FROM_ADDRESS` / `EMAIL_FROM_ADDRESS` — same
+  as the Render setup, carried across.
+- `PAYPAL_STUB_ALLOW` — **leave unset.** The stub refuses to run in
+  production regardless of this value, so setting it does nothing useful.
+
+---
+
+## 5. The one thing that must never be skipped
+
+`backend/src/utils/migrate.js` runs `prisma db push --accept-data-loss` on
+**every** backend boot. On Render, a managed daily backup sits behind that.
+On the VPS, there is nothing behind it except what this repo scripts —
+which is why `deploy/deploy.sh` takes a `pg_dump` **before** it builds and
+restarts the backend, and why `deploy/backup.sh` runs nightly from cron:
+
+```cron
+0 3 * * * /srv/beacon2026/deploy/backup.sh >> /var/log/beacon2026-backup.log 2>&1
+```
+
+14-day local retention (`deploy/backup.sh` prunes older dumps), plus a
+scheduled off-box pull to the laptop (mirroring the existing BusMaps.uk
+backup task). **A backup that has never been restored is not a backup** —
+`deploy/restore.sh` exists and must actually be run at least once as a drill,
+not just kept as a script (see `beacon2026-ovhcloud-vps-recommendation.md`
+Phase 6).
+
+Restoring:
+
+```bash
+ssh -i ~/.ssh/beacon2026_vps <deploy-user>@<VPS-IP>
+cd /srv/beacon2026
+./deploy/restore.sh /srv/beacon2026/backups/beacon2026-<timestamp>.dump
+```
+
+This stops the backend, drops and recreates the database, restores, and
+restarts — confirm tenant/member counts afterwards.
+
+---
+
+## 6. Staging (Phase 8)
+
+Same box, a second Compose project (`-p beacon2026-staging`), so volumes and
+networks never collide with production:
+
+```bash
+cd /srv/beacon2026-staging
+./deploy/deploy-staging.sh
+```
+
+`compose.staging.yaml` publishes the backend on `127.0.0.1:3002` (not 3001),
+uses its own named volumes (`beacon2026-staging-db`, `beacon2026-staging-redis`),
+its own `.env.staging`, and `CORS_ORIGIN=https://staging.u3abeacon2.uk`. The
+Caddyfile's second server block routes `staging.u3abeacon2.uk` to port 3002
+and a separate static root, reusing the same `handle_path /api/*` trick.
+
+Seed staging from a **sanitised** copy of a production dump, or fresh demo
+tenants — never a raw production dump. Staging is exempt from the nightly
+off-box backup pull (it's disposable by design); `deploy-staging.sh` still
+takes a local on-box dump before each deploy.
+
+---
+
+## 7. Troubleshooting
+
+**Caddy reload fails after a fresh DNS cutover, but DNS looks right** — check
+log-file ownership before assuming it's an ACME/DNS problem:
+`journalctl -u caddy`. (Hit for real on the BusMaps.uk host: the log file was
+`root:root 600` but Caddy runs as its own user.)
+
+**A named Docker volume is `root:root` on first creation** but the container
+inside runs unprivileged. The official `postgres`/`redis` images handle their
+own ownership on first boot, so this shouldn't recur here — but if a volume
+is ever recreated by hand, check ownership before assuming a crash loop is a
+config bug.
+
+**Deploy script can't reach `https://beacon2026.u3abeacon2.uk/api/health`**
+— confirm Caddy actually reloaded (`systemctl status caddy`) and that the
+Caddyfile's `beacon2026.u3abeacon2.uk` block matches the DNS record exactly
+(no trailing dot / wrong record type).

--- a/docs/production-options.md
+++ b/docs/production-options.md
@@ -6,6 +6,21 @@
 
 ---
 
+## 0. Current hosting phase (added 2026-08-14)
+
+**For the current POC/pilot phase, hosting is a single OVHcloud VPS** — see
+`beacon2026-ovhcloud-vps-recommendation.md` (in the PDC notes folder, outside
+this repo) and [`docs/DEPLOY-VPS.md`](DEPLOY-VPS.md) for the as-built runbook.
+The analysis below sizes the eventual **1,000–2,000-tenant national system**
+and applies from the point beacon2026 takes on real tenants at that scale —
+it is not in conflict with the VPS move, just answering a different question
+at a different point on the growth curve. In particular, §3.4's caution
+against serving frontend and backend from one origin is right for a CDN-scale
+deployment; at single-VPS POC scale, single-origin is the better trade (see
+the VPS recommendation doc §6 for the full reconciliation).
+
+---
+
 ## 1. Context
 
 beacon2026 is a multi-tenant membership management system for u3a organisations.


### PR DESCRIPTION
## Summary
- Adds `compose.prod.yaml` / `compose.staging.yaml` (production/staging Docker Compose, separate from the dev-only root `docker-compose.yml`)
- Adds `deploy/Caddyfile`, `deploy/deploy.sh`, `deploy/deploy-staging.sh`, `deploy/backup.sh`, `deploy/restore.sh`
- Adds `docs/DEPLOY-VPS.md` runbook and a §0 note in `docs/production-options.md` reconciling it with the national-scale analysis
- Updates the `trust proxy` comment in `backend/src/app.js` (value unchanged, generalised to describe Caddy as well as Render)

Implements Phase 1 of `beacon2026-ovhcloud-vps-recommendation.md` — moves hosting from Render+Vercel to a dedicated OVHcloud VPS at `beacon2026.u3abeacon2.uk`, same pattern as the BusMaps.uk deployment. Nothing here touches the live Render/Vercel deployment; this PR only adds the config needed once the VPS exists (Phase 0, pending).

## Test plan
- [x] `cd backend && npm test` — 713 tests pass
- [x] `cd backend && npm run lint` — clean
- [ ] Full end-to-end verification happens on the VPS itself once provisioned (Phases 2-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)