### PR TITLE
Document the VPS production move everywhere a reader would look

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,38 @@ that still says "Unreleased".
   guide) stays in the repo as the documented no-command-line fallback for
   u3a volunteers.
 
+- **Production is now live on the VPS** (`beacon2026.u3abeacon2.uk`), with real
+  data migrated from Render, a nightly-backed-up database, and a full green
+  E2E run (164/164) against it. GitHub Actions secrets now point at it.
+  Render+Vercel are being kept running in parallel for a safety window before
+  decommissioning (see `beacon2026-ovhcloud-vps-recommendation.md` Phase 9).
+
 ### Changed
 - `app.set('trust proxy', 1)` comment in `backend/src/app.js` updated to
   describe the reverse proxy generically (Render's load balancer or Caddy)
   rather than naming only Render — the setting itself is unchanged and
   correct for both.
+- **Refresh cookie `sameSite` is now configurable** (`COOKIE_SAME_SITE`,
+  default `'lax'`) instead of hardcoded `'none'`. `'none'` was only ever
+  needed for the Render+Vercel split-origin POC, which now sets it explicitly
+  via `render.yaml`. On the VPS's single origin, `'lax'` is correct and
+  CSRF-resistant by default.
+- **`generalLimiter` (the app-wide rate limiter) is now configurable**
+  (`GENERAL_RATE_LIMIT_MAX`, default unchanged at 300/15min/IP) instead of
+  hardcoded, matching `authLimiter`'s existing pattern. Found and needed
+  because the VPS is fast enough that the E2E suite's real per-test logins
+  and requests exhausted the default budget from a single CI-runner IP well
+  inside the rate-limit window — something Render's slower responses had
+  been masking. Both `AUTH_RATE_LIMIT_MAX` and `GENERAL_RATE_LIMIT_MAX` are
+  raised in the VPS's own `.env` (`docs/DEPLOY-VPS.md` §4); production's
+  documented defaults are unchanged.
+- Production/staging Postgres bumped `16-alpine` → `18-alpine`
+  (`compose.prod.yaml`/`compose.staging.yaml`) to match Render's own database,
+  which had been auto-upgraded to PG18 since the VPS plan was written — the
+  version mismatch blocked `pg_dump` during data migration. The 18+ image
+  also changed its expected data-volume mount point to `/var/lib/postgresql`
+  (was `.../data`); the dev-only root `docker-compose.yml` stays on 16-alpine
+  with the old mount, which is correct for that version.
 
 ---
 

--- a/CLAUDE-E2E.md
+++ b/CLAUDE-E2E.md
@@ -1,7 +1,9 @@
 # beacon2026 — E2E Test Reference
 
 End-to-end tests live in `e2e/` and run via Playwright against a live
-staging deployment on Render.
+deployment — production, the OVHcloud VPS, since 2026-08-14 (see
+`docs/DEPLOY-VPS.md`). Earlier runs targeted the Render/Vercel POC deployment;
+references to "Render" below describe that era and are kept for history.
 
 ---
 
@@ -26,9 +28,24 @@ staging deployment on Render.
 cd e2e && npm test          # local (needs frontend + backend running)
 ```
 
-In CI the workflow (`.github/workflows/e2e.yml`) runs against the Render
-staging deployment. Backend/frontend URLs and credentials come from
-GitHub Secrets.
+In CI the workflow (`.github/workflows/e2e.yml`) runs against the deployment
+named in the `BEACON2026_BASE_URL`/`BEACON2026_API_URL` GitHub secrets — the VPS
+since 2026-08-14. Credentials also come from GitHub Secrets.
+
+**A fast backend can exhaust the rate limiters the E2E suite never used to hit.**
+The `adminPage` fixture does a real login per test (see "Critical constraint"
+below) plus several requests each; 164 tests is enough to burn through the
+default `AUTH_RATE_LIMIT_MAX` (100/15min/IP) and `GENERAL_RATE_LIMIT_MAX`
+(300/15min/IP) well inside the window when the backend responds fast — which
+Render's slower/cold-start responses had been masking by simply taking longer
+per test, never actually finishing 164 tests inside one 15-minute rate-limit
+window. Symptom: a long, consistent run of failures starting partway through
+the suite, each landing at just under the CI assertion timeout (15s), with no
+errors in the backend's own logs (429s aren't logged) — check
+`X-RateLimit-Remaining` on a live request before assuming it's a real app bug.
+Fix is in the target deployment's own `.env`, not the workflow: raise
+`AUTH_RATE_LIMIT_MAX`/`GENERAL_RATE_LIMIT_MAX` there (both are env-configurable
+in `backend/src/app.js`).
 
 ---
 
@@ -126,7 +143,7 @@ navigate from this starting point using SPA links.
 
 ## Global-setup flow
 
-1. Wait for frontend and backend services (handles Render cold starts)
+1. Wait for frontend and backend services (handled Render cold starts historically; a no-op wait against the always-on VPS)
 2. Log in as system admin
 3. Create the test tenant (or reset admin password if it already exists)
 4. Log in as the test-tenant admin
@@ -269,7 +286,8 @@ npx playwright show-trace e2e/test-results/<test-folder>/trace.zip
 
 ## Debugging E2E failures
 
-- **Render logs** — check the backend's application log for auth errors.
+- **Backend logs** (`docker logs beacon2026-backend-1` on the VPS, or the Render
+  dashboard for the POC deployment) — check for auth errors.
   Common patterns:
   - `POST /auth/login: Invalid credentials` at line 24 → tenant not found
   - `POST /auth/login: Invalid credentials` at line 48 → wrong password or

--- a/CLAUDE-REFERENCE.md
+++ b/CLAUDE-REFERENCE.md
@@ -2168,8 +2168,34 @@ changes the code, but treat it as a summary, not the authority.
 
 ## 26. Deployment and Infrastructure
 
-See `DEPLOYMENT.md` for the full step-by-step guide (written for non-technical users).
-Key facts for developers:
+**Production (since 2026-08-14) is a dedicated OVHcloud VPS**, single origin
+behind Caddy. See `docs/DEPLOY-VPS.md` for the full runbook (SSH access, deploy
+script, `.env` contents, backups/restore) and
+`beacon2026-ovhcloud-vps-recommendation.md` (PDC notes folder, outside this repo)
+for the migration rationale. Key facts for developers:
+
+| Component | Hosted on | Config |
+|-----------|-----------|--------|
+| Frontend + Backend | One OVHcloud VPS, behind Caddy | `compose.prod.yaml`, `deploy/Caddyfile`; Caddy's `handle_path /api/*` strips the prefix so the backend needs no route changes |
+| Database | Self-hosted PostgreSQL 18 (Docker) | Schema-per-tenant, `beacon2026` DB, named volume `beacon2026-db` |
+
+**Environment variables** live in `/srv/beacon2026/.env` on the VPS itself
+(never committed) — see `docs/DEPLOY-VPS.md` §4 for the full list, including
+`AUTH_RATE_LIMIT_MAX`/`GENERAL_RATE_LIMIT_MAX` raised above the
+`backend/.env.example` defaults (a fast single-VPS backend can otherwise exhaust
+either budget from one busy IP faster than the split-origin POC deployment ever
+could).
+
+**Database backup/restore**: nightly cron (`deploy/backup.sh`, 03:00 UTC,
+14-day retention) plus an off-box pull to the laptop. Restore with
+`deploy/restore.sh <dump-file>` — drops and recreates the database, so treat it
+as destructive. Full instructions in `docs/DEPLOY-VPS.md` §5.
+
+### POC/fallback deployment (Render + Vercel)
+
+See `DEPLOYMENT.md` for the full step-by-step guide (written for non-technical
+users) — kept in the repo as a no-command-line fallback path, **not** what
+production actually runs on.
 
 | Component | Hosted on | Config |
 |-----------|-----------|--------|

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,5 +1,10 @@
 # beacon2026 — Deployment Guide (Proof of Concept)
 
+> **This is not what production runs on.** Since 2026-08-14, production runs on a
+> dedicated OVHcloud VPS — see [`docs/DEPLOY-VPS.md`](docs/DEPLOY-VPS.md). This guide
+> is kept as a documented no-command-line fallback path for u3a volunteers without
+> server access.
+
 This guide gets beacon2026 live on the internet using free hosting.
 No command line or server knowledge needed — everything is done through websites.
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ beacon2026/
 │   └── history/              Archived 2026-06 review docs (read-only)
 │
 ├── docker-compose.yml         Local full-stack (Postgres + Redis + apps)
+├── compose.prod.yaml          Production VPS stack (see docs/DEPLOY-VPS.md)
 ├── .github/workflows/ci.yml   Runs backend + frontend lint, format, tests
-├── render.yaml                Render blueprint (backend + Postgres)
-├── DEPLOYMENT.md              Step-by-step deployment guide (Render + Vercel)
+├── render.yaml                Render blueprint — POC/fallback path, not production
+├── DEPLOYMENT.md              Step-by-step no-CLI deployment guide (Render + Vercel POC)
 ├── CLAUDE.md                  Instructions for Claude Code (session workflow)
 ├── CLAUDE-STANDARDS.md        Cross-cutting development checklist
 └── CLAUDE-REFERENCE.md        Detailed implementation notes by module
@@ -192,8 +193,14 @@ resources, creates the five default roles, and sets up the first admin user.
 
 ## Deployment
 
-See [DEPLOYMENT.md](DEPLOYMENT.md) for a step-by-step guide to deploying on
-Render (backend + Postgres) and Vercel (frontend) — no command-line knowledge needed.
+**Production** runs on a dedicated OVHcloud VPS (single origin behind Caddy) — see
+[`docs/DEPLOY-VPS.md`](docs/DEPLOY-VPS.md) for the runbook and
+[`beacon2026-ovhcloud-vps-recommendation.md`](../beacon2026-ovhcloud-vps-recommendation.md)
+(PDC notes folder, outside this repo) for the migration rationale.
+
+For a free, no-command-line POC deployment (Render + Vercel), see
+[DEPLOYMENT.md](DEPLOYMENT.md) — kept in the repo as a documented fallback path for
+u3a volunteers without server access, not what production actually runs on.
 
 ## Modules implemented
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,7 +102,8 @@ What the operator must still do:
 
 - Publish a privacy policy and lawful-basis statement for members.
 - Put a data-processing agreement in place with the hosting providers
-  (e.g. Render, Vercel, SendGrid).
+  (OVHcloud for the production VPS, plus SendGrid; Render/Vercel for the POC
+  fallback path).
 - Define and follow retention, breach-notification, and subject-rights
   procedures.
 

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -56,8 +56,13 @@ beacon2026 is a ground-up rebuild with these goals:
 - System tier: separate system admin login, tenant CRUD, set-temp-password
   (forces `must_change_password` on all affected users)
 - Auto-migrate and auto-seed on startup (`migrate.js`) — no shell access needed
-- Redis session invalidation (disabled in POC; `USE_REDIS=false`)
-- Deployed: backend on Render, frontend on Vercel, DB on Render PostgreSQL
+- Redis session invalidation — enabled in production (`USE_REDIS=true` on the VPS);
+  the Render POC path still runs without it (`USE_REDIS=false`, falls back to a
+  Postgres table, see `backend/src/utils/redis.js`)
+- Deployed (since 2026-08-14): dedicated OVHcloud VPS, single origin behind Caddy
+  (`docs/DEPLOY-VPS.md`). The original Render (backend + DB) + Vercel (frontend)
+  POC deployment is documented in `DEPLOYMENT.md` as a no-command-line fallback
+  path, not what production runs on
 - CI: GitHub Actions runs backend + frontend tests on every push to `claude/**` branches
 - E2E: Playwright test suite against staging
 - **Cookie consent** — GDPR-compliant dialog on first visit; optional cookies
@@ -325,7 +330,7 @@ startup. All DDL uses `IF NOT EXISTS`; seed INSERTs use `ON CONFLICT DO NOTHING`
 | Frontend | React 18 + Vite |
 | UI styling | Tailwind CSS v3 |
 | Backend | Node.js + Express |
-| Database | PostgreSQL (Render) |
+| Database | PostgreSQL 18 (self-hosted on the VPS; Render Postgres for the POC fallback path) |
 | ORM/query | Prisma (system tables) + `$queryRawUnsafe` (tenant tables) |
 | Auth | JWT access (15 min, in-memory) + refresh token (30 days, httpOnly cookie) |
 | Password | bcrypt, 12 rounds |
@@ -333,7 +338,7 @@ startup. All DDL uses `IF NOT EXISTS`; seed INSERTs use `ON CONFLICT DO NOTHING`
 | Excel | ExcelJS (read + write) |
 | PDF | PDFKit (labels, member list download) |
 | Testing | Vitest (unit), Playwright (E2E) |
-| Deployment | Render (backend + DB), Vercel (frontend) |
+| Deployment | Dedicated OVHcloud VPS, single origin (`docs/DEPLOY-VPS.md`); Render+Vercel POC fallback documented in `DEPLOYMENT.md` |
 
 ### Project layout
 


### PR DESCRIPTION
## Summary
Docs-only. README.md, DEPLOYMENT.md, CLAUDE-REFERENCE.md §26, CLAUDE-E2E.md, SECURITY.md, and `beacon2026 Project Definition.md` all still described Render+Vercel as production. Production has run on a dedicated OVHcloud VPS since 2026-08-14 — these now point there, with DEPLOYMENT.md/render.yaml kept explicitly as the documented no-CLI POC fallback rather than silently going stale.

CLAUDE-E2E.md also gains the rate-limit lesson learned while getting a full green E2E run against the VPS (PR #523), so a future session hitting a similar "flaky in CI, fine manually" case has it written down.

CHANGELOG.md gets the entries for PRs #519–524 (SameSite fix, Postgres 18 bump, rate-limit fix) that shipped alongside the migration but hadn't been logged.

## Test plan
Docs-only — no code changed, no tests needed per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)