### PR TITLE
Fix staging deploy: pass --env-file .env.staging to docker compose

### DIFF
--- a/deploy/deploy-staging.sh
+++ b/deploy/deploy-staging.sh
@@ -7,21 +7,27 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# --env-file is required on every invocation: compose.staging.yaml's
+# ${POSTGRES_PASSWORD} substitution is resolved by Compose itself (not by
+# the backend service's `env_file: .env.staging`), and Compose only reads a
+# file named `.env` by default — which does not exist in this directory.
+COMPOSE="docker compose --env-file .env.staging -p beacon2026-staging -f compose.staging.yaml"
+
 echo "==> Backing up staging database before deploy..."
-docker compose -p beacon2026-staging -f compose.staging.yaml --profile backup run --rm backup
+$COMPOSE --profile backup run --rm backup
 
 echo "==> Pulling latest code on current branch: $(git branch --show-current)"
 git pull
 
 echo "==> Building images..."
-docker compose -p beacon2026-staging -f compose.staging.yaml build
+$COMPOSE build
 
 echo "==> Starting backend/postgres/redis..."
-docker compose -p beacon2026-staging -f compose.staging.yaml up -d postgres redis backend
+$COMPOSE up -d postgres redis backend
 
 echo "==> Building frontend into /srv/beacon2026-staging/dist..."
 mkdir -p /srv/beacon2026-staging/dist
-docker compose -p beacon2026-staging -f compose.staging.yaml run --rm frontend-build
+$COMPOSE run --rm frontend-build
 
 echo "==> Reloading Caddy..."
 sudo systemctl reload caddy


### PR DESCRIPTION
## Summary
- `compose.staging.yaml`'s `${POSTGRES_PASSWORD}` substitution is resolved by Compose itself (not by the backend service's `env_file: .env.staging`), and Compose only reads a file literally named `.env` by default.
- First live run of Phase 8 (staging) hit this: `POSTGRES_PASSWORD` silently defaulted to blank, and the postgres container failed its healthcheck.
- Fix: every `docker compose` invocation in `deploy-staging.sh` now passes `--env-file .env.staging`.

## Test plan
- [x] Reproduced the failure on the live VPS during first staging deploy attempt
- [ ] Redeploy staging on the VPS with the fix and confirm the gate: `https://staging.u3abeacon2.uk/api/health` returns healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)