### PR TITLE
Bump production/staging Postgres to 18-alpine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ Thumbs.db
 .vscode/
 .idea/
 
+# Claude Code local (personal) settings
+.claude/settings.local.json
+
 # E2E test state and artefacts (generated per run)
 e2e/.e2e-state.json
 e2e/.e2e-storage.json

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -12,7 +12,7 @@
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_USER: beacon2026
@@ -73,7 +73,7 @@ services:
       - /srv/beacon2026/dist:/host-dist
 
   backup:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     entrypoint:
       [
         'sh',

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -11,7 +11,7 @@
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_USER: beacon2026
@@ -68,7 +68,7 @@ services:
       - /srv/beacon2026-staging/dist:/host-dist
 
   backup:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     entrypoint:
       [
         'sh',

--- a/docs/DEPLOY-VPS.md
+++ b/docs/DEPLOY-VPS.md
@@ -33,7 +33,7 @@ without command-line access — it is not deleted by this move.
   ┌──────────┴──────────────────────────────────────┐
   │  Docker Compose  (nothing else published)       │
   │                                                 │
-  │   backend ──────▶ postgres:16-alpine  ──▶ named volume  beacon2026-db
+  │   backend ──────▶ postgres:18-alpine  ──▶ named volume  beacon2026-db
   │      │        └─▶ redis:7-alpine                │
   │      │                                          │
   │   frontend-build  (one-shot: vite build → dist) │


### PR DESCRIPTION
## Summary
- `compose.prod.yaml` / `compose.staging.yaml`: postgres image `16-alpine` -> `18-alpine`
- `docs/DEPLOY-VPS.md`: architecture diagram updated to match
- `.gitignore`: ignore `.claude/settings.local.json` (personal permission overrides)

Found while running Phase 5 (data migration) of the VPS move: Render's `beacon2026-postgres` has been auto-upgraded to PostgreSQL 18 since the recommendation doc was written, so `pg_dump` against it from the VPS's postgres:16 container refused with "server version mismatch". No real data exists on the VPS yet, so bumping now is free.

## Test plan
- [x] `cd backend && npm test` — 713 tests pass (no backend code touched)
- [ ] Redeploy to VPS, confirm postgres 18 comes up healthy, retry the Render dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)