### PR TITLE
Make refresh-cookie SameSite configurable, default lax

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,12 @@ SEED_ADMIN_NAME=System Administrator        # optional, defaults to "System Admi
 # Optional in dev/test.
 CORS_ORIGIN=http://localhost:5173
 
+# ── Refresh cookie SameSite (optional) ────────────────────────────────────
+# Defaults to 'lax', correct when frontend and backend share one origin
+# (the normal VPS deployment). Only set this to 'none' if frontend and
+# backend are on different origins (e.g. the Render+Vercel POC path).
+COOKIE_SAME_SITE=
+
 # ── Server (optional) ─────────────────────────────────────────────────────
 NODE_ENV=development                         # development | production | test
 PORT=3001

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -33,7 +33,11 @@ const COOKIE_NAME = 'beacon2026_refresh';
 const cookieOptions = {
   httpOnly: true,
   secure: true,
-  sameSite: 'none', // required for cross-origin (Vercel frontend → Render backend)
+  // 'lax' is correct — and CSRF-resistant by default — for the normal
+  // single-origin deployment (VPS: Caddy serves frontend and backend from
+  // the same origin). Render+Vercel's split-origin deployment is the one
+  // exception and sets COOKIE_SAME_SITE=none in render.yaml to match.
+  sameSite: process.env.COOKIE_SAME_SITE ?? 'lax',
   maxAge: 1000 * 60 * 60 * 24 * parseInt(process.env.JWT_REFRESH_EXPIRES_DAYS ?? '30', 10),
 };
 

--- a/render.yaml
+++ b/render.yaml
@@ -50,6 +50,9 @@ services:
       - key: CORS_ORIGIN
         sync: false        # Paste your Vercel frontend URL here
 
+      - key: COOKIE_SAME_SITE
+        value: none         # required for cross-origin (Vercel frontend -> Render backend)
+
 databases:
   - name: beacon2026-db
     region: frankfurt


### PR DESCRIPTION
## Summary
- `backend/src/routes/auth.js`: refresh cookie `sameSite` now reads `process.env.COOKIE_SAME_SITE ?? 'lax'` instead of being hardcoded to `'none'`
- `render.yaml`: adds `COOKIE_SAME_SITE=none` so the existing Render+Vercel split-origin deployment is unaffected
- `backend/.env.example`: documents the new optional variable

Found while verifying the first VPS deploy (`beacon2026-ovhcloud-vps-recommendation.md` Phase 4 gate: refresh cookie should be `SameSite=Lax` once frontend and backend share an origin) — the code still hardcoded `'none'`, so this was needed to actually realise that hardening rather than just being possible in principle.

## Test plan
- [x] `cd backend && npm test` — 713 tests pass
- [x] `cd backend && npm run lint` — clean
- [ ] Re-deploy to the VPS and confirm the refresh cookie is `SameSite=Lax` in DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)