### PR TITLE
Fix postgres 18 data mount point

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: beacon2026
     volumes:
-      - beacon2026-db:/var/lib/postgresql/data
+      - beacon2026-db:/var/lib/postgresql
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U beacon2026']
       interval: 5s

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -18,7 +18,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: beacon2026
     volumes:
-      - beacon2026-staging-db:/var/lib/postgresql/data
+      - beacon2026-staging-db:/var/lib/postgresql
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U beacon2026']
       interval: 5s


### PR DESCRIPTION
## Summary
`compose.prod.yaml` / `compose.staging.yaml`: postgres volume mount changed from `/var/lib/postgresql/data` to `/var/lib/postgresql` — the postgres:18-alpine image refuses to start against the old mount point (pg_ctlcluster-compatible layout is required from 18+).

Found immediately when redeploying the VPS after #520 (the 16->18 bump) — container start failed with a clear error pointing at the new expected mount. Dev's `docker-compose.yml` stays on postgres:16-alpine with the old mount, which is correct for that version.

## Test plan
- [ ] Redeploy VPS, confirm postgres 18 starts healthy this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)