### PR TITLE
Update deployment docs for staging; recover orphaned README formatting commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ that still says "Unreleased".
   `.env` by default. Without the flag, `POSTGRES_PASSWORD` silently defaulted
   to blank and the postgres container failed its healthcheck on first deploy.
 
+### Documentation
+- Development/deployment docs (`README.md`, `docs/DEPLOY-VPS.md`,
+  `beacon2026 Project Definition.md`, `CLAUDE-E2E.md`, `e2e/README.md`,
+  `KNOWN-ISSUES.md`) updated for the new staging environment: how to deploy a
+  branch to it, how to reset it, and two gotchas hit on its first live deploy
+  (the `--env-file` bug above, and a harmless TLS race between Caddy's
+  certificate issuance and the deploy script's own health-check curl on a
+  brand-new domain). Flagged an open decision: CI's E2E workflow currently
+  points at production rather than the new staging environment.
+
 ## [Unreleased] — 2026-08-14
 
 ### Added

--- a/CLAUDE-E2E.md
+++ b/CLAUDE-E2E.md
@@ -1,9 +1,23 @@
 # beacon2026 — E2E Test Reference
 
 End-to-end tests live in `e2e/` and run via Playwright against a live
-deployment — production, the OVHcloud VPS, since 2026-08-14 (see
-`docs/DEPLOY-VPS.md`). Earlier runs targeted the Render/Vercel POC deployment;
+deployment. Earlier runs targeted the Render/Vercel POC deployment;
 references to "Render" below describe that era and are kept for history.
+
+**Where CI currently points, and why that's worth revisiting:** `.github/workflows/e2e.yml`
+was written to run "against a live staging deployment" (its own header
+comment), but during the 2026-08-14 VPS migration the `BEACON2026_BASE_URL`/
+`BEACON2026_API_URL` secrets were pointed at the **production** VPS as a
+one-off smoke test after the move, and were never repointed afterwards. A
+real staging environment now exists (`https://staging.u3abeacon2.uk`, see
+`docs/DEPLOY-VPS.md` §6, live since 2026-08-15) — pointing these secrets at
+it instead would match the workflow's original intent and stop a manually
+triggered E2E run from creating/deleting a real tenant against production.
+The workflow only runs on `workflow_dispatch` (its auto-triggers are
+commented out), so the exposure is bounded to whoever manually runs it — but
+this is still a live production risk worth closing out. Not yet done as of
+2026-08-15; ask before changing the secrets, since it's a CI/CD config change
+against a production-facing pipeline.
 
 ---
 

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -539,6 +539,20 @@ All items in this section have been completed (v0.8.6).
   service settings, without recreating the service. See
   `DEPLOYMENT.md` → Troubleshooting for the general fix if this recurs.
 
+## Staging — Deferred Items
+
+- `[OPEN]` **E2E CI (`.github/workflows/e2e.yml`) points at production, not
+  staging.** `BEACON2026_BASE_URL`/`BEACON2026_API_URL` were set to the
+  production VPS URL on 2026-08-14 as a one-off post-migration smoke test and
+  never repointed. A real staging environment now exists
+  (`https://staging.u3abeacon2.uk`, live 2026-08-15, `docs/DEPLOY-VPS.md` §6)
+  — repointing the secrets there would match the workflow's own documented
+  intent ("run against a live staging deployment") and stop a manually
+  triggered run from creating/deleting a real tenant against production. The
+  workflow only runs on `workflow_dispatch` (auto-triggers are commented
+  out), so exposure is bounded, but this should be closed out. See
+  `CLAUDE-E2E.md` for the full context.
+
 ## Temporary UI — Deferred Items
 
 - `[DEFERRED]` **Menu "NEW" badges are temporary and should be removed.**

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ beacon2026/
 │
 ├── docker-compose.yml         Local full-stack (Postgres + Redis + apps)
 ├── compose.prod.yaml          Production VPS stack (see docs/DEPLOY-VPS.md)
+├── compose.staging.yaml       Staging VPS stack, same box, separate project (docs/DEPLOY-VPS.md §6)
 ├── .github/workflows/ci.yml   Runs backend + frontend lint, format, tests
 ├── render.yaml                Render blueprint — POC/fallback path, not production
 ├── DEPLOYMENT.md              Step-by-step no-CLI deployment guide (Render + Vercel POC)
@@ -169,6 +170,11 @@ This creates the tenant's PostgreSQL schema (`u3a_oxfordshire`), seeds all privi
 [`docs/DEPLOY-VPS.md`](docs/DEPLOY-VPS.md) for the runbook and
 [`beacon2026-ovhcloud-vps-recommendation.md`](../beacon2026-ovhcloud-vps-recommendation.md)
 (PDC notes folder, outside this repo) for the migration rationale.
+
+**Staging** runs alongside it on the same VPS, at `https://staging.u3abeacon2.uk`
+— its own Postgres, Redis, and Compose project, seeded fresh (never a copy of
+real member data). See [`docs/DEPLOY-VPS.md`](docs/DEPLOY-VPS.md) §6 for how
+to deploy a feature branch there and reset it.
 
 For a free, no-command-line POC deployment (Render + Vercel), see
 [DEPLOYMENT.md](DEPLOYMENT.md) — kept in the repo as a documented fallback path for

