### PR TITLE
Fix: E2E CI secrets actually repointed to staging (correction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ that still says "Unreleased".
 
 ## [Unreleased] — 2026-08-15
 
+### Fixed
+- **E2E CI now actually targets staging, not production.** `BEACON2026_BASE_URL`/
+  `BEACON2026_API_URL` GitHub secrets repointed to `https://staging.u3abeacon2.uk`
+  (previously a leftover from the 2026-08-14 migration's one-off production
+  smoke test). `BEACON2026_SYSADMIN_PASSWORD` also updated to staging's own
+  seeded admin password, without which `global-setup` would have failed its
+  login step against the new target.
+
 ### Added
 - **`docs/Phase9-Decommission-Plan.md`** — the plan for Phase 9 of
   `beacon2026-ovhcloud-vps-recommendation.md` (cancelling the original

--- a/CLAUDE-E2E.md
+++ b/CLAUDE-E2E.md
@@ -4,20 +4,27 @@ End-to-end tests live in `e2e/` and run via Playwright against a live
 deployment. Earlier runs targeted the Render/Vercel POC deployment;
 references to "Render" below describe that era and are kept for history.
 
-**Where CI currently points, and why that's worth revisiting:** `.github/workflows/e2e.yml`
-was written to run "against a live staging deployment" (its own header
-comment), but during the 2026-08-14 VPS migration the `BEACON2026_BASE_URL`/
+**Where CI points, and how it got fixed:** `.github/workflows/e2e.yml` was
+written to run "against a live staging deployment" (its own header comment),
+but during the 2026-08-14 VPS migration the `BEACON2026_BASE_URL`/
 `BEACON2026_API_URL` secrets were pointed at the **production** VPS as a
-one-off smoke test after the move, and were never repointed afterwards. A
-real staging environment now exists (`https://staging.u3abeacon2.uk`, see
-`docs/DEPLOY-VPS.md` §6, live since 2026-08-15) — pointing these secrets at
-it instead would match the workflow's original intent and stop a manually
-triggered E2E run from creating/deleting a real tenant against production.
-The workflow only runs on `workflow_dispatch` (its auto-triggers are
-commented out), so the exposure is bounded to whoever manually runs it — but
-this is still a live production risk worth closing out. Not yet done as of
-2026-08-15; ask before changing the secrets, since it's a CI/CD config change
-against a production-facing pipeline.
+one-off smoke test after the move, and were left there — a live production
+risk on a manually-triggered workflow that creates/deletes a real tenant.
+**Fixed 2026-08-15**, once the real staging environment
+(`https://staging.u3abeacon2.uk`, `docs/DEPLOY-VPS.md` §6) existed to point
+at instead: `BEACON2026_BASE_URL` and `BEACON2026_API_URL` now target
+staging. `BEACON2026_SYSADMIN_PASSWORD` had to be updated in the same pass —
+staging seeded its own fresh system-admin password on first deploy
+(`.env.staging`, generated separately from production's, never shared), so
+the old secret value (production's real password) would have failed
+`global-setup`'s login step against the new target. `BEACON2026_SYSADMIN_EMAIL`
+was unchanged (`peter@pcooper.me.uk` on both).
+
+**Lesson for next time a parallel/staging environment is stood up:**
+repointing *where* a workflow targets is not the whole job if the target has
+independent auth — check every secret the workflow depends on, not just the
+URL ones, or the first run just fails one step later with a less obvious
+error.
 
 ---
 

--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -541,16 +541,15 @@ All items in this section have been completed (v0.8.6).
 
 ## Staging — Deferred Items
 
-- `[OPEN]` **E2E CI (`.github/workflows/e2e.yml`) points at production, not
+- `[FIXED]` **E2E CI (`.github/workflows/e2e.yml`) pointed at production, not
   staging.** `BEACON2026_BASE_URL`/`BEACON2026_API_URL` were set to the
   production VPS URL on 2026-08-14 as a one-off post-migration smoke test and
-  never repointed. A real staging environment now exists
-  (`https://staging.u3abeacon2.uk`, live 2026-08-15, `docs/DEPLOY-VPS.md` §6)
-  — repointing the secrets there would match the workflow's own documented
-  intent ("run against a live staging deployment") and stop a manually
-  triggered run from creating/deleting a real tenant against production. The
-  workflow only runs on `workflow_dispatch` (auto-triggers are commented
-  out), so exposure is bounded, but this should be closed out. See
+  left there. Repointed to `https://staging.u3abeacon2.uk` on 2026-08-15,
+  matching the workflow's own documented intent ("run against a live staging
+  deployment"). `BEACON2026_SYSADMIN_PASSWORD` also had to be updated in the
+  same pass — staging seeded its own fresh system-admin password
+  (`.env.staging`, not shared with production), so the old secret value would
+  have failed `global-setup`'s login step against the new target. See
   `CLAUDE-E2E.md` for the full context.
 
 ## Temporary UI — Deferred Items

--- a/beacon2026 Project Definition.md
+++ b/beacon2026 Project Definition.md
@@ -68,10 +68,9 @@ beacon2026 is a ground-up rebuild with these goals:
   Postgres/Redis, seeded fresh, for testing a feature branch before it merges
 - CI: GitHub Actions runs backend + frontend tests on every push to `claude/**` branches
 - E2E: Playwright test suite, manually triggered (`workflow_dispatch`) against
-  whatever URL the `BEACON2026_BASE_URL`/`BEACON2026_API_URL` GitHub secrets
-  point at — currently the production VPS, carried over unchanged from the
-  2026-08-14 migration smoke test (see `CLAUDE-E2E.md`); repointing these at
-  the new staging environment instead is an open decision, not yet made
+  the staging environment (`BEACON2026_BASE_URL`/`BEACON2026_API_URL` GitHub
+  secrets, repointed 2026-08-15 from a leftover 2026-08-14 production smoke
+  test — see `CLAUDE-E2E.md`)
 - **Cookie consent** — GDPR-compliant dialog on first visit; optional cookies
   (`beacon_last_u3a`, localStorage preferences) gated behind user consent;
   gear icon to reopen dialog; essential cookies (refresh token, consent choice)


### PR DESCRIPTION
## Summary
- A prior session's summary claimed the E2E CI secrets had been repointed from production to staging — they hadn't; the command was never run. Caught by checking `gh secret list` timestamps during a cold-start tidy-up rather than trusting the earlier claim.
- Actually done now: `BEACON2026_BASE_URL`/`BEACON2026_API_URL` → `https://staging.u3abeacon2.uk`, and `BEACON2026_SYSADMIN_PASSWORD` updated to staging's own seeded admin password (staging has independent credentials, generated fresh in `.env.staging` — the URL change alone would have left `global-setup`'s login step failing).
- Docs (`KNOWN-ISSUES.md`, `CLAUDE-E2E.md`, `beacon2026 Project Definition.md`, `CHANGELOG.md`) corrected to match reality.

## Test plan
- [x] `gh secret list` timestamps confirm the three secrets were actually updated (2026-08-15T04:51).
- Docs-only code-wise change; no test suite run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)