### PR TITLE
Make general rate limiter configurable (GENERAL_RATE_LIMIT_MAX)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,6 +45,10 @@ BCRYPT_ROUNDS=12
 MAX_FAILED_LOGINS=5
 LOCKOUT_MINUTES=15
 AUTH_RATE_LIMIT_MAX=100                       # admin auth requests / 15 min / IP
+GENERAL_RATE_LIMIT_MAX=300                    # all other requests / 15 min / IP —
+  # raise this on environments a single IP hits hard (e.g. the E2E suite's CI
+  # runner), since a fast backend can otherwise legitimately exhaust 300
+  # requests well inside the window.
 # Unauthenticated members-portal auth (register/login/forgot/reset/verify) is
 # rate-limited far more tightly than the admin endpoints.
 PORTAL_AUTH_RATE_LIMIT_MAX=20                 # portal auth requests / 15 min / IP

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -103,7 +103,10 @@ const authLimiter = rateLimit({
   max: parseInt(process.env.AUTH_RATE_LIMIT_MAX || '100', 10),
   message: { error: 'Too many attempts, please try again later.' },
 });
-const generalLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 300 });
+const generalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: parseInt(process.env.GENERAL_RATE_LIMIT_MAX || '300', 10),
+});
 app.use(generalLimiter);
 
 app.use('/auth', authLimiter, authRoutes);


### PR DESCRIPTION
## Summary
`generalLimiter` (300 req/15min/IP) was the only rate limiter in `app.js` still hardcoded — `authLimiter` and the public API limiter both already read their max from env. Added `GENERAL_RATE_LIMIT_MAX`, default unchanged at 300.

## Why
The E2E suite against the VPS failed consistently from test ~32 onward across two full runs, every failure landing at ~13s (just under the 15s CI assertion timeout). Manual reproduction in a browser showed the frontend tab-switch itself works fine and fast (sub-second, 4/4 clean runs) — the difference is request *volume*: the VPS responds fast enough that Playwright burns through ~30 tests' worth of requests well inside the rate limiter's 15-minute window, something Render's slower/cold-start responses had been masking by simply taking longer per test.

## Test plan
- [x] `cd backend && npm test` — 713 tests pass
- [x] `cd backend && npm run lint` — clean
- [ ] Set a higher `GENERAL_RATE_LIMIT_MAX` in the VPS `.env` and re-run the E2E workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)