--- a/README.md
+++ b/README.md
@@ -1,31 +1,16 @@
 # beacon2026
 
-Modern rebuild of the [Beacon](https://www.u3abeacon.org.uk/) u3a management system —
-a multi-tenant web app for running u3a groups across the UK.
+Modern rebuild of the [Beacon](https://www.u3abeacon.org.uk/) u3a management system — a multi-tenant web app for running u3a groups across the UK.
 
-> **For human contributors:** this `README.md` and [`CONTRIBUTING.md`](CONTRIBUTING.md)
-> are the entry points for people. The `CLAUDE*.md` files (`CLAUDE.md`,
-> `CLAUDE-STANDARDS.md`, `CLAUDE-REFERENCE.md`, `CLAUDE-E2E.md`) are tooling for
-> Claude Code sessions, not primary documentation — read them only if you want to
-> understand how the AI-assisted workflow operates.
+> **For human contributors:** this `README.md` and [`CONTRIBUTING.md`](CONTRIBUTING.md) are the entry points for people. The `CLAUDE*.md` files (`CLAUDE.md`, `CLAUDE-STANDARDS.md`, `CLAUDE-REFERENCE.md`, `CLAUDE-E2E.md`) are tooling for Claude Code sessions, not primary documentation — read them only if you want to understand how the AI-assisted workflow operates.
 
 ## What beacon2026 is (plain-language overview)
 
-beacon2026 is a web application that u3a organisations use to run their membership,
-groups, finances, and communications. Each u3a gets its own private, isolated
-area within one shared system ("multi-tenant"), so many u3as can be hosted
-together at low cost.
+beacon2026 is a web application that u3a organisations use to run their membership, groups, finances, and communications. Each u3a gets its own private, isolated area within one shared system ("multi-tenant"), so many u3as can be hosted together at low cost.
 
-- **Who uses it:** a u3a's own volunteers — membership secretary, treasurer,
-  group coordinators — through an ordinary web browser. There is nothing to
-  install. Members themselves can join and renew online through a self-service
-  portal.
-- **Where it runs / what it costs:** it deploys to low-cost cloud hosting. A
-  proof-of-concept runs on free tiers; a stable production setup is roughly
-  £12/month plus an optional domain name. See [DEPLOYMENT.md](DEPLOYMENT.md).
-- **Status:** feature-complete against the original Beacon and working end-to-end,
-  but currently a demonstration/proof-of-concept — see the table below and
-  [SECURITY.md](SECURITY.md) before putting real member data into it.
+- **Who uses it:** a u3a's own volunteers — membership secretary, treasurer, group coordinators — through an ordinary web browser. There is nothing to install. Members themselves can join and renew online through a self-service portal.
+- **Where it runs / what it costs:** it deploys to low-cost cloud hosting. A proof-of-concept runs on free tiers; a stable production setup is roughly £12/month plus an optional domain name. See [DEPLOYMENT.md](DEPLOYMENT.md).
+- **Status:** feature-complete against the original Beacon and working end-to-end, but currently a demonstration/proof-of-concept — see the table below and [SECURITY.md](SECURITY.md) before putting real member data into it.
 
 ### Status at a glance
 
@@ -38,8 +23,7 @@ together at low cost.
 | **Independent security audit / penetration test** | Not yet done (see [SECURITY.md](SECURITY.md)) |
 | **User-guide screenshots** | Outstanding — guide text is complete |
 
-For the authoritative feature inventory, see
-[`beacon2026 Project Definition.md`](beacon2026%20Project%20Definition.md).
+For the authoritative feature inventory, see [`beacon2026 Project Definition.md`](beacon2026%20Project%20Definition.md).
 
 ## Project structure
 
@@ -89,9 +73,7 @@ beacon2026/
 └── CLAUDE-REFERENCE.md        Detailed implementation notes by module
 ```
 
-> For the full module/route/page inventory, see
-> [`beacon2026 Project Definition.md`](beacon2026%20Project%20Definition.md) — this tree
-> is a quick orientation map; that document is the authoritative detail.
+> For the full module/route/page inventory, see [`beacon2026 Project Definition.md`](beacon2026%20Project%20Definition.md) — this tree is a quick orientation map; that document is the authoritative detail.
 
 ## Quick start (local development)
 
@@ -111,10 +93,7 @@ npm run build                 # prisma generate — creates the Prisma client
 npm run dev                   # pushes schema + seeds first admin, then serves on :3001
 ```
 
-On startup the server runs `prisma db push` and seeds the first system admin
-automatically (from `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD`) — no separate
-migrate/seed step is needed. To run those manually instead, use
-`npm run db:migrate` and `npm run db:seed`.
+On startup the server runs `prisma db push` and seeds the first system admin automatically (from `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD`) — no separate migrate/seed step is needed. To run those manually instead, use `npm run db:migrate` and `npm run db:seed`.
 
 ### Frontend
 
@@ -129,17 +108,14 @@ The frontend expects the API at `VITE_API_URL` (defaults to `http://localhost:30
 
 ### Run the whole stack with Docker (optional)
 
-Instead of installing Postgres/Redis and running each service by hand, the repo
-ships a `docker-compose.yml` that brings up Postgres, Redis, the backend, and the
-frontend together — handy for a quick demo or for running the E2E suite locally:
+Instead of installing Postgres/Redis and running each service by hand, the repo ships a `docker-compose.yml` that brings up Postgres, Redis, the backend, and the frontend together — handy for a quick demo or for running the E2E suite locally:
 
 ```bash
 docker compose up --build       # http://localhost:5173 (frontend), :3001 (API)
 docker compose down -v          # stop and wipe the database volume
 ```
 
-All credentials in `docker-compose.yml` are throwaway local-only values; the
-stack is for development only and is never used to deploy a real instance.
+All credentials in `docker-compose.yml` are throwaway local-only values; the stack is for development only and is never used to deploy a real instance.
 
 ## Tests
 
@@ -149,12 +125,9 @@ cd frontend && npm test            # vitest + React Testing Library smoke tests
 cd e2e      && npm test            # Playwright (staging, or the local docker stack)
 ```
 
-Add coverage with `npm run test:coverage` in `backend/` or `frontend/` — it writes
-an HTML report to `coverage/` and prints a summary. The E2E suite can target
-staging or the local docker stack above (see `e2e/.env.example`).
+Add coverage with `npm run test:coverage` in `backend/` or `frontend/` — it writes an HTML report to `coverage/` and prints a summary. The E2E suite can target staging or the local docker stack above (see `e2e/.env.example`).
 
-CI runs backend + frontend lint, format check, and tests (with coverage uploaded
-as an artifact) on every push to a `claude/**` branch and on PRs to `main`.
+CI runs backend + frontend lint, format check, and tests (with coverage uploaded as an artifact) on every push to a `claude/**` branch and on PRs to `main`.
 
 ## Creating a u3a tenant
 
@@ -174,8 +147,7 @@ curl -X POST http://localhost:3001/system/tenants \
   }'
 ```
 
-This creates the tenant's PostgreSQL schema (`u3a_oxfordshire`), seeds all privilege
-resources, creates the five default roles, and sets up the first admin user.
+This creates the tenant's PostgreSQL schema (`u3a_oxfordshire`), seeds all privilege resources, creates the five default roles, and sets up the first admin user.
 
 ## Architecture
 
@@ -192,8 +164,7 @@ resources, creates the five default roles, and sets up the first admin user.
 
 ## Deployment
 
-See [DEPLOYMENT.md](DEPLOYMENT.md) for a step-by-step guide to deploying on
-Render (backend + Postgres) and Vercel (frontend) — no command-line knowledge needed.
+See [DEPLOYMENT.md](DEPLOYMENT.md) for a step-by-step guide to deploying on Render (backend + Postgres) and Vercel (frontend) — no command-line knowledge needed.
 
 ## Modules implemented
 
@@ -228,3 +199,4 @@ Render (backend + Postgres) and Vercel (frontend) — no command-line knowledge 
 - [x] Public links (online joining toggle, portal URLs)
 - [x] Public pages (groups list, calendar — unauthenticated)
 - [x] Members Portal (self-service: login, groups, calendar, personal details, online renewal, card request)
+

--- a/analyse-u3a-artifacts/README.md
+++ b/analyse-u3a-artifacts/README.md
@@ -1,21 +1,15 @@
 # `analyse-u3a-artifacts/`
 
-Generated reference material for the **Analyse u3a** project — a separate,
-local-only desktop app that consumes the same `.xlsx` backup format that
-beacon2026 imports from the original Beacon system.
+Generated reference material for the **Analyse u3a** project — a separate, local-only desktop app that consumes the same `.xlsx` backup format that beacon2026 imports from the original Beacon system.
 
-This folder is produced **inside the beacon2026 repo** so it can be reviewed and
-revised here, but its **only purpose is to be copied wholesale into the new
-Analyse u3a repo**. None of the files in this folder are read by beacon2026 at
-runtime.
+This folder is produced **inside the beacon2026 repo** so it can be reviewed and revised here, but its **only purpose is to be copied wholesale into the new Analyse u3a repo**. None of the files in this folder are read by beacon2026 at runtime.
 
 ---
 
 ## How to use
 
 1. Create the new repo (recommended name: `analyse-u3a`).
-2. Copy the **contents** of this folder into the new repo's root, so the
-   layout in the new repo becomes:
+2. Copy the **contents** of this folder into the new repo's root, so the layout in the new repo becomes:
    ```
    analyse-u3a/
    ├── CLAUDE.md
@@ -28,13 +22,8 @@ runtime.
        ├── json/
        └── zod/
    ```
-3. In the new repo, set up `package.json` with `zod` and (recommended)
-   `exceljs` as dependencies. The Zod schemas import `zod` and use ESM
-   `.js` extensions in their import paths — leave `"type": "module"` in the
-   new `package.json` and `"moduleResolution": "node16"` (or `"nodenext"`)
-   in `tsconfig.json`.
-4. Open the new repo with Claude Code or Codex; the AI agent should read
-   `CLAUDE.md` first, which links to everything else.
+3. In the new repo, set up `package.json` with `zod` and (recommended) `exceljs` as dependencies. The Zod schemas import `zod` and use ESM `.js` extensions in their import paths — leave `"type": "module"` in the new `package.json` and `"moduleResolution": "node16"` (or `"nodenext"`) in `tsconfig.json`.
+4. Open the new repo with Claude Code or Codex; the AI agent should read `CLAUDE.md` first, which links to everything else.
 
 ---
 
@@ -57,23 +46,13 @@ runtime.
 
 ## Source of truth
 
-These files were reverse-engineered from
-`backend/src/routes/backup.js` (the `restoreBeacon` function) in the beacon2026
-repository, and verified against the real backup
-`docs/FromBeacon/202603170140_St Ives Cambridge Demo24 u3abackup.xlsx`.
+These files were reverse-engineered from `backend/src/routes/backup.js` (the `restoreBeacon` function) in the beacon2026 repository, and verified against the real backup `docs/FromBeacon/202603170140_St Ives Cambridge Demo24 u3abackup.xlsx`.
 
-If a future change to Beacon (the legacy PHP system) alters the backup file
-format, these artifacts will need updating. The way to find out: try loading
-a newer backup; the Zod parser will throw on unexpected columns or types.
+If a future change to Beacon (the legacy PHP system) alters the backup file format, these artifacts will need updating. The way to find out: try loading a newer backup; the Zod parser will throw on unexpected columns or types.
 
 ---
 
 ## Scope reminder
 
-Only **15 of the 23 sheets** present in a Beacon backup are documented and
-schematised here. The omitted sheets — `Roles`, `Privileges`, `System Users`,
-`Polls`, `Poll assignments`, `System Messages`, `Site Settings 1`,
-`Site Settings 2` — are not relevant to the planned analyses (membership
-patterns, group popularity, attendance, churn, renewal payments). If a future
-analysis needs them, follow the patterns established in this folder to add
-them.
+Only **15 of the 23 sheets** present in a Beacon backup are documented and schematised here. The omitted sheets — `Roles`, `Privileges`, `System Users`, `Polls`, `Poll assignments`, `System Messages`, `Site Settings 1`, `Site Settings 2` — are not relevant to the planned analyses (membership patterns, group popularity, attendance, churn, renewal payments). If a future analysis needs them, follow the patterns established in this folder to add them.
+

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -63,8 +63,15 @@ beacon2026 is a ground-up rebuild with these goals:
   (`docs/DEPLOY-VPS.md`). The original Render (backend + DB) + Vercel (frontend)
   POC deployment is documented in `DEPLOYMENT.md` as a no-command-line fallback
   path, not what production runs on
+- Staging (since 2026-08-15): a second, isolated Compose project on the same
+  VPS at `https://staging.u3abeacon2.uk` (`docs/DEPLOY-VPS.md` §6) — own
+  Postgres/Redis, seeded fresh, for testing a feature branch before it merges
 - CI: GitHub Actions runs backend + frontend tests on every push to `claude/**` branches
-- E2E: Playwright test suite against staging
+- E2E: Playwright test suite, manually triggered (`workflow_dispatch`) against
+  whatever URL the `BEACON2026_BASE_URL`/`BEACON2026_API_URL` GitHub secrets
+  point at — currently the production VPS, carried over unchanged from the
+  2026-08-14 migration smoke test (see `CLAUDE-E2E.md`); repointing these at
+  the new staging environment instead is an open decision, not yet made
 - **Cookie consent** — GDPR-compliant dialog on first visit; optional cookies
   (`beacon_last_u3a`, localStorage preferences) gated behind user consent;
   gear icon to reopen dialog; essential cookies (refresh token, consent choice)
@@ -338,7 +345,7 @@ startup. All DDL uses `IF NOT EXISTS`; seed INSERTs use `ON CONFLICT DO NOTHING`
 | Excel | ExcelJS (read + write) |
 | PDF | PDFKit (labels, member list download) |
 | Testing | Vitest (unit), Playwright (E2E) |
-| Deployment | Dedicated OVHcloud VPS, single origin (`docs/DEPLOY-VPS.md`); Render+Vercel POC fallback documented in `DEPLOYMENT.md` |
+| Deployment | Dedicated OVHcloud VPS: production (single origin) + staging (separate Compose project, same box) — `docs/DEPLOY-VPS.md`; Render+Vercel POC fallback documented in `DEPLOYMENT.md` |
 
 ### Project layout
 

--- a/docs/BeaconUG/README.md
+++ b/docs/BeaconUG/README.md
@@ -1,25 +1,17 @@
 # BeaconUG — original Beacon User Guide (legacy reference only)
 
-This directory contains the **original Beacon** User Guide, transcribed to
-Markdown (with accompanying images) from the published u3a Beacon documentation.
+This directory contains the **original Beacon** User Guide, transcribed to Markdown (with accompanying images) from the published u3a Beacon documentation.
 
-It is kept here as **reference material only** — to verify how the legacy system
-behaves when building or comparing beacon2026 features. It is **not** beacon2026's own
-documentation and does not describe the beacon2026 UI.
+It is kept here as **reference material only** — to verify how the legacy system behaves when building or comparing beacon2026 features. It is **not** beacon2026's own documentation and does not describe the beacon2026 UI.
 
 - For the **beacon2026** User Guide, see [`../beacon2026UG/index.md`](../beacon2026UG/index.md).
-- For a feature-by-feature comparison between the two systems, see
-  [`../BeaconUG-Comparison.md`](../BeaconUG-Comparison.md).
+- For a feature-by-feature comparison between the two systems, see [`../BeaconUG-Comparison.md`](../BeaconUG-Comparison.md).
 
 ## Notes for maintainers
 
-- Section numbering follows the original Beacon guide, which differs from
-  beacon2026's. Section 8's index title is "Set-Up Operations" (folder
-  `8. System settings`), not the System Settings screen (doc `8.3`).
-- Some `.png` images are truncated on the right; where that happens a `.jpg`
-  with the same name holds the full screenshot — use the `.jpg`.
-- If an image is too small or blurry to read, ask for a clearer version rather
-  than guessing at the content.
+- Section numbering follows the original Beacon guide, which differs from beacon2026's. Section 8's index title is "Set-Up Operations" (folder `8. System settings`), not the System Settings screen (doc `8.3`).
+- Some `.png` images are truncated on the right; where that happens a `.jpg` with the same name holds the full screenshot — use the `.jpg`.
+- If an image is too small or blurry to read, ask for a clearer version rather than guessing at the content.
 
-The text and screenshots originate from u3a / The Third Age Trust's Beacon
-documentation and are reproduced here for development reference.
+The text and screenshots originate from u3a / The Third Age Trust's Beacon documentation and are reproduced here for development reference.
+

--- a/docs/DEPLOY-VPS.md
+++ b/docs/DEPLOY-VPS.md
@@ -154,26 +154,51 @@ restarts — confirm tenant/member counts afterwards.
 
 ---
 
-## 6. Staging (Phase 8)
+## 6. Staging
 
-Same box, a second Compose project (`-p beacon2026-staging`), so volumes and
-networks never collide with production:
+**Live since 2026-08-15** at `https://staging.u3abeacon2.uk`. Same box, a
+second Compose project (`-p beacon2026-staging`), so volumes and networks
+never collide with production:
 
 ```bash
 cd /srv/beacon2026-staging
+git checkout <your-feature-branch>   # deploy-staging.sh deliberately doesn't force main
 ./deploy/deploy-staging.sh
 ```
 
 `compose.staging.yaml` publishes the backend on `127.0.0.1:3002` (not 3001),
 uses its own named volumes (`beacon2026-staging-db`, `beacon2026-staging-redis`),
-its own `.env.staging`, and `CORS_ORIGIN=https://staging.u3abeacon2.uk`. The
-Caddyfile's second server block routes `staging.u3abeacon2.uk` to port 3002
-and a separate static root, reusing the same `handle_path /api/*` trick.
+its own `.env.staging` (fresh secrets, not shared with production — see
+`/srv/beacon2026-staging/.env.staging` on the box, not committed), and
+`CORS_ORIGIN=https://staging.u3abeacon2.uk`. The Caddyfile's second server
+block routes `staging.u3abeacon2.uk` to port 3002 and a separate static root,
+reusing the same `handle_path /api/*` trick.
 
-Seed staging from a **sanitised** copy of a production dump, or fresh demo
-tenants — never a raw production dump. Staging is exempt from the nightly
-off-box backup pull (it's disposable by design); `deploy-staging.sh` still
-takes a local on-box dump before each deploy.
+**`docker compose` needs `--env-file .env.staging` on every invocation** —
+`deploy-staging.sh` already does this (fixed in PR #526). Compose's own
+`${POSTGRES_PASSWORD}` variable substitution in `compose.staging.yaml` is
+resolved by Compose itself, not by the backend service's
+`env_file: .env.staging` directive, and Compose only auto-reads a file
+literally named `.env` (which doesn't exist in `/srv/beacon2026-staging`).
+Running any raw `docker compose -p beacon2026-staging -f compose.staging.yaml
+...` command by hand without `--env-file .env.staging` will silently pass a
+blank Postgres password and fail the healthcheck — always use
+`deploy-staging.sh`, or prefix manual commands with `--env-file .env.staging`.
+
+Seeded fresh (no data copied across) at first deploy — no tenants exist until
+you create one via the system-admin UI at `https://staging.u3abeacon2.uk/system/login`.
+Going forward, seed from a **sanitised** copy of a production dump, or fresh
+demo tenants — never a raw production dump. Staging is exempt from the
+nightly off-box backup pull (it's disposable by design); `deploy-staging.sh`
+still takes a local on-box dump before each deploy.
+
+To wipe staging back to empty (e.g. after a batch of manual testing):
+
+```bash
+cd /srv/beacon2026-staging
+docker compose --env-file .env.staging -p beacon2026-staging -f compose.staging.yaml down -v
+./deploy/deploy-staging.sh
+```
 
 ---
 
@@ -194,3 +219,14 @@ config bug.
 — confirm Caddy actually reloaded (`systemctl status caddy`) and that the
 Caddyfile's `beacon2026.u3abeacon2.uk` block matches the DNS record exactly
 (no trailing dot / wrong record type).
+
+**First deploy to a brand-new domain fails the script's own `curl .../api/health`
+check with a TLS error, even though everything else succeeded** — this is a
+race, not a real failure. Caddy only starts its Let's Encrypt HTTP-01
+challenge *after* it reloads with the new domain in its config, and issuance
+takes a few seconds; the deploy script's `curl` can run before the
+certificate exists. Confirmed via `journalctl -u caddy`: on the first staging
+deploy (2026-08-15), the certificate was obtained ~7 seconds after
+`systemctl reload caddy` returned. Check `journalctl -u caddy --since '5
+minutes ago'` for `"certificate obtained successfully"` before assuming a
+real problem — this only happens once per domain, not on every deploy.

--- a/docs/FromBeacon/README.md
+++ b/docs/FromBeacon/README.md
@@ -1,58 +1,28 @@
 # `docs/FromBeacon/` — original Beacon reference material
 
-This directory holds selected artefacts from the original u3a **Beacon** system,
-kept **strictly as reference material** while building beacon2026. They are **not**
-part of the beacon2026 application, are not imported or executed by it, and are not
-covered by the beacon2026 `LICENSE`.
+This directory holds selected artefacts from the original u3a **Beacon** system, kept **strictly as reference material** while building beacon2026. They are **not** part of the beacon2026 application, are not imported or executed by it, and are not covered by the beacon2026 `LICENSE`.
 
 ## Copyright and status
 
-All material in this directory remains the property of its respective copyright
-holders. beacon2026:
+All material in this directory remains the property of its respective copyright holders. beacon2026:
 
 - makes **no claim of ownership** over any of this material;
 - makes **no claim of any right to redistribute** it;
-- includes only what is genuinely needed **only as reference**, not as a basis
-  for copying original code or content.
+- includes only what is genuinely needed **only as reference**, not as a basis for copying original code or content.
 
-If any rights holder would prefer this material not be present in the
-repository, it will be removed on request (see `SECURITY.md` / repository
-contact).
+If any rights holder would prefer this material not be present in the repository, it will be removed on request (see `SECURITY.md` / repository contact).
 
-**`privileges.php` and `styles.css` removed 2026-08-01.** These were original
-Beacon source files carrying the notice *"This script is Copyright John
-Franklin for all content as at 1st February 2017. © John Franklin 2017. The
-Third Age Trust is permitted to use and modify the script according to the
-terms of the Software Licence Agreement dated 7th February 2017."* — a licence
-that runs to the Third Age Trust, not to this project. The facts they
-documented (Beacon's internal privilege/audit numeric codes, needed to
-interpret Beacon export files) have already been independently re-expressed in
-beacon2026's own code (`backend/src/seed/privilegeResources.js`,
-`backend/src/routes/backup/restore.js`) using original naming and structure.
-With that extraction complete, there was no remaining reason to host Franklin's
-actual copyrighted files, verbatim and publicly, in this repo.
+**`privileges.php` and `styles.css` removed 2026-08-01.** These were original Beacon source files carrying the notice *"This script is Copyright John Franklin for all content as at 1st February 2017. © John Franklin 2017. The Third Age Trust is permitted to use and modify the script according to the terms of the Software Licence Agreement dated 7th February 2017."* — a licence that runs to the Third Age Trust, not to this project. The facts they documented (Beacon's internal privilege/audit numeric codes, needed to interpret Beacon export files) have already been independently re-expressed in beacon2026's own code (`backend/src/seed/privilegeResources.js`, `backend/src/routes/backup/restore.js`) using original naming and structure. With that extraction complete, there was no remaining reason to host Franklin's actual copyrighted files, verbatim and publicly, in this repo.
 
-**`202603170140_St Ives Cambridge Demo24 u3abackup.xlsx` and
-`Gift-Aid-Schedule-Excel.ods` removed 2026-08-01.** These had served their
-purpose as format references during development; there was no ongoing need to
-keep hosting them.
+**`202603170140_St Ives Cambridge Demo24 u3abackup.xlsx` and `Gift-Aid-Schedule-Excel.ods` removed 2026-08-01.** These had served their purpose as format references during development; there was no ongoing need to keep hosting them.
 
-**`Cookie Control text.png` removed 2026-08-01.** Not imported or referenced by
-any beacon2026 code, so there was no reason to keep hosting it. See
-`KNOWN-ISSUES.md` → "Repo hygiene & licensing" for the still-open question of
-whether the *wording* it documented (used in `CookieConsent.jsx`) needs
-permission from the Third Age Trust.
+**`Cookie Control text.png` removed 2026-08-01.** Not imported or referenced by any beacon2026 code, so there was no reason to keep hosting it. See `KNOWN-ISSUES.md` → "Repo hygiene & licensing" for the still-open question of whether the *wording* it documented (used in `CookieConsent.jsx`) needs permission from the Third Age Trust.
 
 ## Contents
 
-This directory is currently empty of tracked files other than this README —
-all original Beacon material that had served its reference purpose has been
-removed. It remains here as a place to document provenance if any such
-material is added back in future.
+This directory is currently empty of tracked files other than this README — all original Beacon material that had served its reference purpose has been removed. It remains here as a place to document provenance if any such material is added back in future.
 
 ## Why keep it here
 
-beacon2026 is an independent reproduction; these files document *what the original
-behaved like* so the reproduction can be faithful without copying the original
-implementation. Treat everything here as read-only reference, never as code to
-lift into beacon2026.
+beacon2026 is an independent reproduction; these files document *what the original behaved like* so the reproduction can be faithful without copying the original implementation. Treat everything here as read-only reference, never as code to lift into beacon2026.
+

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -1,9 +1,6 @@
 # Historical review documents
 
-These are **point-in-time snapshots** from the 2026-06 full-codebase review and
-improvement effort. They are kept for reference and are **no longer updated**.
-Anything still outstanding has been folded into the single living backlog,
-[`../../KNOWN-ISSUES.md`](../../KNOWN-ISSUES.md).
+These are **point-in-time snapshots** from the 2026-06 full-codebase review and improvement effort. They are kept for reference and are **no longer updated**. Anything still outstanding has been folded into the single living backlog, [`../../KNOWN-ISSUES.md`](../../KNOWN-ISSUES.md).
 
 | File | What it was | Status |
 |------|-------------|--------|
@@ -13,9 +10,7 @@ Anything still outstanding has been folded into the single living backlog,
 
 Notes:
 
-- Paths and "current state" descriptions inside these files reflect the repo
-  **as it was when they were written** and may since have changed.
-- The numbered findings (e.g. "KI #9", "Chunk 7") are still referenced by id
-  from `KNOWN-ISSUES.md` and `CHANGELOG.md`, which is why the documents are
-  archived rather than deleted.
+- Paths and "current state" descriptions inside these files reflect the repo **as it was when they were written** and may since have changed.
+- The numbered findings (e.g. "KI #9", "Chunk 7") are still referenced by id from `KNOWN-ISSUES.md` and `CHANGELOG.md`, which is why the documents are archived rather than deleted.
 - For what is left to do, always start from `KNOWN-ISSUES.md`.
+

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,8 +10,14 @@ Tests are organised to mirror the **Beacon User Guide** sections, so that each t
 
 - Node.js 18+
 - A running beacon2026 instance (frontend + backend + database). Either:
-  - a deployed **staging** instance, **or**
+  - the deployed **staging** instance at `https://staging.u3abeacon2.uk` (see
+    `docs/DEPLOY-VPS.md` §6 — deploy your branch there first with
+    `deploy-staging.sh`), **or**
   - the **local docker stack** — run `docker compose up --build` from the repo root, then use the localhost values documented at the top of `.env.example` (this needs no separate staging environment)
+
+  In CI (`.github/workflows/e2e.yml`, manually triggered), the target is
+  whatever `BEACON2026_BASE_URL`/`BEACON2026_API_URL` point at — see
+  `CLAUDE-E2E.md` for the current target and an open decision about it.
 - A system-admin account on that instance (to create the test tenant). The local docker stack seeds one automatically (`admin@beacon2026.local` / `ChangeMe123!`).
 
 ---

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,8 +2,7 @@
 
 Playwright-based user acceptance tests for the beacon2026 administration system.
 
-Tests are organised to mirror the **Beacon User Guide** sections, so that each
-test can be traced back to documented user behaviour.
+Tests are organised to mirror the **Beacon User Guide** sections, so that each test can be traced back to documented user behaviour.
 
 ---
 
@@ -12,11 +11,8 @@ test can be traced back to documented user behaviour.
 - Node.js 18+
 - A running beacon2026 instance (frontend + backend + database). Either:
   - a deployed **staging** instance, **or**
-  - the **local docker stack** — run `docker compose up --build` from the repo
-    root, then use the localhost values documented at the top of `.env.example`
-    (this needs no separate staging environment)
-- A system-admin account on that instance (to create the test tenant). The local
-  docker stack seeds one automatically (`admin@beacon2026.local` / `ChangeMe123!`).
+  - the **local docker stack** — run `docker compose up --build` from the repo root, then use the localhost values documented at the top of `.env.example` (this needs no separate staging environment)
+- A system-admin account on that instance (to create the test tenant). The local docker stack seeds one automatically (`admin@beacon2026.local` / `ChangeMe123!`).
 
 ---
 
@@ -70,37 +66,23 @@ npm run test:report
 Runs **once** before any test file.
 
 1. Logs in as system admin.
-2. Creates the test tenant (`beacon2026_TEST_TENANT_SLUG`) if it does not already exist.
-   If it does exist, resets the admin password to the known value (so tests always
-   start from a known state even after a previous failed run).
+2. Creates the test tenant (`beacon2026_TEST_TENANT_SLUG`) if it does not already exist. If it does exist, resets the admin password to the known value (so tests always start from a known state even after a previous failed run).
 3. Logs in as the test-tenant admin.
-4. Seeds a **"Current Account"** finance account and a **"Joint"** member class
-   (the four default member statuses and "Individual" class are created automatically
-   by the beacon2026 tenant-creation process).
+4. Seeds a **"Current Account"** finance account and a **"Joint"** member class (the four default member statuses and "Individual" class are created automatically by the beacon2026 tenant-creation process).
 
 ### Auth fixture (`fixtures/admin.js`)
 
-Each test that needs a logged-in browser imports `{ test, expect }` from
-`fixtures/admin.js` instead of `@playwright/test`.  The `adminPage` fixture
-performs a fresh browser login before each test and provides the authenticated
-page.
+Each test that needs a logged-in browser imports `{ test, expect }` from `fixtures/admin.js` instead of `@playwright/test`.  The `adminPage` fixture performs a fresh browser login before each test and provides the authenticated page.
 
-Because beacon2026 stores the access token **in memory only** (never cookies or
-localStorage), there is no way to share a session via Playwright's `storageState`.
-A fresh login per test adds ~200 ms and keeps tests fully independent.
+Because beacon2026 stores the access token **in memory only** (never cookies or localStorage), there is no way to share a session via Playwright's `storageState`. A fresh login per test adds ~200 ms and keeps tests fully independent.
 
 ### Test data isolation
 
-Every test creates its own data (with a `Date.now()` suffix to avoid collisions)
-and cleans it up in the same test or the last test in a `describe` block.  Tests
-within a file run **serially** (Playwright `fullyParallel: false`) so the
-create → edit → delete sequence within a describe block is reliable.
+Every test creates its own data (with a `Date.now()` suffix to avoid collisions) and cleans it up in the same test or the last test in a `describe` block.  Tests within a file run **serially** (Playwright `fullyParallel: false`) so the create → edit → delete sequence within a describe block is reliable.
 
 ### Global teardown (`global-teardown.js`)
 
-Enabled by default.  The test tenant is **always** deleted after the run,
-regardless of whether tests passed or failed.  This prevents leftover tenants
-from accumulating in the database.
+Enabled by default.  The test tenant is **always** deleted after the run, regardless of whether tests passed or failed.  This prevents leftover tenants from accumulating in the database.
 
 ---
 
@@ -159,37 +141,24 @@ The tests are structured for **regression after deployment**:
 
 1. **Global setup** ensures a clean, known baseline every run.
 2. **Tests are self-contained** — no shared mutable state between test files.
-3. **Numbered ordering** matches the Beacon UG so gaps are obvious when new
-   features are added.
-4. **Acceptance criteria** map directly to user-guide behaviour, not
-   implementation details — so tests remain valid as the frontend evolves.
+3. **Numbered ordering** matches the Beacon UG so gaps are obvious when new features are added.
+4. **Acceptance criteria** map directly to user-guide behaviour, not implementation details — so tests remain valid as the frontend evolves.
 
 When a new beacon2026 feature is implemented:
-- Add a new spec file (or extend an existing one) that covers the corresponding
-  UG section.
+- Add a new spec file (or extend an existing one) that covers the corresponding UG section.
 - If global-setup needs new seed data for those tests, add it to `global-setup.js`.
 
 ---
 
 ## Troubleshooting
 
-**`global-setup` fails with "System-admin login failed"**
-→ Check `beacon2026_API_URL`, `beacon2026_SYSADMIN_USERNAME`, `beacon2026_SYSADMIN_PASSWORD`.
+**`global-setup` fails with "System-admin login failed"** → Check `beacon2026_API_URL`, `beacon2026_SYSADMIN_USERNAME`, `beacon2026_SYSADMIN_PASSWORD`.
 
-**`global-setup` fails with "Tenant admin login failed"**
-→ The tenant may have been left in a bad state from a previous run where teardown
-didn't complete (e.g. process killed).  Manually delete the tenant via the system
-admin UI, then re-run.
+**`global-setup` fails with "Tenant admin login failed"** → The tenant may have been left in a bad state from a previous run where teardown didn't complete (e.g. process killed).  Manually delete the tenant via the system admin UI, then re-run.
 
-**Tests fail with "waitForURL timed out"**
-→ The staging server may be slow.  Increase `navigationTimeout` in
-`playwright.config.js`.
+**Tests fail with "waitForURL timed out"** → The staging server may be slow.  Increase `navigationTimeout` in `playwright.config.js`.
 
-**Download tests time out**
-→ The export endpoint may be generating a large file.  Increase the timeout
-passed to `page.waitForEvent('download', { timeout: … })`.
+**Download tests time out** → The export endpoint may be generating a large file.  Increase the timeout passed to `page.waitForEvent('download', { timeout: … })`.
 
-**Selector not found**
-→ The UI may have changed.  Check the relevant Page Object Model and update the
-locator.  Prefer `getByRole` / `getByLabel` / `getByText` over CSS selectors for
-resilience.
+**Selector not found** → The UI may have changed.  Check the relevant Page Object Model and update the locator.  Prefer `getByRole` / `getByLabel` / `getByText` over CSS selectors for resilience.
+


### PR DESCRIPTION
## Summary
- Reviewed all development/deployment docs against the new staging environment (`https://staging.u3abeacon2.uk`, live since 2026-08-15) and brought them up to date: `README.md`, `docs/DEPLOY-VPS.md` §6, `beacon2026 Project Definition.md`, `CLAUDE-E2E.md`, `e2e/README.md`, `KNOWN-ISSUES.md`.
- Documented two real gotchas hit during staging's first live deploy: the `--env-file .env.staging` Compose fix (already merged in #526) and a harmless Caddy/ACME TLS race on a brand-new domain's first deploy.
- **Flagged, not changed:** CI's E2E workflow (`.github/workflows/e2e.yml`) currently points `BEACON2026_BASE_URL`/`BEACON2026_API_URL` at production, left over from a one-off post-migration smoke test on 2026-08-14. Its own header comment says it's meant to run "against a live staging deployment" — now that staging exists, repointing the secrets there would match that intent and remove a live production risk from a manually-triggered workflow. Left as an open `KNOWN-ISSUES.md` item since changing production-facing CI secrets needs a separate go-ahead.
- **Also recovered:** `da00bcb` ("Remove hard-wrapped paragraphs from README files") was sitting unpushed on local `main` since 2026-08-09 — a pure markdown reflow, no wording changed — carried along through several merge commits but never landed in a PR. Included here so it's finally in `main` properly.

## Test plan
- Docs-only change, no tests required per `CLAUDE.md`.
- [x] Verified `docs/DEPLOY-VPS.md` §6 commands match the actual `deploy-staging.sh` behaviour after PR #526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)